### PR TITLE
fix(seo): GSC sync falls back to project website + result persists

### DIFF
--- a/apps/api/src/seo/gsc-sync.service.spec.ts
+++ b/apps/api/src/seo/gsc-sync.service.spec.ts
@@ -18,6 +18,9 @@ const mockPrisma = {
     findMany: jest.fn(),
     update: jest.fn(),
   },
+  project: {
+    findUnique: jest.fn(),
+  },
 };
 
 const mockGoogleIntegrations = {
@@ -36,6 +39,7 @@ describe('GscSyncService', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks();
+    mockPrisma.project.findUnique.mockResolvedValue({ websiteUrl: 'https://example.com/' });
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/apps/api/src/seo/gsc-sync.service.ts
+++ b/apps/api/src/seo/gsc-sync.service.ts
@@ -43,12 +43,20 @@ export class GscSyncService {
 
     const siteUrl = config.siteUrl as string;
 
-    // 2. Load all tracked keywords that have a url
+    // Load project website so keywords without explicit Target URL fall back to
+    // the project's homepage. Most keywords want to rank the homepage; only
+    // specific landing-page targets have their own url set.
+    const project = await this.prisma.project.findUnique({
+      where: { id: projectId },
+      select: { websiteUrl: true },
+    });
+    const projectWebsite = project?.websiteUrl || null;
+
+    // 2. Load all tracked keywords (url may be null → falls back to projectWebsite)
     const keywords = await this.prisma.keyword.findMany({
       where: {
         projectId,
         isTracking: true,
-        url: { not: null },
       },
     });
 
@@ -103,8 +111,9 @@ export class GscSyncService {
 
     for (const keyword of keywords) {
       const previousRank = keyword.currentRank ?? null;
+      const effectiveUrl = keyword.url || projectWebsite;
 
-      if (!keyword.url) {
+      if (!effectiveUrl) {
         skipped.push(`${keyword.keyword}:NO_URL`);
         details.push({
           keywordId: keyword.id,
@@ -119,7 +128,7 @@ export class GscSyncService {
       const row = rows.find(
         (r) =>
           r.keys[0]?.toLowerCase() === keyword.keyword.toLowerCase() &&
-          hostMatches(r.keys[1], keyword.url!),
+          hostMatches(r.keys[1], effectiveUrl),
       );
 
       if (!row) {

--- a/apps/web/src/routes/(app)/projects/[id]/seo/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/seo/+page.svelte
@@ -113,10 +113,11 @@
     // Load project website so Target URL defaults to the homepage.
     try {
       const project = await api.get<any>(`/projects/${projectId}`);
-      if (project?.website) projectWebsite = project.website;
+      if (project?.websiteUrl) projectWebsite = project.websiteUrl;
     } catch {
       // Non-blocking — form just stays empty.
     }
+    loadPersistedSyncResult();
     await fetchKeywords();
   });
 
@@ -205,6 +206,34 @@
   }
 
   let lastSyncResult: GscSyncResult | null = null;
+  let lastSyncAt: string | null = null;
+
+  function syncStorageKey(pid: string) {
+    return `seo:lastSync:${pid}`;
+  }
+
+  function loadPersistedSyncResult() {
+    try {
+      const raw = localStorage.getItem(syncStorageKey(projectId));
+      if (!raw) return;
+      const parsed = JSON.parse(raw) as { result: GscSyncResult; at: string };
+      lastSyncResult = parsed.result;
+      lastSyncAt = parsed.at;
+    } catch {
+      // ignore corrupted entry
+    }
+  }
+
+  function persistSyncResult(result: GscSyncResult) {
+    try {
+      localStorage.setItem(
+        syncStorageKey(projectId),
+        JSON.stringify({ result, at: new Date().toISOString() }),
+      );
+    } catch {
+      // localStorage can be disabled/full — ignore
+    }
+  }
 
   async function syncFromGsc() {
     syncing = true;
@@ -214,6 +243,8 @@
         { projectId },
       );
       lastSyncResult = result;
+      lastSyncAt = new Date().toISOString();
+      persistSyncResult(result);
       await fetchKeywords();
     } catch (e: any) {
       const code = e?.body?.code || e?.code;
@@ -237,6 +268,12 @@
 
   function dismissSyncResult() {
     lastSyncResult = null;
+    lastSyncAt = null;
+    try {
+      localStorage.removeItem(syncStorageKey(projectId));
+    } catch {
+      // ignore
+    }
   }
 
   async function runSeoAudit() {
@@ -488,9 +525,17 @@
         </div>
       {/if}
 
-      <p class="text-xs text-gray-400 mt-3">
-        GSC data lags by 2–3 days. Positions shown are an average over {lastSyncResult.date}. For faster feedback use <strong>Record position</strong> on individual keywords.
-      </p>
+      <div class="text-xs text-gray-400 mt-3 space-y-1">
+        <p>GSC data lags by 2–3 days. Positions shown are an average for {lastSyncResult.date}. For same-day feedback use <strong>Record position</strong> on individual keywords.</p>
+        {#if lastSyncResult.matched === 0 && lastSyncResult.synced > 0}
+          <p class="text-amber-700">
+            <strong>Why no matches?</strong> Your site isn't yet ranking in the top ~100 Google results for these keywords, or Google hasn't indexed your content yet. Check back in a few days as Google discovers and ranks your pages.
+          </p>
+        {/if}
+        {#if lastSyncAt}
+          <p>Last sync: {new Date(lastSyncAt).toLocaleString()}</p>
+        {/if}
+      </div>
     </div>
   {/if}
 

--- a/apps/web/src/routes/(app)/projects/[id]/settings/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/settings/+page.svelte
@@ -115,7 +115,7 @@
       enabledIds = new Set(enabled.map((a: any) => a.id));
       trackingInfo = tracking;
       if (project.baseCurrency) baseCurrency = project.baseCurrency;
-      if (project.website) projectWebsite = project.website;
+      if (project.websiteUrl) projectWebsite = project.websiteUrl;
     } catch (e) {
       console.error(e);
     } finally {


### PR DESCRIPTION
## Why

User screenshot showed 21 keywords on the SEO page, but \"Sync from Google Search Console\" reported only \"0 of 1 matched\". Three problems behind that:

1. Only the one keyword created AFTER PR #75 had a Target URL. The sync filter \`Keyword.url IS NOT NULL\` skipped the 20 older ones.
2. The sync result card disappeared on page refresh.
3. \"0 matched\" with no explanation looked like a bug.

Also: PR #75's frontend used \`project.website\` but the Prisma field is \`websiteUrl\` — so the Target URL auto-default never fired.

## Changes

**Backend**
- \`GscSyncService.syncProject\`: loads \`project.websiteUrl\` and uses it as fallback when \`keyword.url\` is null. All tracked keywords are processed now, not just those with explicit URLs.

**Frontend**
- Fix \`project.website\` → \`project.websiteUrl\` (one-line bug from PR #75, breaks both SEO page and settings page GSC site-picker pre-fill)
- Sync result card now persisted to \`localStorage\` keyed by projectId; reloaded on mount
- Dismiss clears the persisted entry
- Card renders \"Last sync: <timestamp>\" line
- When \`matched === 0\`, amber block explains why (site not ranking in top 100 yet, or Google hasn't indexed yet)

## Test plan

- [ ] Sync on a project with mix of keywords — all processed, not just those with URL
- [ ] Refresh the SEO page — result card is still there with its data
- [ ] Click the X on the card — it disappears and doesn't come back on refresh
- [ ] Fresh project with 0 ranks — amber \"why no matches?\" appears
- [ ] Existing keyword with an explicit Target URL still uses that URL