### PR TITLE
fix(api): allow scheduledAt without accountIds (multilingual sibling rows)

### DIFF
--- a/apps/api/src/content/content.service.spec.ts
+++ b/apps/api/src/content/content.service.spec.ts
@@ -37,12 +37,26 @@ describe('ContentService.create — scheduled', () => {
     ).rejects.toBeInstanceOf(BadRequestException);
   });
 
-  it('rejects when scheduledAt is set without accountIds', async () => {
+  it('allows scheduledAt without accountIds (multilingual sibling row): SCHEDULED, no publications', async () => {
     const future = new Date(Date.now() + 60_000).toISOString();
+    mockPrisma.content.create.mockResolvedValue({ id: 'ct1', language: 'en', contentGroupId: 'grp1' });
+    await service.create({
+      projectId: 'p1', type: 'SOCIAL_POST', title: 't', body: 'b',
+      scheduledAt: future as any,
+      contentGroupId: 'grp1',
+    } as any, 'u1');
+    expect(mockPrisma.content.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ status: 'SCHEDULED', scheduledAt: future }),
+    }));
+    expect(mockPrisma.contentPublication.createMany).not.toHaveBeenCalled();
+  });
+
+  it('rejects accountIds without scheduledAt', async () => {
+    mockPrisma.socialAccount.findMany.mockResolvedValue([{ id: 'acc1', platform: 'LINKEDIN', language: 'en' }]);
     await expect(
       service.create({
         projectId: 'p1', type: 'SOCIAL_POST', title: 't', body: 'b',
-        scheduledAt: future as any,
+        scheduledPublicationAccountIds: ['acc1'],
       } as any, 'u1'),
     ).rejects.toBeInstanceOf(BadRequestException);
   });

--- a/apps/api/src/content/content.service.ts
+++ b/apps/api/src/content/content.service.ts
@@ -79,14 +79,22 @@ export class ContentService {
       organizationId = project?.organizationId;
     }
 
-    const scheduling = !!dto.scheduledAt || !!dto.scheduledPublicationAccountIds?.length;
-    if (scheduling) {
-      if (!dto.scheduledAt || !dto.scheduledPublicationAccountIds?.length) {
-        throw new BadRequestException('scheduledAt and scheduledPublicationAccountIds must be provided together');
-      }
-      if (new Date(dto.scheduledAt).getTime() <= Date.now()) {
+    // Multilingual scheduling contract: the frontend creates N sibling Content rows
+    // (one per language) sharing a contentGroupId, sends `scheduledAt` on every call,
+    // but `scheduledPublicationAccountIds` only on the LAST call (once all siblings
+    // exist and the API can resolve account.language → matching sibling content).
+    // So "scheduledAt alone" is a valid sibling-row state; "accountIds alone" is not.
+    const hasPublications = !!dto.scheduledPublicationAccountIds?.length;
+    const hasScheduledAt = !!dto.scheduledAt;
+    if (hasPublications && !hasScheduledAt) {
+      throw new BadRequestException('scheduledAt is required when scheduledPublicationAccountIds is set');
+    }
+    if (hasScheduledAt) {
+      if (new Date(dto.scheduledAt!).getTime() <= Date.now()) {
         throw new BadRequestException('scheduledAt must be in the future');
       }
+    }
+    if (hasPublications) {
       const attached = await this.prisma.socialAccount.findMany({
         where: {
           id: { in: dto.scheduledPublicationAccountIds },
@@ -95,7 +103,7 @@ export class ContentService {
         },
         select: { id: true, platform: true, language: true },
       });
-      if (attached.length !== dto.scheduledPublicationAccountIds.length) {
+      if (attached.length !== dto.scheduledPublicationAccountIds!.length) {
         throw new BadRequestException('One or more selected social accounts are not attached to this project');
       }
       (dto as any).__attachedAccounts = attached;
@@ -117,14 +125,16 @@ export class ContentService {
           platform: dto.platform as any,
           platforms: dto.platforms || [],
           scheduledAt: dto.scheduledAt,
-          status: scheduling ? 'SCHEDULED' : undefined,
+          // A sibling row (scheduledAt without publications) is still SCHEDULED
+          // from the user's point of view — they see the badge in the list.
+          status: hasScheduledAt ? 'SCHEDULED' : undefined,
           aiGenerated: dto.aiGenerated || false,
           language: dto.language || undefined,
           contentGroupId: dto.contentGroupId || undefined,
         },
       });
 
-      if (scheduling) {
+      if (hasPublications) {
         const groupRows = created.contentGroupId
           ? await tx.content.findMany({
               where: { contentGroupId: created.contentGroupId },


### PR DESCRIPTION
## Summary

The multilingual scheduled-create flow rejects its own first-iteration payloads with:

\`scheduledAt and scheduledPublicationAccountIds must be provided together\`

Per the design contract, the frontend sends \`scheduledAt\` on every language iteration but \`scheduledPublicationAccountIds\` only on the last (once all siblings exist, so \`account.language → matching content\` can resolve). The backend validation was too strict and rejected the first 1-2 siblings.

Fix: split the intent into two flags.
- \`scheduledAt\` alone → sibling row, \`Content.status='SCHEDULED'\`, no publications
- \`accountIds\` alone → still rejected (illogical)
- both → publications created, language-matched across the group

(This commit was in PR #50 but didn't make it into the squash merge — only the hint commit did. Re-submitting standalone.)

## Test plan

- [ ] Create scheduled multilingual content (all 3 languages) → no 400, all sibling rows SCHEDULED, publications language-matched
- [ ] Create single-language scheduled content → unchanged
- [ ] Submit accountIds without scheduledAt → still 400

11/11 content.service.spec.ts tests pass.