### PR TITLE
fix(web): localize content type and status in lists (SOCIAL_POST → Social Post)

### DIFF
--- a/apps/web/src/routes/(app)/content/+page.svelte
+++ b/apps/web/src/routes/(app)/content/+page.svelte
@@ -67,6 +67,27 @@
     pl: 'bg-red-100 text-red-700',
     ru: 'bg-green-100 text-green-700',
   };
+
+  const statusLabel: Record<string, string> = {
+    DRAFT: 'content.draft',
+    REVIEW: 'content.review',
+    APPROVED: 'content.approved',
+    PUBLISHED: 'content.published',
+    REJECTED: 'content.rejected',
+    SCHEDULED: 'content.scheduled',
+  };
+
+  const typeLabel: Record<string, string> = {
+    SOCIAL_POST: 'content.socialPost',
+    BLOG_ARTICLE: 'content.blogArticle',
+    EMAIL: 'content.emailContent',
+    NEWSLETTER: 'content.newsletter',
+    AD_COPY: 'content.adCopy',
+    LANDING_PAGE: 'content.landingPage',
+    SEO_ARTICLE: 'content.seoArticle',
+    REFERRAL_COPY: 'content.referralCopy',
+    IN_APP_MESSAGE: 'content.inAppMessage',
+  };
 </script>
 
 <div class="p-4 sm:p-6">
@@ -116,7 +137,10 @@
                     {#each group.items as gi}
                       <span class="text-xs px-1.5 py-0.5 rounded font-medium {langBadge[gi.language] || 'bg-gray-100 text-gray-600'}">{(gi.language || '?').toUpperCase()}</span>
                     {/each}
-                    <span class="text-xs text-gray-400">{group.items[0].type || ''} · {group.items[0].status || ''}</span>
+                    <span class="text-xs text-gray-400">
+                      {group.items[0].type ? (typeLabel[group.items[0].type] ? $_(typeLabel[group.items[0].type]) : group.items[0].type.replace(/_/g, ' ')) : ''}
+                      {#if group.items[0].status}· {statusLabel[group.items[0].status] ? $_(statusLabel[group.items[0].status]) : group.items[0].status}{/if}
+                    </span>
                   </div>
                   <h3 class="font-medium text-gray-900 dark:text-white">{group.items[0].title}</h3>
                 </div>
@@ -158,7 +182,10 @@
                   {/if}
                 </div>
                 <h3 class="font-medium text-gray-900 dark:text-white">{item.title}</h3>
-                <p class="text-sm text-gray-500 dark:text-gray-400">{item.type || ''}{item.status ? ' · ' + item.status : ''}</p>
+                <p class="text-sm text-gray-500 dark:text-gray-400">
+                  {item.type ? (typeLabel[item.type] ? $_(typeLabel[item.type]) : item.type.replace(/_/g, ' ')) : ''}
+                  {#if item.status}· {statusLabel[item.status] ? $_(statusLabel[item.status]) : item.status}{/if}
+                </p>
               </div>
               {#if ctx.type === 'organization'}
                 <span class="text-xs px-2 py-1 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">

--- a/apps/web/src/routes/(app)/projects/[id]/content/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/content/+page.svelte
@@ -368,6 +368,18 @@
     SCHEDULED: 'content.scheduled',
   };
 
+  const typeLabel: Record<string, string> = {
+    SOCIAL_POST: 'content.socialPost',
+    BLOG_ARTICLE: 'content.blogArticle',
+    EMAIL: 'content.emailContent',
+    NEWSLETTER: 'content.newsletter',
+    AD_COPY: 'content.adCopy',
+    LANDING_PAGE: 'content.landingPage',
+    SEO_ARTICLE: 'content.seoArticle',
+    REFERRAL_COPY: 'content.referralCopy',
+    IN_APP_MESSAGE: 'content.inAppMessage',
+  };
+
   function toggleGroup(groupId: string) {
     if (expandedGroups.has(groupId)) expandedGroups.delete(groupId);
     else expandedGroups.add(groupId);
@@ -555,7 +567,7 @@
               <div class="flex flex-col sm:flex-row items-start justify-between gap-3 sm:gap-4">
                 <div class="flex-1 min-w-0">
                   <div class="flex flex-wrap items-center gap-1.5 mb-2">
-                    <span class="text-xs px-2 py-0.5 bg-gray-100 text-gray-600 rounded font-medium">{group.items[0].type.replace('_', ' ')}</span>
+                    <span class="text-xs px-2 py-0.5 bg-gray-100 text-gray-600 rounded font-medium">{typeLabel[group.items[0].type] ? $_(typeLabel[group.items[0].type]) : group.items[0].type.replace(/_/g, ' ')}</span>
                     <span class="text-xs px-2 py-0.5 rounded {statusBadge[group.items[0].status] || 'bg-gray-100 text-gray-600'}">{$_(statusLabel[group.items[0].status] || 'content.draft')}</span>
                     {#each group.items as item}
                       <span class="text-xs px-2 py-0.5 rounded font-medium {langBadgeColor[item.language] || 'bg-gray-100 text-gray-600'}">{(item.language || 'en').toUpperCase()}</span>
@@ -670,7 +682,7 @@
             <div class="flex flex-col sm:flex-row items-start justify-between gap-3 sm:gap-4">
               <div class="flex-1 min-w-0">
                 <div class="flex flex-wrap items-center gap-1.5 mb-2">
-                  <span class="text-xs px-2 py-0.5 bg-gray-100 text-gray-600 rounded font-medium">{content.type.replace('_', ' ')}</span>
+                  <span class="text-xs px-2 py-0.5 bg-gray-100 text-gray-600 rounded font-medium">{typeLabel[content.type] ? $_(typeLabel[content.type]) : content.type.replace(/_/g, ' ')}</span>
                   {#if content.platforms?.length}
                     {#each content.platforms as p}
                       <span class="text-xs px-2 py-0.5 bg-blue-50 text-blue-600 rounded">{p}</span>


### PR DESCRIPTION
## Summary
- Content list items rendered the raw enum — "SOCIAL_POST · APPROVED" — on both `/content` (org-level) and `/projects/[id]/content` (grouped + single layouts).
- Added a `typeLabel` map (parallel to the existing `statusLabel`) and swapped the render to `$_(typeLabel[x])`, so the text is translated per the user's locale: EN "Social Post · Approved", PL "Post społecznościowy · Zatwierdzone", RU "Пост в соцсетях · Одобрено".
- Falls back to `type.replace(/_/g, ' ')` if the enum isn't in the map, so an unknown value still renders without the underscore.

## Test plan
- [ ] Switch locale to EN/PL/RU and open `/projects/[id]/content` — type + status are translated in both grouped header and single-item cards
- [ ] Open `/content` (org-level) — same, for grouped and single items
- [ ] Content with an unusual type (shouldn't occur today, but safety) renders as space-separated words, not raw enum

🤖 Generated with [Claude Code](https://claude.com/claude-code)