### PR TITLE
fix(api): decode multipart filenames as UTF-8 on document upload

### DIFF
--- a/apps/api/src/documents/documents.controller.ts
+++ b/apps/api/src/documents/documents.controller.ts
@@ -129,6 +129,9 @@ export class DocumentsController {
     if (!projectId) {
       throw new BadRequestException('projectId is required');
     }
+    // Multer decodes multipart filenames as Latin-1 while browsers send UTF-8,
+    // which mangles Cyrillic/Unicode names. Re-decode before persisting.
+    file.originalname = Buffer.from(file.originalname, 'latin1').toString('utf8');
     return this.documentsService.createFromUpload(
       file,
       projectId,


### PR DESCRIPTION
## Summary
- Multer decodes multipart filenames as Latin-1 while browsers send them as UTF-8, so Cyrillic/Unicode names were stored mangled (e.g. "Отчёт об эффективности.md" → "ÐÑÑÑÑ Ð¾Ð± ÑÑÑÐµÐºÑÐ¸Ð²Ð½Ð¾ÑÑÐ¸.md").
- Re-decode `file.originalname` via `Buffer.from(…, 'latin1').toString('utf8')` before passing it to the service, so `fileName` (and subsequent download prompts) render correctly.

## Test plan
- [ ] Upload a file with a Cyrillic name (`Отчёт.md`) — card and view modal show the correct name.
- [ ] Download the uploaded file — browser saves it with the correct UTF-8 filename.
- [ ] Upload an ASCII-only file — name unchanged (round-trip safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)