### PR TITLE
feat(seo): visible GSC sync results with per-keyword diff

### DIFF
--- a/apps/api/src/seo/gsc-sync.service.spec.ts
+++ b/apps/api/src/seo/gsc-sync.service.spec.ts
@@ -199,7 +199,14 @@ describe('GscSyncService', () => {
 
     const result = await service.syncProject('proj-1');
 
-    expect(result).toEqual({ synced: 0, matched: 0, skipped: [] });
+    expect(result).toEqual({
+      synced: 0,
+      matched: 0,
+      skipped: [],
+      details: [],
+      siteUrl: GSC_CONFIG.siteUrl,
+      date: expect.any(String),
+    });
     expect(mockGoogleIntegrations.fetchSearchConsoleData).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/src/seo/gsc-sync.service.ts
+++ b/apps/api/src/seo/gsc-sync.service.ts
@@ -3,10 +3,21 @@ import { PrismaService } from '../database/prisma.service';
 import { GoogleIntegrationsService } from '../google-integrations/google-integrations.service';
 import { SeoService } from './seo.service';
 
+export interface GscSyncDetail {
+  keywordId: string;
+  keyword: string;
+  rank: number | null;
+  previousRank: number | null;
+  reason?: 'NO_URL' | 'NO_MATCH_IN_GSC';
+}
+
 export interface GscSyncSummary {
   synced: number;
   matched: number;
   skipped: string[];
+  details: GscSyncDetail[];
+  siteUrl: string;
+  date: string;
 }
 
 @Injectable()
@@ -42,7 +53,14 @@ export class GscSyncService {
     });
 
     if (keywords.length === 0) {
-      return { synced: 0, matched: 0, skipped: [] };
+      return {
+        synced: 0,
+        matched: 0,
+        skipped: [],
+        details: [],
+        siteUrl,
+        date: getYesterdayDateString(),
+      };
     }
 
     // Ensure fresh access token
@@ -81,10 +99,20 @@ export class GscSyncService {
     // 4. Match each keyword to a GSC row
     let matched = 0;
     const skipped: string[] = [];
+    const details: GscSyncDetail[] = [];
 
     for (const keyword of keywords) {
+      const previousRank = keyword.currentRank ?? null;
+
       if (!keyword.url) {
         skipped.push(`${keyword.keyword}:NO_URL`);
+        details.push({
+          keywordId: keyword.id,
+          keyword: keyword.keyword,
+          rank: null,
+          previousRank,
+          reason: 'NO_URL',
+        });
         continue;
       }
 
@@ -96,6 +124,13 @@ export class GscSyncService {
 
       if (!row) {
         skipped.push(`${keyword.keyword}:NO_MATCH_IN_GSC`);
+        details.push({
+          keywordId: keyword.id,
+          keyword: keyword.keyword,
+          rank: null,
+          previousRank,
+          reason: 'NO_MATCH_IN_GSC',
+        });
         continue;
       }
 
@@ -104,19 +139,33 @@ export class GscSyncService {
       // 5. Upsert rank history for yesterday
       await this.seo.addRankHistoryForDate(keyword.id, roundedRank, row.keys[1], getYesterdayDate());
 
-      // 6. Update keyword metadata
+      // 6. Update keyword metadata (including currentRank so the summary chart/row reflects latest)
       await this.prisma.keyword.update({
         where: { id: keyword.id },
         data: {
           lastCheckedAt: new Date(),
           lastCheckError: null,
+          currentRank: roundedRank,
         },
       });
 
+      details.push({
+        keywordId: keyword.id,
+        keyword: keyword.keyword,
+        rank: roundedRank,
+        previousRank,
+      });
       matched++;
     }
 
-    return { synced: keywords.length, matched, skipped };
+    return {
+      synced: keywords.length,
+      matched,
+      skipped,
+      details,
+      siteUrl,
+      date: getYesterdayDateString(),
+    };
   }
 }
 

--- a/apps/web/src/routes/(app)/projects/[id]/seo/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/seo/+page.svelte
@@ -173,17 +173,32 @@
     }
   }
 
