### PR TITLE
feat(seo): Target URL defaults to project website

### DIFF
--- a/apps/web/src/routes/(app)/projects/[id]/seo/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/seo/+page.svelte
@@ -33,6 +33,8 @@
 
   $: defaultSearchLocale = deriveSearchLocale($locale);
 
+  let projectWebsite = '';
+
   let form = {
     keyword: '',
     targetRank: 10,
@@ -42,8 +44,14 @@
   };
 
   // Keep form.searchLocale in sync with locale when modal opens
+  // Pre-fill Target URL with project website so the common case (promote homepage)
+  // is zero-input. User can still override for specific landing pages.
   $: if (showModal) {
-    form = { ...form, searchLocale: defaultSearchLocale };
+    form = {
+      ...form,
+      searchLocale: defaultSearchLocale,
+      url: form.url || projectWebsite,
+    };
   }
 
   // Rank history cache: keywordId -> number[]
@@ -69,7 +77,7 @@
   function openRecordModal(kw: any) {
     recordModalKeyword = kw;
     recordRank = '';
-    recordUrl = kw.url || '';
+    recordUrl = kw.url || projectWebsite || '';
     recordNotInTop100 = false;
   }
 
@@ -102,6 +110,13 @@
   }
 
   onMount(async () => {
+    // Load project website so Target URL defaults to the homepage.
+    try {
+      const project = await api.get<any>(`/projects/${projectId}`);
+      if (project?.website) projectWebsite = project.website;
+    } catch {
+      // Non-blocking — form just stays empty.
+    }
     await fetchKeywords();
   });
 
@@ -257,6 +272,17 @@
       return new URL(url).host;
     } catch {
       return url;
+    }
+  }
+
+  function getTargetUrlPath(url: string | null | undefined): string {
+    if (!url) return '';
+    try {
+      const u = new URL(url);
+      const path = u.pathname + u.search;
+      return path === '/' ? '' : path;
+    } catch {
+      return '';
     }
   }
 
@@ -533,7 +559,12 @@
                 <!-- Target URL -->
                 <td class="px-5 py-3.5 max-w-[140px]">
                   {#if urlHost}
-                    <span class="text-sm text-gray-600 truncate block" title={kw.url}>{urlHost}</span>
+                    {#if projectWebsite && kw.url === projectWebsite}
+                      <span class="text-xs text-gray-500 italic" title={kw.url}>Homepage</span>
+                    {:else}
+                      {@const pathOnly = getTargetUrlPath(kw.url)}
+                      <span class="text-sm text-gray-600 truncate block" title={kw.url}>{pathOnly || urlHost}</span>
+                    {/if}
                   {:else}
                     <span class="text-sm text-gray-400">—</span>
                   {/if}
@@ -751,17 +782,22 @@
 
         <!-- Target URL -->
         <div>
-          <label for="seo-url" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('seo.targetUrl')}</label>
+          <label for="seo-url" class="block text-sm font-medium text-gray-700 mb-1.5">
+            {$_('seo.targetUrl')}
+            <span class="font-normal text-gray-400 text-xs ml-1">— {$_('common.optional')}</span>
+          </label>
           <input
             id="seo-url"
             type="text"
             bind:value={form.url}
             class="w-full px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent
               {urlError ? 'border-red-400 focus:ring-red-400' : 'border-gray-300'}"
-            placeholder="https://your-page.com/path"
+            placeholder={projectWebsite || 'https://your-page.com/path'}
           />
           {#if urlError}
             <p class="mt-1 text-xs text-red-500">Must start with https:// or http://</p>
+          {:else if projectWebsite && form.url === projectWebsite}
+            <p class="mt-1 text-xs text-gray-400">Defaulted to your project website. Change only if you want to rank a specific page for this keyword.</p>
           {:else}
             <p class="mt-1 text-xs text-gray-400">{$_('seo.targetUrlHelper')}</p>
           {/if}


### PR DESCRIPTION
## Why

User flagged that filling Target URL for every keyword is noise — the common case is promoting the homepage. The field should auto-fill with the project's website; users only touch it when targeting a specific landing page.

## Changes

- Add Keyword modal: \`form.url\` defaults to \`project.website\` on modal open
- Label shows \"(optional)\" so the intent is clear
- Helper text reacts to the current value — different copy when the value equals the project website vs. a custom path
- Keyword table renders \"Homepage\" (italic muted) when the keyword URL matches the project website, else shows the path only (e.g. \`/features/payroll\`) with the full URL in a tooltip
- Record position modal's Matched URL pre-fills from \`keyword.url\` first, falling back to \`projectWebsite\`

## Out of scope

- Backend: no changes. \`keyword.url\` stays as-is (nullable for backward compat; new rows just happen to carry the project website when user didn't override).
- Default-URL indicator on keyword detail page: not touched for this PR; will pick up automatically from the same row data.

## Test plan

- [ ] Open Add Keyword modal — Target URL pre-filled with your project's website
- [ ] Save without editing — keyword row shows \"Homepage\"
- [ ] Add another with \`/blog/foo\` — row shows \`/blog/foo\`
- [ ] Open Record position on a keyword — Matched URL pre-filled from the keyword's URL