### PR TITLE
fix(web): click a post on /content opens the edit page directly

### DIFF
--- a/apps/web/src/routes/(app)/content/+page.svelte
+++ b/apps/web/src/routes/(app)/content/+page.svelte
@@ -135,27 +135,13 @@
             {#if expandedGroups.has(group.groupId)}
               <div class="border-t border-gray-200 dark:border-gray-700">
                 {#each group.items as item}
-                  <div class="p-4 border-b border-gray-100 dark:border-gray-700 last:border-b-0 hover:bg-gray-50 dark:hover:bg-gray-700/50">
-                    <div class="flex items-start justify-between gap-3">
-                      <div class="min-w-0 flex-1">
-                        <div class="flex items-center gap-2">
-                          <span class="text-xs px-1.5 py-0.5 rounded font-bold {langBadge[item.language] || 'bg-gray-100 text-gray-600'}">{(item.language || '?').toUpperCase()}</span>
-                          <h3 class="font-medium text-gray-900 dark:text-white truncate">{item.title}</h3>
-                        </div>
-                        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">{item.body?.substring(0, 150)}</p>
-                      </div>
-                      <div class="flex items-center gap-1.5 flex-shrink-0">
-                        <a href="/projects/{item.projectId}/content/{item.id}/edit" class="text-xs px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200">
-                          {$_('common.edit')}
-                        </a>
-                        {#if item.status === 'APPROVED' || item.status === 'PUBLISHED'}
-                          <a href="/projects/{item.projectId}/content?focus={item.id}&action=publish" class="text-xs px-3 py-1.5 border border-blue-300 text-blue-600 rounded-lg hover:bg-blue-50 dark:hover:bg-blue-900/20">
-                            {$_('social.publish')}
-                          </a>
-                        {/if}
-                      </div>
+                  <a href="/projects/{item.projectId}/content/{item.id}/edit" class="block p-4 border-b border-gray-100 dark:border-gray-700 last:border-b-0 hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                    <div class="flex items-center gap-2">
+                      <span class="text-xs px-1.5 py-0.5 rounded font-bold {langBadge[item.language] || 'bg-gray-100 text-gray-600'}">{(item.language || '?').toUpperCase()}</span>
+                      <h3 class="font-medium text-gray-900 dark:text-white">{item.title}</h3>
                     </div>
-                  </div>
+                    <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">{item.body?.substring(0, 150)}</p>
+                  </a>
                 {/each}
               </div>
             {/if}
@@ -163,9 +149,9 @@
         {:else}
           <!-- Single content item -->
           {@const item = group.items[0]}
-          <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all">
-            <div class="flex items-start justify-between gap-3">
-              <div class="min-w-0 flex-1">
+          <a href="/projects/{item.projectId}/content/{item.id}/edit" class="block bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
+            <div class="flex items-center justify-between">
+              <div>
                 <div class="flex items-center gap-1.5 mb-1">
                   {#if item.language}
                     <span class="text-xs px-1.5 py-0.5 rounded font-medium {langBadge[item.language] || 'bg-gray-100 text-gray-600'}">{item.language.toUpperCase()}</span>
@@ -174,23 +160,13 @@
                 <h3 class="font-medium text-gray-900 dark:text-white">{item.title}</h3>
                 <p class="text-sm text-gray-500 dark:text-gray-400">{item.type || ''}{item.status ? ' · ' + item.status : ''}</p>
               </div>
-              <div class="flex items-center gap-2 flex-shrink-0">
-                {#if ctx.type === 'organization'}
-                  <span class="text-xs px-2 py-1 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
-                    {item.projectName || $_('org.scopeProject')}
-                  </span>
-                {/if}
-                <a href="/projects/{item.projectId}/content/{item.id}/edit" class="text-xs px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200">
-                  {$_('common.edit')}
-                </a>
-                {#if item.status === 'APPROVED' || item.status === 'PUBLISHED'}
-                  <a href="/projects/{item.projectId}/content?focus={item.id}&action=publish" class="text-xs px-3 py-1.5 border border-blue-300 text-blue-600 rounded-lg hover:bg-blue-50 dark:hover:bg-blue-900/20">
-                    {$_('social.publish')}
-                  </a>
-                {/if}
-              </div>
+              {#if ctx.type === 'organization'}
+                <span class="text-xs px-2 py-1 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
+                  {item.projectName || $_('org.scopeProject')}
+                </span>
+              {/if}
             </div>
-          </div>
+          </a>
         {/if}
       {/each}
     </div>

--- a/apps/web/src/routes/(app)/content/+page.svelte
+++ b/apps/web/src/routes/(app)/content/+page.svelte
@@ -135,13 +135,27 @@
             {#if expandedGroups.has(group.groupId)}
               <div class="border-t border-gray-200 dark:border-gray-700">
                 {#each group.items as item}
-                  <a href="/projects/{item.projectId}/content?focus={item.id}" class="block p-4 border-b border-gray-100 dark:border-gray-700 last:border-b-0 hover:bg-gray-50 dark:hover:bg-gray-700/50">
-                    <div class="flex items-center gap-2">
-                      <span class="text-xs px-1.5 py-0.5 rounded font-bold {langBadge[item.language] || 'bg-gray-100 text-gray-600'}">{(item.language || '?').toUpperCase()}</span>
-                      <h3 class="font-medium text-gray-900 dark:text-white">{item.title}</h3>
+                  <div class="p-4 border-b border-gray-100 dark:border-gray-700 last:border-b-0 hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                    <div class="flex items-start justify-between gap-3">
+                      <div class="min-w-0 flex-1">
+                        <div class="flex items-center gap-2">
+                          <span class="text-xs px-1.5 py-0.5 rounded font-bold {langBadge[item.language] || 'bg-gray-100 text-gray-600'}">{(item.language || '?').toUpperCase()}</span>
+                          <h3 class="font-medium text-gray-900 dark:text-white truncate">{item.title}</h3>
+                        </div>
+                        <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">{item.body?.substring(0, 150)}</p>
+                      </div>
+                      <div class="flex items-center gap-1.5 flex-shrink-0">
+                        <a href="/projects/{item.projectId}/content/{item.id}/edit" class="text-xs px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200">
+                          {$_('common.edit')}
+                        </a>
+                        {#if item.status === 'APPROVED' || item.status === 'PUBLISHED'}
+                          <a href="/projects/{item.projectId}/content?focus={item.id}&action=publish" class="text-xs px-3 py-1.5 border border-blue-300 text-blue-600 rounded-lg hover:bg-blue-50 dark:hover:bg-blue-900/20">
+                            {$_('social.publish')}
+                          </a>
+                        {/if}
+                      </div>
                     </div>
-                    <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">{item.body?.substring(0, 150)}</p>
-                  </a>
+                  </div>
                 {/each}
               </div>
             {/if}
@@ -149,9 +163,9 @@
         {:else}
           <!-- Single content item -->
           {@const item = group.items[0]}
-          <a href="/projects/{item.projectId}/content?focus={item.id}" class="block bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
-            <div class="flex items-center justify-between">
-              <div>
+          <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all">
+            <div class="flex items-start justify-between gap-3">
+              <div class="min-w-0 flex-1">
                 <div class="flex items-center gap-1.5 mb-1">
                   {#if item.language}
                     <span class="text-xs px-1.5 py-0.5 rounded font-medium {langBadge[item.language] || 'bg-gray-100 text-gray-600'}">{item.language.toUpperCase()}</span>
@@ -160,13 +174,23 @@
                 <h3 class="font-medium text-gray-900 dark:text-white">{item.title}</h3>
                 <p class="text-sm text-gray-500 dark:text-gray-400">{item.type || ''}{item.status ? ' · ' + item.status : ''}</p>
               </div>
-              {#if ctx.type === 'organization'}
-                <span class="text-xs px-2 py-1 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
-                  {item.projectName || $_('org.scopeProject')}
-                </span>
-              {/if}
+              <div class="flex items-center gap-2 flex-shrink-0">
+                {#if ctx.type === 'organization'}
+                  <span class="text-xs px-2 py-1 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">
+                    {item.projectName || $_('org.scopeProject')}
+                  </span>
+                {/if}
+                <a href="/projects/{item.projectId}/content/{item.id}/edit" class="text-xs px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 text-gray-700 dark:text-gray-200">
+                  {$_('common.edit')}
+                </a>
+                {#if item.status === 'APPROVED' || item.status === 'PUBLISHED'}
+                  <a href="/projects/{item.projectId}/content?focus={item.id}&action=publish" class="text-xs px-3 py-1.5 border border-blue-300 text-blue-600 rounded-lg hover:bg-blue-50 dark:hover:bg-blue-900/20">
+                    {$_('social.publish')}
+                  </a>
+                {/if}
+              </div>
             </div>
-          </a>
+          </div>
         {/if}
       {/each}
     </div>

--- a/apps/web/src/routes/(app)/projects/[id]/content/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/content/+page.svelte
@@ -12,9 +12,6 @@
   let showModal = false;
   let generating = false;
   $: projectId = $page.params['id'];
-  $: focusContentId = $page.url.searchParams.get('focus');
-  $: focusAction = $page.url.searchParams.get('action');
-  let highlightedId: string | null = null;
 
   // Sync picker with this project
   $: if ($projectsStore.length > 0 && projectId) {
@@ -111,26 +108,6 @@
   $: if (projectId && projectId !== prevProjectId) {
     prevProjectId = projectId;
     loadContent(projectId);
-  }
-
-  // Focus a specific content item when arriving with ?focus=<id>
-  let focusHandledFor: string | null = null;
-  $: if (!loading && focusContentId && focusContentId !== focusHandledFor) {
-    const target = contents.find(c => c.id === focusContentId);
-    if (target) {
-      focusHandledFor = focusContentId;
-      if (target.contentGroupId) expandedGroups = new Set(expandedGroups).add(target.contentGroupId);
-      if (focusAction === 'publish' && (target.status === 'APPROVED' || target.status === 'PUBLISHED')) {
-        openPublish(target);
-      } else {
-        setTimeout(() => {
-          const el = document.getElementById(`content-card-${focusContentId}`);
-          if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-          highlightedId = focusContentId;
-          setTimeout(() => { if (highlightedId === focusContentId) highlightedId = null; }, 2500);
-        }, 50);
-      }
-    }
   }
 
   interface ContentGroup { groupId: string | null; items: any[]; }
@@ -534,7 +511,7 @@
             {#if expandedGroups.has(group.groupId)}
               <div class="border-t border-gray-200">
                 {#each group.items as content}
-                  <div id="content-card-{content.id}" class="p-5 border-b border-gray-100 last:border-b-0 bg-gray-50/50 transition-all duration-300 {highlightedId === content.id ? 'ring-2 ring-primary-500 ring-inset bg-primary-50/50' : ''}">
+                  <div class="p-5 border-b border-gray-100 last:border-b-0 bg-gray-50/50">
                     <div class="flex flex-col sm:flex-row items-start justify-between gap-3 sm:gap-4">
                       <div class="flex-1 min-w-0">
                         <div class="flex flex-wrap items-center gap-1.5 mb-2">
@@ -594,7 +571,7 @@
         {:else}
           <!-- Single content item -->
           {@const content = group.items[0]}
-          <div id="content-card-{content.id}" class="bg-white rounded-xl border border-gray-200 border-l-4 {statusBorderAccent[content.status] || 'border-l-gray-300'} p-5 hover:shadow-sm transition-all duration-300 {highlightedId === content.id ? 'ring-2 ring-primary-500 shadow-md' : ''}">
+          <div class="bg-white rounded-xl border border-gray-200 border-l-4 {statusBorderAccent[content.status] || 'border-l-gray-300'} p-5 hover:shadow-sm transition-shadow duration-150">
             <div class="flex flex-col sm:flex-row items-start justify-between gap-3 sm:gap-4">
               <div class="flex-1 min-w-0">
                 <div class="flex flex-wrap items-center gap-1.5 mb-2">

--- a/apps/web/src/routes/(app)/projects/[id]/content/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/content/+page.svelte
@@ -13,6 +13,7 @@
   let generating = false;
   $: projectId = $page.params['id'];
   $: focusContentId = $page.url.searchParams.get('focus');
+  $: focusAction = $page.url.searchParams.get('action');
   let highlightedId: string | null = null;
 
   // Sync picker with this project
@@ -119,12 +120,16 @@
     if (target) {
       focusHandledFor = focusContentId;
       if (target.contentGroupId) expandedGroups = new Set(expandedGroups).add(target.contentGroupId);
-      setTimeout(() => {
-        const el = document.getElementById(`content-card-${focusContentId}`);
-        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        highlightedId = focusContentId;
-        setTimeout(() => { if (highlightedId === focusContentId) highlightedId = null; }, 2500);
-      }, 50);
+      if (focusAction === 'publish' && (target.status === 'APPROVED' || target.status === 'PUBLISHED')) {
+        openPublish(target);
+      } else {
+        setTimeout(() => {
+          const el = document.getElementById(`content-card-${focusContentId}`);
+          if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          highlightedId = focusContentId;
+          setTimeout(() => { if (highlightedId === focusContentId) highlightedId = null; }, 2500);
+        }, 50);
+      }
     }
   }
 
@@ -563,12 +568,13 @@
                             {$_('social.publish')}
                           </button>
                         {/if}
-                        <button
-                          on:click|stopPropagation={() => openEdit(content)}
+                        <a
+                          on:click|stopPropagation
+                          href="/projects/{projectId}/content/{content.id}/edit"
                           class="text-xs px-3 py-1.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
                         >
                           {$_('common.edit')}
-                        </button>
+                        </a>
                         <button
                           on:click|stopPropagation={() => deletingId = content.id}
                           class="text-xs px-2 py-1.5 border border-red-200 text-red-500 rounded-lg hover:bg-red-50 transition-colors duration-150 cursor-pointer"
@@ -657,12 +663,12 @@
                   {$_('content.repurpose')}
                 </button>
                 <!-- Edit button -->
-                <button
-                  on:click={() => openEdit(content)}
+                <a
+                  href="/projects/{projectId}/content/{content.id}/edit"
                   class="text-xs px-3 py-1.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
                 >
                   {$_('common.edit')}
-                </button>
+                </a>
                 <!-- Delete button -->
                 <button
                   on:click={() => deletingId = content.id}


### PR DESCRIPTION
## Summary
- Clicking a post card on `/content` now navigates straight to `/projects/<id>/content/<cid>/edit` instead of dropping the user back into the project posts list.
- The edit route stays inside the `(app)` layout, so the sidebar and header remain visible while editing — no fullscreen modal.
- Also updated the Edit button on the project content page to use the same dedicated edit route for consistency, and removed the now-unused deep-link helpers (`?focus=`, `?action=`, scroll/highlight logic).

## Test plan
- [ ] Open `/content` and click a single post → lands on the edit page with title/body editable, sidebar + header visible.
- [ ] Open `/content`, expand a multilingual group, click one of the language items → lands on the edit page for that language variant.
- [ ] On `/projects/<id>/content`, click the Edit button on a post → same edit page, sidebar + header visible.
- [ ] Save from the edit page, return to the list, confirm the change persisted.

https://claude.ai/code/session_01ULNCNf52gMX1ehiBwyuyYx