### PR TITLE
feat(web): dashboard stats — KPI, activity metrics, per-project breakdown

### DIFF
--- a/apps/web/src/lib/components/DashboardKpiCards.svelte
+++ b/apps/web/src/lib/components/DashboardKpiCards.svelte
@@ -1,0 +1,166 @@
+<script lang="ts">
+  import { _ } from 'svelte-i18n';
+  import { onMount } from 'svelte';
+  import { api } from '$lib/api/client';
+
+  export let organizationId: string;
+  export let period: 7 | 30 | 90 = 30;
+
+  type Summary = {
+    contentCountAll: number;
+    campaignCount: number;
+    subscriberCount: number;
+    socialAccountCount: number;
+  };
+
+  type Totals = {
+    total: Record<string, number>;
+    change: Record<string, number>;
+    trend: Record<string, 'up' | 'down' | 'stable'>;
+  };
+
+  let summary: Summary | null = null;
+  let summaryLoading = true;
+  let summaryError = false;
+
+  let totals: Totals | null = null;
+  let totalsLoading = true;
+  let totalsError = false;
+
+  onMount(async () => {
+    await Promise.all([loadSummary(), loadTotals()]);
+  });
+
+  async function loadSummary() {
+    summaryLoading = true;
+    summaryError = false;
+    try {
+      summary = await api.get<Summary>('/analytics/summary', { organizationId });
+    } catch {
+      summaryError = true;
+      summary = null;
+    } finally {
+      summaryLoading = false;
+    }
+  }
+
+  async function loadTotals() {
+    totalsLoading = true;
+    totalsError = false;
+    try {
+      totals = await api.get<Totals>('/analytics/metrics/totals', { organizationId, days: period });
+    } catch {
+      totalsError = true;
+      totals = null;
+    } finally {
+      totalsLoading = false;
+    }
+  }
+
+  function setPeriod(p: 7 | 30 | 90) {
+    if (period === p) return;
+    period = p;
+    loadTotals();
+  }
+
+  function formatNumber(n: number): string {
+    if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+    if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+    return String(n);
+  }
+
+  function trendClass(trend: string | undefined): string {
+    if (trend === 'up') return 'text-green-600';
+    if (trend === 'down') return 'text-red-600';
+    return 'text-gray-400';
+  }
+
+  function trendArrow(trend: string | undefined): string {
+    if (trend === 'up') return '↑';
+    if (trend === 'down') return '↓';
+    return '—';
+  }
+
+  const kpiIconContent = 'M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z';
+  const kpiIconCampaign = 'M3 5a2 2 0 012-2h1.28a2 2 0 011.664.89l.812 1.22A2 2 0 0010.42 6H19a2 2 0 012 2v9a2 2 0 01-2 2H5a2 2 0 01-2-2V5z';
+  const kpiIconSubs = 'M18 18.72a9.094 9.094 0 003.741-.479 3 3 0 00-4.682-2.72m.94 3.198l.001.031c0 .225-.012.447-.037.666A11.944 11.944 0 0112 21c-2.17 0-4.207-.576-5.963-1.584A6.062 6.062 0 016 18.719m12 0a5.971 5.971 0 00-.941-3.197m0 0A5.995 5.995 0 0012 12.75a5.995 5.995 0 00-5.058 2.772m0 0a3 3 0 00-4.681 2.72 8.986 8.986 0 003.74.477m.94-3.197a5.971 5.971 0 00-.94 3.197M15 6.75a3 3 0 11-6 0 3 3 0 016 0zm6 3a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0zm-13.5 0a2.25 2.25 0 11-4.5 0 2.25 2.25 0 014.5 0z';
+  const kpiIconSocial = 'M7.217 10.907a2.25 2.25 0 100 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186l9.566-5.314m-9.566 7.5l9.566 5.314m0 0a2.25 2.25 0 103.935 2.186 2.25 2.25 0 00-3.935-2.186zm0-12.814a2.25 2.25 0 103.933-2.185 2.25 2.25 0 00-3.933 2.185z';
+</script>
+
+<div class="space-y-4 mb-6">
+  <!-- KPI block -->
+  <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+    {#each [
+      { label: $_('dashboard.kpiTotalContent'), value: summary?.contentCountAll, icon: kpiIconContent, bg: 'bg-blue-50', fg: 'text-blue-600' },
+      { label: $_('dashboard.kpiCampaigns'), value: summary?.campaignCount, icon: kpiIconCampaign, bg: 'bg-amber-50', fg: 'text-amber-600' },
+      { label: $_('dashboard.kpiSubscribers'), value: summary?.subscriberCount, icon: kpiIconSubs, bg: 'bg-emerald-50', fg: 'text-emerald-600' },
+      { label: $_('dashboard.kpiSocialAccounts'), value: summary?.socialAccountCount, icon: kpiIconSocial, bg: 'bg-violet-50', fg: 'text-violet-600' },
+    ] as card}
+      <div class="bg-white border border-gray-200 rounded-xl p-4 flex items-center gap-3">
+        <div class="w-10 h-10 {card.bg} rounded-lg flex items-center justify-center flex-shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 {card.fg}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
+            <path stroke-linecap="round" stroke-linejoin="round" d={card.icon} />
+          </svg>
+        </div>
+        <div class="min-w-0">
+          <p class="text-xs text-gray-500 truncate">{card.label}</p>
+          {#if summaryLoading}
+            <div class="h-6 w-14 bg-gray-100 rounded animate-pulse mt-1"></div>
+          {:else if summaryError}
+            <p class="text-base font-semibold text-gray-300">—</p>
+          {:else}
+            <p class="text-xl font-bold text-gray-900">{formatNumber(card.value ?? 0)}</p>
+          {/if}
+        </div>
+      </div>
+    {/each}
+  </div>
+
+  <!-- Activity block -->
+  <div class="bg-white border border-gray-200 rounded-xl p-4">
+    <div class="flex items-center justify-between flex-wrap gap-2 mb-4">
+      <h2 class="text-sm font-semibold text-gray-700">{$_('dashboard.activityTitle')}</h2>
+      <div class="inline-flex items-center border border-gray-200 rounded-lg overflow-hidden text-xs">
+        {#each [{ v: 7, label: $_('analytics.period7') }, { v: 30, label: $_('analytics.period30') }, { v: 90, label: $_('analytics.period90') }] as opt}
+          <button
+            type="button"
+            class="px-3 py-1.5 transition-colors cursor-pointer {period === opt.v ? 'bg-primary-600 text-white' : 'text-gray-600 hover:bg-gray-50'}"
+            on:click={() => setPeriod(opt.v as 7 | 30 | 90)}
+          >
+            {opt.label}
+          </button>
+        {/each}
+      </div>
+    </div>
+
+    <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+      {#each [
+        { key: 'visitors', label: $_('analytics.visitors') },
+        { key: 'leads', label: $_('analytics.leads') },
+        { key: 'conversions', label: $_('analytics.conversions') },
+        { key: 'emailOpens', label: $_('analytics.emailOpens') },
+      ] as metric}
+        <div class="rounded-lg border border-gray-100 bg-gray-50/50 px-3 py-3">
+          <p class="text-xs text-gray-500 truncate">{metric.label}</p>
+          {#if totalsLoading}
+            <div class="h-6 w-16 bg-gray-200 rounded animate-pulse mt-1.5"></div>
+            <div class="h-3 w-10 bg-gray-100 rounded animate-pulse mt-2"></div>
+          {:else if totalsError || !totals}
+            <p class="text-lg font-semibold text-gray-300 mt-1">—</p>
+          {:else}
+            <p class="text-lg font-bold text-gray-900 mt-1">{formatNumber(totals.total[metric.key] ?? 0)}</p>
+            <p class="text-xs mt-1 flex items-center gap-1 {trendClass(totals.trend[metric.key])}">
+              <span>{trendArrow(totals.trend[metric.key])}</span>
+              {#if (totals.change[metric.key] ?? 0) !== 0}
+                <span>{Math.abs(totals.change[metric.key] ?? 0)}%</span>
+              {:else}
+                <span class="text-gray-400">{$_('analytics.noChange')}</span>
+              {/if}
+              <span class="text-gray-400 ml-1 truncate">{$_('analytics.vsLastPeriod')}</span>
+            </p>
+          {/if}
+        </div>
+      {/each}
+    </div>
+  </div>
+</div>

--- a/apps/web/src/lib/components/ProjectCardStats.svelte
+++ b/apps/web/src/lib/components/ProjectCardStats.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { _ } from 'svelte-i18n';
+
+  export let stats: { content: number; emailsSent: number; pageViews: number; conversions: number } | undefined = undefined;
+  export let period: number;
+  export let loading = false;
+
+  function formatNumber(n: number): string {
+    if (n >= 1_000_000) return (n / 1_000_000).toFixed(1) + 'M';
+    if (n >= 1_000) return (n / 1_000).toFixed(1) + 'K';
+    return String(n);
+  }
+
+  $: hasAnyActivity = stats && (stats.pageViews + stats.emailsSent + stats.conversions + stats.content > 0);
+</script>
+
+<div class="border-t border-gray-100 pt-3 mt-3">
+  <p class="text-[11px] uppercase tracking-wide text-gray-400 mb-2">
+    {$_('dashboard.lastNDays').replace('{n}', String(period))}
+  </p>
+  {#if loading}
+    <div class="grid grid-cols-4 gap-2">
+      {#each [0, 1, 2, 3] as _i}
+        <div class="h-5 bg-gray-100 rounded animate-pulse"></div>
+      {/each}
+    </div>
+  {:else if !stats || !hasAnyActivity}
+    <p class="text-xs text-gray-400">{$_('dashboard.noActivity')}</p>
+  {:else}
+    <div class="grid grid-cols-4 gap-2 text-xs">
+      <div class="flex flex-col items-start">
+        <span class="flex items-center gap-1 text-gray-500" title={$_('analytics.pageViews')}>
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8"><path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"/><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
+        </span>
+        <span class="text-gray-900 font-semibold mt-0.5">{formatNumber(stats.pageViews)}</span>
+      </div>
+      <div class="flex flex-col items-start">
+        <span class="flex items-center gap-1 text-gray-500" title={$_('analytics.emailOpens')}>
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8"><path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75"/></svg>
+        </span>
+        <span class="text-gray-900 font-semibold mt-0.5">{formatNumber(stats.emailsSent)}</span>
+      </div>
+      <div class="flex flex-col items-start">
+        <span class="flex items-center gap-1 text-gray-500" title={$_('analytics.conversions')}>
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
+        </span>
+        <span class="text-gray-900 font-semibold mt-0.5">{formatNumber(stats.conversions)}</span>
+      </div>
+      <div class="flex flex-col items-start">
+        <span class="flex items-center gap-1 text-gray-500" title={$_('content.content')}>
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z"/></svg>
+        </span>
+        <span class="text-gray-900 font-semibold mt-0.5">{formatNumber(stats.content)}</span>
+      </div>
+    </div>
+  {/if}
+</div>

--- a/apps/web/src/routes/(app)/dashboard/+page.svelte
+++ b/apps/web/src/routes/(app)/dashboard/+page.svelte
@@ -4,8 +4,54 @@
   import { currentProjectStore, organizationIdStore, projectsStore } from '$lib/stores/projects';
   import type { Project, ProjectExportData, ProjectExportSection, ImportValidationResult } from '@marketing-ai/shared-types';
   import { goto } from '$app/navigation';
+  import DashboardKpiCards from '$lib/components/DashboardKpiCards.svelte';
+  import ProjectCardStats from '$lib/components/ProjectCardStats.svelte';
 
   $: projects = $projectsStore;
+
+  // ── Dashboard stats ──
+  type ProjectStats = { content: number; emailsSent: number; pageViews: number; conversions: number };
+  type OrgSummaryResponse = {
+    byProject: Array<{ projectId: string; projectName: string } & ProjectStats>;
+  };
+
+  let period: 7 | 30 | 90 = 30;
+  let projectStats: Record<string, ProjectStats> = {};
+  let projectStatsLoading = false;
+  let previousPeriod: 7 | 30 | 90 = period;
+  let lastLoadedOrg: string | null = null;
+
+  $: if ($organizationIdStore && ($organizationIdStore !== lastLoadedOrg || period !== previousPeriod)) {
+    lastLoadedOrg = $organizationIdStore;
+    previousPeriod = period;
+    loadByProject();
+  }
+
+  async function loadByProject() {
+    if (!$organizationIdStore) return;
+    projectStatsLoading = true;
+    try {
+      const res = await api.get<OrgSummaryResponse>('/analytics/organization', {
+        organizationId: $organizationIdStore,
+        period: `${period}d`,
+      });
+      const next: Record<string, ProjectStats> = {};
+      for (const row of res.byProject || []) {
+        next[row.projectId] = {
+          content: row.content,
+          emailsSent: row.emailsSent,
+          pageViews: row.pageViews,
+          conversions: row.conversions,
+        };
+      }
+      projectStats = next;
+    } catch {
+      // Keep previous stats to avoid visual glitch; but mark empty on first failure
+      if (Object.keys(projectStats).length === 0) projectStats = {};
+    } finally {
+      projectStatsLoading = false;
+    }
+  }
 
   // ── Import ──
   let showImportModal = false;
@@ -133,6 +179,10 @@
     </div>
   </div>
 
+  {#if $projectsStore.length > 0 && $organizationIdStore}
+    <DashboardKpiCards organizationId={$organizationIdStore} bind:period />
+  {/if}
+
   {#if $projectsStore.length === 0}
     <div class="flex flex-col items-center justify-center py-24 text-center">
       <div class="w-20 h-20 bg-primary-50 rounded-2xl flex items-center justify-center mb-6">
@@ -194,6 +244,8 @@
               {(project as any)._count?.checklists || 0}
             </span>
           </div>
+
+          <ProjectCardStats stats={projectStats[project.id]} {period} loading={projectStatsLoading} />
         </a>
       {/each}
     </div>

--- a/apps/web/src/routes/(app)/dashboard/+page.svelte
+++ b/apps/web/src/routes/(app)/dashboard/+page.svelte
@@ -202,7 +202,7 @@
         <a
           href="/projects/{project.id}/overview"
           on:click={() => currentProjectStore.set(project)}
-          class="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-md hover:border-primary-200 transition-all duration-150 group block cursor-pointer border-t-4
+          class="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-md hover:border-primary-200 transition-all duration-150 group cursor-pointer border-t-4 flex flex-col h-full
             {project.status === 'ACTIVE' ? 'border-t-green-400' : project.status === 'PAUSED' ? 'border-t-amber-400' : 'border-t-gray-200'}"
         >
           <div class="flex items-start justify-between mb-4">
@@ -230,7 +230,7 @@
             <p class="text-sm text-gray-500 mb-4 line-clamp-2">{project.description}</p>
           {/if}
 
-          <div class="flex gap-4 text-xs text-gray-400 border-t border-gray-100 pt-4">
+          <div class="flex gap-4 text-xs text-gray-400 border-t border-gray-100 pt-4 mt-auto">
             <span class="flex items-center gap-1">
               <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" /></svg>
               {(project as any)._count?.content || 0}

--- a/docs/superpowers/specs/2026-04-20-dashboard-stats-design.md
+++ b/docs/superpowers/specs/2026-04-20-dashboard-stats-design.md
@@ -1,0 +1,129 @@
+# Dashboard Stats — Design
+
+**Date:** 2026-04-20
+**Issue:** https://github.com/micode-ai/marketing-ai-assistant/issues/54
+**Scope:** Frontend only (`apps/web`). No API changes.
+
+## Problem
+
+`/dashboard` currently shows only a list of projects with mini-counters (content, campaigns, checklists). Users cannot see aggregate health of their organization (total activity, trends across projects) without navigating to the `/analytics` page or opening each project.
+
+## Goal
+
+Add three sections to `/dashboard`:
+
+1. **Organization KPI** — non-temporal counters (totals).
+2. **Activity metrics** — temporal counters with period selector (7/30/90d) and trend indicators.
+3. **Extended project cards** — each project card gets a mini-stats section for the selected period.
+
+## Data Sources (existing endpoints, no backend work)
+
+| Endpoint | Purpose | Used where |
+|----------|---------|------------|
+| `GET /analytics/summary?organizationId=X` | Totals: `contentCountAll`, `campaignCount`, `subscriberCount`, `socialAccountCount` | KPI block (period-independent) |
+| `GET /analytics/totals?organizationId=X&days=N` | Returns `{ total, change, trend }` for visitors/leads/conversions/emails over N days vs. previous N days | Activity block |
+| `GET /analytics/org-summary?organizationId=X&period=Nd` | Returns `byProject[]` with `content / emailsSent / pageViews / conversions` per project | Per-project card stats |
+
+All three are already implemented in `apps/api/src/analytics/analytics.service.ts`.
+
+## UI Structure
+
+```
+┌─ Header (title + Import/Create) ──────────────────────────┐
+│                                                           │
+├─ KPI block (period-independent) ──────────────────────────┤
+│  [Content] [Campaigns] [Subscribers] [Social accounts]    │
+│                                                           │
+├─ Activity block  [period: 7d | 30d | 90d] ────────────────┤
+│  [Visitors ↑12%] [Leads ↓3%] [Conversions ↑8%] [Opens]    │
+│                                                           │
+├─ Projects grid (extended cards) ──────────────────────────┤
+│  ┌───────────────┐  ┌───────────────┐                     │
+│  │ Project card  │  │ Project card  │  …                  │
+│  │ (existing)    │  │ (existing)    │                     │
+│  │ ─────         │  │ ─────         │                     │
+│  │ Last N days:  │  │ Last N days:  │                     │
+│  │ 👁 views      │  │ 👁 views      │                     │
+│  │ 📧 opens      │  │ 📧 opens      │                     │
+│  │ 🎯 conv.      │  │ 🎯 conv.      │                     │
+│  └───────────────┘  └───────────────┘                     │
+└───────────────────────────────────────────────────────────┘
+```
+
+The period selector controls **both** the Activity block and the per-project card stats (single source of truth).
+
+## Components
+
+Two small Svelte components, kept next to `+page.svelte` for locality:
+
+### `DashboardKpiCards.svelte`
+- Props: `organizationId: string`, `period: 7 | 30 | 90` (bindable).
+- Owns the loading/state for summary + totals.
+- Emits period changes back to parent via `bind:period`.
+- Internal state:
+  - `summary` — loaded once on mount.
+  - `totals` — reloaded whenever `period` changes.
+- Handles skeleton + error states independently.
+
+### `ProjectCardStats.svelte`
+- Props: `stats: { pageViews, emailsSent, conversions, content } | undefined`, `period: number`.
+- Pure presentational. If `stats` is undefined (loading), shows skeleton; if all zeros, shows "No activity in last N days".
+
+### `+page.svelte` integration
+- Adds single state variable `period: 7 | 30 | 90 = 30`.
+- Loads `orgSummary` (byProject) via reactive statement when `period` changes; stores in `Map<projectId, ProjectStats>`.
+- Passes `stats[project.id]` to `<ProjectCardStats>` inside each card.
+
+## States
+
+| State | Behaviour |
+|-------|-----------|
+| Loading | Skeleton placeholders for KPI cards and each project's stats section (prevents layout shift). |
+| Zero metrics | KPI shows `0`, trend shows `—` (no arrow). |
+| API error | Stats sections hide; project list remains fully functional. |
+| No projects (0) | KPI + activity blocks hidden; existing empty state shown. |
+| Period changes | Activity block + per-project stats reload together; KPI unchanged. |
+
+## i18n
+
+New keys in `packages/i18n/src/locales/{en,pl,ru}.json` under `dashboard` namespace:
+
+```
+dashboard.kpiTotalContent
+dashboard.kpiCampaigns
+dashboard.kpiSubscribers
+dashboard.kpiSocialAccounts
+dashboard.activityVisitors
+dashboard.activityLeads
+dashboard.activityConversions
+dashboard.activityEmailOpens
+dashboard.periodLabel
+dashboard.period7d
+dashboard.period30d
+dashboard.period90d
+dashboard.lastNDays          # "Last {n} days"
+dashboard.noActivity         # "No activity"
+dashboard.noChange           # "—"
+```
+
+## Out of Scope
+
+- Sparkline/chart visualisations — deferred. Simple numbers only for v1.
+- Custom date ranges — only 7/30/90 fixed options.
+- Comparison between projects (already exists in `/analytics`).
+- New backend endpoints.
+
+## Acceptance Criteria
+
+- [ ] KPI block loads from `/analytics/summary` and renders above the project list.
+- [ ] Activity block shows trends, recalculated on period change.
+- [ ] Period selector (7/30/90) drives both activity block and per-project stats.
+- [ ] Per-project stats render from `byProject[]` under each card.
+- [ ] Skeleton placeholders shown during load.
+- [ ] Stats API errors do not break the project list.
+- [ ] All strings localised in `en/pl/ru`.
+- [ ] Mobile layout stacks KPI cards vertically.
+
+## Risks / Open Questions
+
+None significant. All data is already served by existing endpoints; this is a pure UI composition.

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -1306,6 +1306,15 @@
       "otherIncome": "Other"
     }
   },
+  "dashboard": {
+    "kpiTotalContent": "Content",
+    "kpiCampaigns": "Active campaigns",
+    "kpiSubscribers": "Subscribers",
+    "kpiSocialAccounts": "Social accounts",
+    "activityTitle": "Activity",
+    "lastNDays": "Last {n} days",
+    "noActivity": "No activity"
+  },
   "googlePlay": {
     "title": "Google Play Analytics",
     "tabs": {

--- a/packages/i18n/src/locales/pl.json
+++ b/packages/i18n/src/locales/pl.json
@@ -1286,6 +1286,15 @@
       "otherIncome": "Inne"
     }
   },
+  "dashboard": {
+    "kpiTotalContent": "Treści",
+    "kpiCampaigns": "Aktywne kampanie",
+    "kpiSubscribers": "Subskrybenci",
+    "kpiSocialAccounts": "Konta społecznościowe",
+    "activityTitle": "Aktywność",
+    "lastNDays": "Ostatnie {n} dni",
+    "noActivity": "Brak aktywności"
+  },
   "googlePlay": {
     "title": "Analityka Google Play",
     "tabs": {

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -1284,6 +1284,15 @@
       "otherIncome": "Прочее"
     }
   },
+  "dashboard": {
+    "kpiTotalContent": "Контент",
+    "kpiCampaigns": "Активные кампании",
+    "kpiSubscribers": "Подписчики",
+    "kpiSocialAccounts": "Соц. аккаунты",
+    "activityTitle": "Активность",
+    "lastNDays": "За {n} дней",
+    "noActivity": "Нет активности"
+  },
   "googlePlay": {
     "title": "Аналитика Google Play",
     "tabs": {


### PR DESCRIPTION
Closes #54

## Summary
- Adds an organization KPI block (content / campaigns / subscribers / social accounts) above the project list on `/dashboard`.
- Adds an activity block with visitors / leads / conversions / email opens, trend arrows and a 7d / 30d / 90d period selector.
- Adds a per-project mini-stats section inside each card (page views, email opens, conversions, content) driven by the same period.
- No backend changes — reuses `GET /analytics/summary`, `GET /analytics/metrics/totals`, `GET /analytics/organization`.
- New i18n keys under the `dashboard` namespace in `en/pl/ru`.
- Project cards are now `flex flex-col h-full` with `mt-auto` on the footer, so cards align visually whether or not a project has a description.

## Design
`docs/superpowers/specs/2026-04-20-dashboard-stats-design.md`

## Test plan
- [ ] Log in, open `/dashboard` with at least one project.
- [ ] Verify the KPI block renders four cards with real totals.
- [ ] Verify the activity block renders four metrics with trend indicators and `vs last period`.
- [ ] Switch the period selector between 7d / 30d / 90d — activity numbers and per-project stats reload.
- [ ] Verify each project card shows a "Last N days" stats row.
- [ ] Create/pick a project without a description and confirm card height matches siblings.
- [ ] Switch language to PL and RU — all labels localise.
- [ ] With 0 projects, the stats blocks are hidden and the empty state still shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)