### PR TITLE
fix(web): full-screen calendar + downloadable documents

### DIFF
--- a/apps/web/src/routes/(app)/calendar/+page.svelte
+++ b/apps/web/src/routes/(app)/calendar/+page.svelte
@@ -210,7 +210,7 @@
   }
 </script>
 
-<div class="p-4 sm:p-6">
+<div class="p-4 sm:p-6 h-full flex flex-col min-h-0">
   <div class="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 mb-1">
     <span>{currentOrg?.name || $_('header.orgContext')}</span>
     {#if $currentProjectStore}
@@ -281,16 +281,16 @@
   </div>
 
   {#if loading}
-    <div class="bg-white rounded-xl border border-gray-200 p-4">
-      <div class="grid grid-cols-7 gap-px">
+    <div class="bg-white rounded-xl border border-gray-200 p-4 flex-1 min-h-0">
+      <div class="grid grid-cols-7 gap-px h-full">
         {#each Array(42) as _}
-          <div class="h-24 bg-gray-50 rounded animate-pulse"></div>
+          <div class="bg-gray-50 rounded animate-pulse"></div>
         {/each}
       </div>
     </div>
   {:else if viewMode === 'month'}
-    <div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
-      <div class="grid grid-cols-7 border-b border-gray-200 bg-gray-50/50">
+    <div class="bg-white rounded-xl border border-gray-200 overflow-hidden flex-1 min-h-0 flex flex-col">
+      <div class="grid grid-cols-7 border-b border-gray-200 bg-gray-50/50 flex-shrink-0">
         {#each ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as dayKey}
           <div class="py-2.5 text-center text-xs font-medium text-gray-500 uppercase tracking-wide">
             {$_(`calendar.${dayKey}`)}
@@ -298,16 +298,19 @@
         {/each}
       </div>
 
-      <div class="grid grid-cols-7">
+      <div
+        class="grid grid-cols-7 flex-1 min-h-0"
+        style="grid-template-rows: repeat({Math.ceil(calendarDays.length / 7)}, minmax(0, 1fr));"
+      >
         {#each calendarDays as dayInfo}
           {@const dateKey = toDateKey(new Date(dayInfo.year, dayInfo.month, dayInfo.day))}
           {@const dayContents = contentByDate[dateKey] || []}
           {@const todayHighlight = isToday(dayInfo.year, dayInfo.month, dayInfo.day)}
           <div
-            class="min-h-[100px] p-1.5 border-b border-r border-gray-100
+            class="min-h-[100px] p-1.5 border-b border-r border-gray-100 flex flex-col overflow-hidden
                    {dayInfo.isCurrentMonth ? '' : 'opacity-40'}"
           >
-            <div class="flex items-start justify-between mb-1">
+            <div class="flex items-start justify-between mb-1 flex-shrink-0">
               {#if todayHighlight}
                 <span class="bg-primary-600 text-white text-xs font-semibold w-6 h-6 rounded-full flex items-center justify-center">
                   {dayInfo.day}
@@ -319,8 +322,8 @@
               {/if}
             </div>
 
-            <div class="space-y-0.5">
-              {#each dayContents.slice(0, 3) as content (content.id)}
+            <div class="space-y-0.5 flex-1 min-h-0 overflow-y-auto">
+              {#each dayContents as content (content.id)}
                 <!-- svelte-ignore a11y-click-events-have-key-events -->
                 <!-- svelte-ignore a11y-no-static-element-interactions -->
                 <div
@@ -333,18 +336,13 @@
                   <span class="truncate">{content.title}</span>
                 </div>
               {/each}
-              {#if dayContents.length > 3}
-                <div class="text-[10px] text-gray-400 px-1.5">
-                  {$_('calendar.moreItems', { values: { count: dayContents.length - 3 } })}
-                </div>
-              {/if}
             </div>
           </div>
         {/each}
       </div>
     </div>
   {:else}
-    <div class="space-y-2">
+    <div class="space-y-2 flex-1 min-h-0 overflow-y-auto">
       {#each Array(7) as _, i}
         {@const weekDay = new Date(currentWeekStart.getFullYear(), currentWeekStart.getMonth(), currentWeekStart.getDate() + i)}
         {@const dateKey = toDateKey(weekDay)}

--- a/apps/web/src/routes/(app)/projects/[id]/calendar/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/calendar/+page.svelte
@@ -308,7 +308,7 @@
   }
 </script>
 
-<div class="p-4 sm:p-6">
+<div class="p-4 sm:p-6 h-full flex flex-col min-h-0">
   <SectionHint sectionKey="calendar" titleKey="hints.calendar.title" descKey="hints.calendar.desc" />
   <!-- Header -->
   <div class="flex items-center justify-between mb-5">
@@ -392,18 +392,18 @@
 
   {#if loading}
     <!-- Loading skeleton -->
-    <div class="bg-white rounded-xl border border-gray-200 p-4">
-      <div class="grid grid-cols-7 gap-px">
+    <div class="bg-white rounded-xl border border-gray-200 p-4 flex-1 min-h-0">
+      <div class="grid grid-cols-7 gap-px h-full">
         {#each Array(42) as _}
-          <div class="h-24 bg-gray-50 rounded animate-pulse"></div>
+          <div class="bg-gray-50 rounded animate-pulse"></div>
         {/each}
       </div>
     </div>
   {:else if viewMode === 'month'}
     <!-- Month view -->
-    <div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
+    <div class="bg-white rounded-xl border border-gray-200 overflow-hidden flex-1 min-h-0 flex flex-col">
       <!-- Day-of-week header -->
-      <div class="grid grid-cols-7 border-b border-gray-200 bg-gray-50/50">
+      <div class="grid grid-cols-7 border-b border-gray-200 bg-gray-50/50 flex-shrink-0">
         {#each ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as dayKey}
           <div class="py-2.5 text-center text-xs font-medium text-gray-500 uppercase tracking-wide">
             {$_(`calendar.${dayKey}`)}
@@ -412,7 +412,10 @@
       </div>
 
       <!-- Day cells grid -->
-      <div class="grid grid-cols-7">
+      <div
+        class="grid grid-cols-7 flex-1 min-h-0"
+        style="grid-template-rows: repeat({Math.ceil(calendarDays.length / 7)}, minmax(0, 1fr));"
+      >
         {#each calendarDays as dayInfo, idx}
           {@const dateKey = toDateKey(new Date(dayInfo.year, dayInfo.month, dayInfo.day))}
           {@const dayContents = contentByDate[dateKey] || []}
@@ -423,12 +426,13 @@
           <div
             class="min-h-[100px] p-1.5 border-b border-r border-gray-100 cursor-pointer
                    hover:bg-gray-50/50 transition-colors duration-100
+                   flex flex-col overflow-hidden
                    {dayInfo.isCurrentMonth ? '' : 'opacity-40'}
                    {campBg}"
             on:click={() => onDayClick(dayInfo)}
           >
             <!-- Day number -->
-            <div class="flex items-start justify-between mb-1">
+            <div class="flex items-start justify-between mb-1 flex-shrink-0">
               {#if todayHighlight}
                 <span class="bg-primary-600 text-white text-xs font-semibold w-6 h-6 rounded-full flex items-center justify-center">
                   {dayInfo.day}
@@ -440,9 +444,9 @@
               {/if}
             </div>
 
-            <!-- Content items (max 3) -->
-            <div class="space-y-0.5">
-              {#each dayContents.slice(0, 3) as content (content.id)}
+            <!-- Content items -->
+            <div class="space-y-0.5 flex-1 min-h-0 overflow-y-auto">
+              {#each dayContents as content (content.id)}
                 <!-- svelte-ignore a11y-click-events-have-key-events -->
                 <!-- svelte-ignore a11y-no-static-element-interactions -->
                 <div
@@ -458,11 +462,6 @@
                   <span class="truncate">{content.title}</span>
                 </div>
               {/each}
-              {#if dayContents.length > 3}
-                <div class="text-[10px] text-gray-400 px-1.5">
-                  {$_('calendar.moreItems', { values: { count: dayContents.length - 3 } })}
-                </div>
-              {/if}
             </div>
           </div>
         {/each}
@@ -470,7 +469,7 @@
     </div>
   {:else}
     <!-- Week view -->
-    <div class="space-y-2">
+    <div class="space-y-2 flex-1 min-h-0 overflow-y-auto">
       {#each Array(7) as _, i}
         {@const weekDay = new Date(currentWeekStart.getFullYear(),
           currentWeekStart.getMonth(), currentWeekStart.getDate() + i)}

--- a/apps/web/src/routes/(app)/projects/[id]/documents/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/documents/+page.svelte
@@ -237,6 +237,24 @@
     }
   }
 
+  // --- Download ---
+  function sanitizeFilename(name: string): string {
+    return name.replace(/[\\/:*?"<>|]/g, '_').trim() || 'document';
+  }
+
+  function downloadMarkdown(doc: any) {
+    const filename = `${sanitizeFilename(doc.title)}.md`;
+    const blob = new Blob([doc.contentMd || ''], { type: 'text/markdown;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
   // --- Delete ---
   async function deleteDocument(id: string) {
     try {
@@ -462,6 +480,30 @@
                   class="text-xs px-3 py-1.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
                 >
                   {$_('common.edit')}
+                </button>
+              {/if}
+              <!-- Download button -->
+              {#if doc.fileUrl}
+                <a
+                  href="{API_URL.replace('/api', '')}{doc.fileUrl}"
+                  download={doc.fileName || doc.title}
+                  on:click|stopPropagation
+                  class="text-xs px-2 py-1.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 cursor-pointer inline-flex items-center"
+                  title={$_('documents.download')}
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                  </svg>
+                </a>
+              {:else if doc.contentMd}
+                <button
+                  on:click|stopPropagation={() => downloadMarkdown(doc)}
+                  class="text-xs px-2 py-1.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
+                  title={$_('documents.download')}
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+                  </svg>
                 </button>
               {/if}
               <!-- Delete button -->
@@ -772,6 +814,16 @@
             </svg>
             {$_('documents.download')}
           </a>
+        {:else if viewingDocument.contentMd}
+          <button
+            on:click={() => downloadMarkdown(viewingDocument)}
+            class="px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors duration-150 cursor-pointer flex items-center gap-2"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
+            </svg>
+            {$_('documents.download')}
+          </button>
         {/if}
         {#if !viewingDocument.fileUrl}
           <button


### PR DESCRIPTION
## Summary
- **Calendar full-screen** — month grid now fills the viewport via `flex-1` with dynamic `grid-template-rows: repeat(N, minmax(0,1fr))`; day cells grow to share the available height and scroll internally when a cell has many items. Applies to both `/calendar` and `/projects/[id]/calendar`.
- **Document download** — every document card and the view modal now expose a download action. Uploaded files download via `fileUrl` anchor; markdown-only documents (including AI-generated) export as `.md` through a client-side blob.

## Test plan
- [ ] Open `/calendar` — month view stretches to full height; cells are tall and scroll internally when many items fall on one day.
- [ ] Navigate between months — row count adapts (5-row vs 6-row months both fill the viewport).
- [ ] Open `/projects/[id]/calendar` — same behaviour, campaign background tints still render.
- [ ] On `< md` widths the calendar auto-switches to week view and scrolls.
- [ ] On the project documents page, click the download icon on an uploaded-file card — browser downloads the original file.
- [ ] Click the download icon on a markdown/AI-generated card — browser downloads a `.md` with the document content.
- [ ] Open an AI document in the view modal → Download button exports `.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)