### PR TITLE
fix(google): 401 on Search Console Connect button

### DIFF
--- a/apps/api/src/google-integrations/google-integrations.controller.ts
+++ b/apps/api/src/google-integrations/google-integrations.controller.ts
@@ -3,6 +3,7 @@ import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import { Response } from 'express';
 import { GoogleIntegrationsService } from './google-integrations.service';
+import { Public } from '../common/decorators/public.decorator';
 
 @ApiTags('google')
 @ApiBearerAuth()
@@ -13,15 +14,15 @@ export class GoogleIntegrationsController {
     private config: ConfigService,
   ) {}
 
-  @Get('auth')
-  authorize(@Query('projectId') projectId: string, @Res() res: Response) {
+  @Get('auth-url')
+  getAuthUrl(@Query('projectId') projectId: string) {
     const apiUrl = this.config.get('API_URL') || 'http://localhost:3000';
     const redirectUri = `${apiUrl}/api/google/callback`;
-    const url = this.googleService.getAuthUrl(redirectUri, projectId);
-    res.redirect(url);
+    return { url: this.googleService.getAuthUrl(redirectUri, projectId) };
   }
 
   @Get('callback')
+  @Public()
   async callback(
     @Query('code') code: string,
     @Query('state') projectId: string,

--- a/apps/web/src/routes/(app)/projects/[id]/settings/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/settings/+page.svelte
@@ -319,8 +319,13 @@
     }
   }
 
-  function connectGsc() {
-    window.location.href = `/api/google/auth?projectId=${projectId}`;
+  async function connectGsc() {
+    try {
+      const result = await api.get<{ url: string }>('/google/auth-url', { projectId });
+      window.location.href = result.url;
+    } catch (e: any) {
+      gscError = e.message || 'Failed to start Google OAuth';
+    }
   }
 
   async function saveGscSiteUrl() {


### PR DESCRIPTION
## Summary

Follow-up to PR #67. After merge, clicking **Connect Google Search Console** returns 401 from our own API before reaching Google.

## Root cause

- \`GET /api/google/auth\` was JWT-protected
- The frontend did \`window.location.href = '/api/google/auth?projectId=...'\` — browser full-page navigation
- Our JWT strategy uses \`ExtractJwt.fromAuthHeaderAsBearerToken()\` — it only reads the token from the \`Authorization: Bearer\` header
- Browser nav doesn't attach Authorization headers, only cookies → 401

## Fix (mirrors Google Play pattern)

- \`GET /api/google/auth-url\` — returns \`{ url }\` as JSON, stays JWT-protected, called via \`api.get()\` (token attached)
- \`GET /api/google/callback\` — marked \`@Public()\`; OAuth redirect from Google doesn't carry our JWT
- Settings page \`connectGsc()\` now fetches the URL then navigates

## Test plan

- [ ] Click **Connect Google Search Console** → OAuth consent screen appears (no 401)
- [ ] After consent, callback redirects back to \`/projects/:id/settings?google=connected\`
- [ ] Verify \`ProjectApiKey\` row persists with encrypted tokens
- [ ] Enter verified site URL, save, run Sync — ranks populate