### PR TITLE
fix(seo): accept CUID projectId in SuggestCompetitorsDto

### DIFF
--- a/apps/api/src/seo/dto/suggest-competitors.dto.ts
+++ b/apps/api/src/seo/dto/suggest-competitors.dto.ts
@@ -1,9 +1,10 @@
-import { IsOptional, IsString, IsUUID, MaxLength } from 'class-validator';
+import { IsNotEmpty, IsOptional, IsString, MaxLength } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 export class SuggestCompetitorsDto {
   @ApiProperty()
-  @IsUUID()
+  @IsString()
+  @IsNotEmpty()
   projectId!: string;
 
   @ApiPropertyOptional({ description: 'Optional free-form guidance from the user (max 500 chars)' })

--- a/apps/api/src/seo/seo.controller.spec.ts
+++ b/apps/api/src/seo/seo.controller.spec.ts
@@ -220,6 +220,14 @@ describe('SeoController', () => {
 });
 
 describe('SuggestCompetitorsDto validation', () => {
+  it('accepts a CUID-shaped projectId (Project.id uses @default(cuid()))', async () => {
+    const dto = plainToInstance(SuggestCompetitorsDto, {
+      projectId: 'clg7t5gxm0000f1p2q3r4s5t6',
+    });
+    const errors = await validate(dto);
+    expect(errors).toHaveLength(0);
+  });
+
   it('accepts a valid UUID and no note', async () => {
     const dto = plainToInstance(SuggestCompetitorsDto, {
       projectId: '00000000-0000-4000-8000-000000000001',
@@ -228,8 +236,15 @@ describe('SuggestCompetitorsDto validation', () => {
     expect(errors).toHaveLength(0);
   });
 
-  it('rejects non-UUID projectId', async () => {
-    const dto = plainToInstance(SuggestCompetitorsDto, { projectId: 'not-a-uuid' });
+  it('rejects empty-string projectId', async () => {
+    const dto = plainToInstance(SuggestCompetitorsDto, { projectId: '' });
+    const errors = await validate(dto);
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors[0].property).toBe('projectId');
+  });
+
+  it('rejects missing projectId', async () => {
+    const dto = plainToInstance(SuggestCompetitorsDto, {});
     const errors = await validate(dto);
     expect(errors.length).toBeGreaterThan(0);
     expect(errors[0].property).toBe('projectId');


### PR DESCRIPTION
## Problem

After PR #79 merged, calling "Suggest with AI" on the competitors page always failed with the generic `suggestFailed` toast.

## Root cause

`SuggestCompetitorsDto.projectId` had `@IsUUID()`, but `Project.id` is declared `@default(cuid())` in the Prisma schema. Global `ValidationPipe` rejected every real request with a 400 before it reached the service.

## Fix

Swap `@IsUUID()` for `@IsString() @IsNotEmpty()` — matches the convention used by every other project-scoped DTO in the codebase (e.g. `CreateContentDto`). `ProjectAccessGuard` already validates existence via DB lookup, so this is no loss of safety.

## Tests

- Added `accepts a CUID-shaped projectId` case that would have caught this (fails red on the old DTO).
- Replaced the now-invalid `rejects non-UUID projectId` case with `rejects empty-string projectId` + `rejects missing projectId`.
- All 18 existing tests in `seo.controller.spec.ts` still pass.

Follow-up on #79.