+  interface GscSyncDetail {
+    keywordId: string;
+    keyword: string;
+    rank: number | null;
+    previousRank: number | null;
+    reason?: 'NO_URL' | 'NO_MATCH_IN_GSC';
+  }
+  interface GscSyncResult {
+    synced: number;
+    matched: number;
+    skipped: string[];
+    details: GscSyncDetail[];
+    siteUrl: string;
+    date: string;
+  }
+
+  let lastSyncResult: GscSyncResult | null = null;
+
   async function syncFromGsc() {
     syncing = true;
     try {
-      const result = await api.post<{ synced: number; matched: number; skipped: string[] }>(
+      const result = await api.post<GscSyncResult>(
         '/seo/keywords/sync-from-gsc',
         { projectId },
       );
-      showToast(
-        $_('seo.syncSuccess', { values: { matched: result.matched, skipped: result.skipped.length } }),
-        'success',
-      );
+      lastSyncResult = result;
       await fetchKeywords();
     } catch (e: any) {
       const code = e?.body?.code || e?.code;
@@ -195,6 +210,18 @@
     } finally {
       syncing = false;
     }
+  }
+
+  function rankDelta(now: number | null, prev: number | null): { text: string; color: string } | null {
+    if (now === null || prev === null) return null;
+    if (now === prev) return { text: '=', color: 'text-gray-500' };
+    const diff = prev - now; // lower rank is better; positive diff = improvement
+    if (diff > 0) return { text: `↑ ${diff}`, color: 'text-green-600' };
+    return { text: `↓ ${Math.abs(diff)}`, color: 'text-red-600' };
+  }
+
+  function dismissSyncResult() {
+    lastSyncResult = null;
   }
 
   async function runSeoAudit() {
@@ -357,6 +384,89 @@
       </button>
     </div>
   </div>
+
+  <!-- GSC sync result panel -->
+  {#if lastSyncResult}
+    <div class="bg-white rounded-xl border border-primary-200 p-5 mb-4 shadow-sm">
+      <div class="flex items-start justify-between mb-3">
+        <div>
+          <h3 class="text-sm font-semibold text-gray-900 flex items-center gap-2">
+            <svg class="w-5 h-5 text-primary-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
+            </svg>
+            Sync complete — pulled Google Search Console data for {lastSyncResult.date}
+          </h3>
+          <p class="text-xs text-gray-500 mt-1">
+            Site: <span class="font-mono text-gray-700">{lastSyncResult.siteUrl}</span>
+            &nbsp;·&nbsp;
+            {lastSyncResult.matched} of {lastSyncResult.synced} keywords matched in GSC
+            {#if lastSyncResult.synced - lastSyncResult.matched > 0}
+              · {lastSyncResult.synced - lastSyncResult.matched} not found
+            {/if}
+          </p>
+        </div>
+        <button
+          on:click={dismissSyncResult}
+          class="text-gray-400 hover:text-gray-600 p-1"
+          title="Dismiss"
+        >
+          <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+          </svg>
+        </button>
+      </div>
+
+      {#if lastSyncResult.details.length > 0}
+        <div class="overflow-hidden border border-gray-100 rounded-lg">
+          <table class="w-full text-sm">
+            <thead class="bg-gray-50">
+              <tr class="text-left text-xs text-gray-500 uppercase">
+                <th class="px-3 py-2 font-medium">Keyword</th>
+                <th class="px-3 py-2 font-medium">Previous</th>
+                <th class="px-3 py-2 font-medium">New rank</th>
+                <th class="px-3 py-2 font-medium">Change</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-gray-50">
+              {#each lastSyncResult.details as d}
+                <tr class="hover:bg-gray-50">
+                  <td class="px-3 py-2 text-gray-900">{d.keyword}</td>
+                  <td class="px-3 py-2 text-gray-500">
+                    {d.previousRank ?? '—'}
+                  </td>
+                  <td class="px-3 py-2">
+                    {#if d.rank !== null}
+                      <span class="font-semibold text-gray-900">#{d.rank}</span>
+                    {:else if d.reason === 'NO_MATCH_IN_GSC'}
+                      <span class="text-gray-400 italic">not ranked in GSC</span>
+                    {:else if d.reason === 'NO_URL'}
+                      <span class="text-amber-600 italic">no target URL</span>
+                    {/if}
+                  </td>
+                  <td class="px-3 py-2">
+                    {#if d.rank !== null}
+                      {@const delta = rankDelta(d.rank, d.previousRank)}
+                      {#if delta}
+                        <span class={delta.color + ' font-medium text-xs'}>{delta.text}</span>
+                      {:else}
+                        <span class="text-gray-400 text-xs">new</span>
+                      {/if}
+                    {:else}
+                      <span class="text-gray-300">—</span>
+                    {/if}
+                  </td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        </div>
+      {/if}
+
+      <p class="text-xs text-gray-400 mt-3">
+        GSC data lags by 2–3 days. Positions shown are an average over {lastSyncResult.date}. For faster feedback use <strong>Record position</strong> on individual keywords.
+      </p>
+    </div>
+  {/if}
 
   {#if loading}
     <!-- Loading skeleton -->


### PR DESCRIPTION
## Why

User clicked \"Sync from Google Search Console\", got only a toast. Nothing visually changed, they couldn't tell whether the sync worked, which keywords matched, or what the new ranks were.

## What

**Backend** — \`GscSyncSummary\` extended:
\`\`\`
{
  synced, matched, skipped,  // unchanged
  details: [{ keywordId, keyword, rank, previousRank, reason? }],
  siteUrl, date
}
\`\`\`
\`currentRank\` on matched keywords is now updated so the list reflects the latest position.

**Frontend** — persistent result card above the keyword table after sync:
- Summary: which site, which date, matched-of-total count
- Per-keyword table: previous rank → new rank with up/down arrows (green for improvement, red for drop)
- Handles three skip reasons: \`NO_MATCH_IN_GSC\` (not ranked), \`NO_URL\` (target URL missing)
- Dismissible via X button
- Footer note reminds users of the 2-3 day GSC lag

## Test plan

- [ ] Sync on a project with some keywords — result card appears with correct counts
- [ ] Keywords that moved up/down show green/red arrows
- [ ] Unranked keywords show \"not ranked in GSC\" in italics
- [ ] Dismiss button hides the card
- [ ] \`currentRank\` on matched rows updates in the main table