### PR TITLE
fix(web): jump directly to the tapped post on project content page

### DIFF
--- a/apps/web/src/routes/(app)/content/+page.svelte
+++ b/apps/web/src/routes/(app)/content/+page.svelte
@@ -135,7 +135,7 @@
             {#if expandedGroups.has(group.groupId)}
               <div class="border-t border-gray-200 dark:border-gray-700">
                 {#each group.items as item}
-                  <a href="/projects/{item.projectId}/content" class="block p-4 border-b border-gray-100 dark:border-gray-700 last:border-b-0 hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                  <a href="/projects/{item.projectId}/content?focus={item.id}" class="block p-4 border-b border-gray-100 dark:border-gray-700 last:border-b-0 hover:bg-gray-50 dark:hover:bg-gray-700/50">
                     <div class="flex items-center gap-2">
                       <span class="text-xs px-1.5 py-0.5 rounded font-bold {langBadge[item.language] || 'bg-gray-100 text-gray-600'}">{(item.language || '?').toUpperCase()}</span>
                       <h3 class="font-medium text-gray-900 dark:text-white">{item.title}</h3>
@@ -149,7 +149,7 @@
         {:else}
           <!-- Single content item -->
           {@const item = group.items[0]}
-          <a href="/projects/{item.projectId}/content" class="block bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
+          <a href="/projects/{item.projectId}/content?focus={item.id}" class="block bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
             <div class="flex items-center justify-between">
               <div>
                 <div class="flex items-center gap-1.5 mb-1">

--- a/apps/web/src/routes/(app)/projects/[id]/content/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/content/+page.svelte
@@ -12,6 +12,8 @@
   let showModal = false;
   let generating = false;
   $: projectId = $page.params['id'];
+  $: focusContentId = $page.url.searchParams.get('focus');
+  let highlightedId: string | null = null;
 
   // Sync picker with this project
   $: if ($projectsStore.length > 0 && projectId) {
@@ -108,6 +110,22 @@
   $: if (projectId && projectId !== prevProjectId) {
     prevProjectId = projectId;
     loadContent(projectId);
+  }
+
+  // Focus a specific content item when arriving with ?focus=<id>
+  let focusHandledFor: string | null = null;
+  $: if (!loading && focusContentId && focusContentId !== focusHandledFor) {
+    const target = contents.find(c => c.id === focusContentId);
+    if (target) {
+      focusHandledFor = focusContentId;
+      if (target.contentGroupId) expandedGroups = new Set(expandedGroups).add(target.contentGroupId);
+      setTimeout(() => {
+        const el = document.getElementById(`content-card-${focusContentId}`);
+        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        highlightedId = focusContentId;
+        setTimeout(() => { if (highlightedId === focusContentId) highlightedId = null; }, 2500);
+      }, 50);
+    }
   }
 
   interface ContentGroup { groupId: string | null; items: any[]; }
@@ -511,7 +529,7 @@
             {#if expandedGroups.has(group.groupId)}
               <div class="border-t border-gray-200">
                 {#each group.items as content}
-                  <div class="p-5 border-b border-gray-100 last:border-b-0 bg-gray-50/50">
+                  <div id="content-card-{content.id}" class="p-5 border-b border-gray-100 last:border-b-0 bg-gray-50/50 transition-all duration-300 {highlightedId === content.id ? 'ring-2 ring-primary-500 ring-inset bg-primary-50/50' : ''}">
                     <div class="flex flex-col sm:flex-row items-start justify-between gap-3 sm:gap-4">
                       <div class="flex-1 min-w-0">
                         <div class="flex flex-wrap items-center gap-1.5 mb-2">
@@ -570,7 +588,7 @@
         {:else}
           <!-- Single content item -->
           {@const content = group.items[0]}
-          <div class="bg-white rounded-xl border border-gray-200 border-l-4 {statusBorderAccent[content.status] || 'border-l-gray-300'} p-5 hover:shadow-sm transition-shadow duration-150">
+          <div id="content-card-{content.id}" class="bg-white rounded-xl border border-gray-200 border-l-4 {statusBorderAccent[content.status] || 'border-l-gray-300'} p-5 hover:shadow-sm transition-all duration-300 {highlightedId === content.id ? 'ring-2 ring-primary-500 shadow-md' : ''}">
             <div class="flex flex-col sm:flex-row items-start justify-between gap-3 sm:gap-4">
               <div class="flex-1 min-w-0">
                 <div class="flex flex-wrap items-center gap-1.5 mb-2">


### PR DESCRIPTION
Clicking a post from the organization-wide /content page previously dropped
users at the project content list, forcing them to find the same post again
to reach Edit/Publish. Pass ?focus=<id> on the link, then auto-expand the
group, scroll to the card, and highlight it on arrival.