### PR TITLE
fix(web): refresh project-scoped data when switching projects

### DIFF
--- a/apps/web/src/lib/components/analytics/MobileAnalyticsDashboard.svelte
+++ b/apps/web/src/lib/components/analytics/MobileAnalyticsDashboard.svelte
@@ -37,7 +37,7 @@
   ];
   $: tabs = allTabs.filter(t => !t.needsBucket || hasGcsBucket);
 
-  onMount(async () => {
+  async function init() {
     await checkStatus();
     if (status?.connected) {
       await syncIfStale();
@@ -49,7 +49,32 @@
     } else {
       loading = false;
     }
+  }
+
+  onMount(async () => {
+    await init();
+    prevProjectId = projectId;
+    mounted = true;
   });
+
+  // Re-initialise when the parent passes a different project (component is reused
+  // across project switches), otherwise the dashboard keeps the old app's data.
+  let mounted = false;
+  let prevProjectId = '';
+  $: if (mounted && projectId && projectId !== prevProjectId) {
+    prevProjectId = projectId;
+    reinit();
+  }
+
+  async function reinit() {
+    if (syncInterval) { clearInterval(syncInterval); syncInterval = null; }
+    metrics = [];
+    status = null;
+    hasGcsBucket = false;
+    activeTab = 'overview';
+    loading = true;
+    await init();
+  }
 
   onDestroy(() => {
     if (syncInterval) {

--- a/apps/web/src/routes/(app)/projects/[id]/analytics/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/analytics/+page.svelte
@@ -18,6 +18,32 @@
     }
   }
 
+  // Refetch when the URL project id changes. SvelteKit reuses this component
+  // across /projects/A → /projects/B, so onMount does NOT fire again — without
+  // this watcher the page keeps showing the previous project's data.
+  let mounted = false;
+  let prevProjectId: string | undefined = '';
+  $: if (mounted && projectId && projectId !== prevProjectId) {
+    prevProjectId = projectId;
+    reloadForProjectChange();
+  }
+
+  async function reloadForProjectChange() {
+    // Reset cached per-tab data so tabs refetch for the newly selected project.
+    utmData = [];
+    funnelData = null;
+    pagesData = [];
+    const project = $currentProjectStore?.id === projectId
+      ? $currentProjectStore
+      : $projectsStore.find((p: any) => p.id === projectId);
+    // The mobile dashboard refetches via its own projectId watcher.
+    if (project?.projectType === 'MOBILE_APP') return;
+    await fetchData();
+    if (activeTab === 'utm') fetchUtmData();
+    if (activeTab === 'funnel') fetchFunnelData();
+    if (activeTab === 'pages') fetchPagesData();
+  }
+
   let loading = true;
   let chartsReady = false;
   let selectedPeriod = 30;
@@ -71,6 +97,8 @@
         await fetchData();
       }
     }
+    prevProjectId = projectId;
+    mounted = true;
   });
 
   onDestroy(() => {

--- a/apps/web/src/routes/(app)/projects/[id]/campaigns/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/campaigns/+page.svelte
@@ -18,6 +18,26 @@
     }
   }
 
+  // Reload when the URL project id changes. SvelteKit reuses this component
+  // across /projects/A → /projects/B, so onMount does NOT fire again — without
+  // this watcher the page keeps showing the previous project's data.
+  let mounted = false;
+  let prevProjectId: string | undefined = '';
+  $: if (mounted && projectId && projectId !== prevProjectId) {
+    prevProjectId = projectId;
+    reloadForProject();
+  }
+
+  async function reloadForProject() {
+    loading = true;
+    campaigns = [];
+    try {
+      campaigns = await api.get<any[]>('/campaigns', { projectId });
+    } finally {
+      loading = false;
+    }
+  }
+
   // Create modal
   let showCreateModal = false;
   let creating = false;
@@ -75,6 +95,8 @@
   onMount(async () => {
     campaigns = await api.get<any[]>('/campaigns', { projectId });
     loading = false;
+    prevProjectId = projectId;
+    mounted = true;
   });
 
   async function createCampaign() {

--- a/apps/web/src/routes/(app)/projects/[id]/checklists/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/checklists/+page.svelte
@@ -49,6 +49,30 @@
     }
   }
 
+  // Reload when the URL project id changes. SvelteKit reuses this component
+  // across /projects/A → /projects/B, so onMount does NOT fire again — without
+  // this watcher the page keeps showing the previous project's checklists.
+  let mounted = false;
+  let prevProjectId: string | undefined = '';
+  $: if (mounted && projectId && projectId !== prevProjectId) {
+    prevProjectId = projectId;
+    reloadForProject();
+  }
+
+  async function reloadForProject() {
+    loading = true;
+    checklists = [];
+    activeChecklistId = null;
+    mdCache.clear();
+    try {
+      const data = await api.get<any[]>('/checklists', { projectId });
+      preCollapseSections(data);
+      checklists = data;
+      initChatsFromDB();
+    } catch { /* silent */ }
+    loading = false;
+  }
+
   let aiForm = { type: 'LAUNCH' };
 
   // ── MD Import state ──
@@ -276,6 +300,8 @@
     // Polling every 30s + refresh on tab focus
     pollingInterval = setInterval(refreshChecklists, 30_000);
     document.addEventListener('visibilitychange', handleVisibilityChange);
+    prevProjectId = projectId;
+    mounted = true;
   });
 
   onDestroy(() => {

--- a/apps/web/src/routes/(app)/projects/[id]/competitors/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/competitors/+page.svelte
@@ -21,6 +21,31 @@
     }
   }
 
+  // Reload when the URL project id changes. SvelteKit reuses this component
+  // across /projects/A → /projects/B, so onMount does NOT fire again — without
+  // this watcher the page keeps showing the previous project's data.
+  let mounted = false;
+  let prevProjectId: string | undefined = '';
+  $: if (mounted && projectId && projectId !== prevProjectId) {
+    prevProjectId = projectId;
+    reloadForProject();
+  }
+
+  async function reloadForProject() {
+    loading = true;
+    competitors = [];
+    suggestedCompetitors = [];
+    snapshotCache = {};
+    expandedSnapshotId = null;
+    try {
+      await Promise.all([loadActiveCompetitors(), loadSuggestedCompetitors()]);
+    } catch (e: any) {
+      console.error('Failed to load competitors:', e);
+    } finally {
+      loading = false;
+    }
+  }
+
   let form = { name: '', websiteUrl: '', description: '' };
 
   // Delete confirm state
@@ -105,6 +130,8 @@
     } finally {
       loading = false;
     }
+    prevProjectId = projectId;
+    mounted = true;
   });
 
   async function addCompetitor() {

--- a/apps/web/src/routes/(app)/projects/[id]/content/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/content/+page.svelte
@@ -125,7 +125,7 @@
   onMount(() => { loadContent(projectId); });
 
   // Also reload when projectId changes (SvelteKit reuses component)
-  let prevProjectId = '';
+  let prevProjectId: string | undefined = '';
   $: if (projectId && projectId !== prevProjectId) {
     prevProjectId = projectId;
     loadContent(projectId);

--- a/apps/web/src/routes/(app)/projects/[id]/documents/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/documents/+page.svelte
@@ -35,6 +35,27 @@
     }
   }
 
+  // Reload when the URL project id changes. SvelteKit reuses this component
+  // across /projects/A → /projects/B, so onMount does NOT fire again — without
+  // this watcher the page keeps showing the previous project's data.
+  let mounted = false;
+  let prevProjectId: string | undefined = '';
+  $: if (mounted && projectId && projectId !== prevProjectId) {
+    prevProjectId = projectId;
+    reloadForProject();
+  }
+
+  async function reloadForProject() {
+    loading = true;
+    documents = [];
+    viewingDocument = null;
+    try {
+      documents = await api.get<any[]>('/documents', { projectId });
+    } finally {
+      loading = false;
+    }
+  }
+
   // AI generation
   let showGenerateModal = false;
   let generating = false;
@@ -99,6 +120,8 @@
     documents = docs;
     docTypes = types;
     loading = false;
+    prevProjectId = projectId;
+    mounted = true;
   });
 
   // --- AI Generation with polling ---

--- a/apps/web/src/routes/(app)/projects/[id]/email/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/email/+page.svelte
@@ -16,6 +16,25 @@
     }
   }
 
+  // Reload when the URL project id changes. SvelteKit reuses this component
+  // across /projects/A → /projects/B, so onMount does NOT fire again — without
+  // this watcher the page keeps showing the previous project's data.
+  let mounted = false;
+  let prevProjectId: string | undefined = '';
+  $: if (mounted && projectId && projectId !== prevProjectId) {
+    prevProjectId = projectId;
+    reloadForProject();
+  }
+
+  function reloadForProject() {
+    lists = [];
+    campaigns = [];
+    selectedList = null;
+    subscribers = [];
+    loadLists();
+    loadCampaigns();
+  }
+
   // ── Types ────────────────────────────────────────────────────────────────
   interface EmailList {
     id: string;
@@ -106,6 +125,8 @@
   onMount(() => {
     loadLists();
     loadCampaigns();
+    prevProjectId = projectId;
+    mounted = true;
   });
 
   // ── Lists ────────────────────────────────────────────────────────────────

--- a/apps/web/src/routes/(app)/projects/[id]/experiments/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/experiments/+page.svelte
@@ -18,6 +18,28 @@
     }
   }
 
+  // Reload when the URL project id changes. SvelteKit reuses this component
+  // across /projects/A → /projects/B, so onMount does NOT fire again — without
+  // this watcher the page keeps showing the previous project's data.
+  let mounted = false;
+  let prevProjectId: string | undefined = '';
+  $: if (mounted && projectId && projectId !== prevProjectId) {
+    prevProjectId = projectId;
+    reloadForProject();
+  }
+
+  async function reloadForProject() {
+    loading = true;
+    experiments = [];
+    resultsFor = null;
+    resultsData = null;
+    try {
+      experiments = await api.get<any[]>('/ab-testing', { projectId });
+    } finally {
+      loading = false;
+    }
+  }
+
   // Create modal
   let showCreateModal = false;
   let creating = false;
@@ -74,6 +96,8 @@
   onMount(async () => {
     experiments = await api.get<any[]>('/ab-testing', { projectId });
     loading = false;
+    prevProjectId = projectId;
+    mounted = true;
   });
 
   async function createExperiment() {

--- a/apps/web/src/routes/(app)/projects/[id]/finances/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/finances/+page.svelte
@@ -427,7 +427,7 @@
   });
 
   // Re-fetch when projectId changes (e.g. project picker)
-  let prevProjectId = '';
+  let prevProjectId: string | undefined = '';
   $: if (projectId && projectId !== prevProjectId) {
     prevProjectId = projectId;
     if (ChartJS) fetchAll();

--- a/apps/web/src/routes/(app)/projects/[id]/overview/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/overview/+page.svelte
@@ -22,6 +22,33 @@
     }
   }
 
+  // Reload when the URL project id changes. SvelteKit reuses this component
+  // across /projects/A → /projects/B, so onMount does NOT fire again — without
+  // this watcher the page keeps showing the previous project's data.
+  let mounted = false;
+  let prevProjectId: string | undefined = '';
+  $: if (mounted && projectId && projectId !== prevProjectId) {
+    prevProjectId = projectId;
+    reloadForProject();
+  }
+
+  async function reloadForProject() {
+    loading = true;
+    summary = null;
+    try {
+      const [project, sum] = await Promise.all([
+        api.get<Project>(`/projects/${projectId}`),
+        api.get<any>('/analytics/summary', { projectId }),
+      ]);
+      currentProjectStore.set(project);
+      summary = sum;
+    } catch (e) {
+      console.error(e);
+    } finally {
+      loading = false;
+    }
+  }
+
   // ── Export ──
   let showExportModal = false;
   let exporting = false;
@@ -79,6 +106,8 @@
   }
 
   onMount(async () => {
+    prevProjectId = projectId;
+    mounted = true;
     if (!projectId) return;
     try {
       const [project, sum] = await Promise.all([

--- a/apps/web/src/routes/(app)/projects/[id]/seo/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/seo/+page.svelte
@@ -23,6 +23,30 @@
     }
   }
 
+  // Reload when the URL project id changes. SvelteKit reuses this component
+  // across /projects/A → /projects/B, so onMount does NOT fire again — without
+  // this watcher the page keeps showing the previous project's keywords.
+  let mounted = false;
+  let prevProjectId: string | undefined = '';
+  $: if (mounted && projectId && projectId !== prevProjectId) {
+    prevProjectId = projectId;
+    reloadForProject();
+  }
+
+  async function reloadForProject() {
+    keywords = [];
+    historyMap = {};
+    loading = true;
+    try {
+      const project = await api.get<any>(`/projects/${projectId}`);
+      projectWebsite = project?.websiteUrl || '';
+    } catch {
+      projectWebsite = '';
+    }
+    loadPersistedSyncResult();
+    await fetchKeywords();
+  }
+
   // Derive default locale from svelte-i18n locale
   function deriveSearchLocale(lang: string | null | undefined): string {
     if (!lang) return 'en-US';
@@ -119,6 +143,8 @@
     }
     loadPersistedSyncResult();
     await fetchKeywords();
+    prevProjectId = projectId;
+    mounted = true;
   });
 
   async function fetchKeywords() {

--- a/apps/web/src/routes/(app)/projects/[id]/sequences/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/sequences/+page.svelte
@@ -17,6 +17,22 @@
     }
   }
 
+  // Reload when the URL project id changes. SvelteKit reuses this component
+  // across /projects/A → /projects/B, so onMount does NOT fire again — without
+  // this watcher the page keeps showing the previous project's data.
+  let mounted = false;
+  let prevProjectId: string | undefined = '';
+  $: if (mounted && projectId && projectId !== prevProjectId) {
+    prevProjectId = projectId;
+    reloadForProject();
+  }
+
+  async function reloadForProject() {
+    sequences = [];
+    expandedIds = new Set<string>();
+    await loadSequences();
+  }
+
   // ── Types ──────────────────────────────────────────────────────────────
   interface SequenceStep {
     id: string;
@@ -84,6 +100,8 @@
   // ── Lifecycle ──────────────────────────────────────────────────────────
   onMount(async () => {
     await loadSequences();
+    prevProjectId = projectId;
+    mounted = true;
   });
 
   async function loadSequences() {

--- a/apps/web/src/routes/(app)/projects/[id]/settings/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/settings/+page.svelte
@@ -17,6 +17,55 @@
   }
   $: isMobileApp = $currentProjectStore?.projectType === 'MOBILE_APP';
 
+  // Reload when the URL project id changes. SvelteKit reuses this component
+  // across /projects/A → /projects/B, so onMount does NOT fire again — without
+  // this watcher the page keeps showing the previous project's data.
+  let mounted = false;
+  let prevProjectId: string | undefined = '';
+  $: if (mounted && projectId && projectId !== prevProjectId) {
+    prevProjectId = projectId;
+    reloadForProject();
+  }
+
+  async function reloadForProject() {
+    // Reset displayed/derived state for the previous project
+    loading = true;
+    allAccounts = [];
+    enabledIds = new Set();
+    trackingInfo = null;
+    baseCurrency = 'USD';
+    projectWebsite = '';
+    gpStatus = null;
+    gscConfig = null;
+    gscSiteUrl = '';
+    gscSites = [];
+
+    if (!$organizationIdStore) { loading = false; return; }
+    try {
+      const [all, enabled, tracking, project] = await Promise.all([
+        api.get<any[]>('/social/accounts', { organizationId: $organizationIdStore }),
+        api.get<any[]>('/social/project-accounts', { projectId }),
+        api.get<{ trackingId: string; snippetUrl: string }>(`/projects/${projectId}/tracking`),
+        api.get<any>(`/projects/${projectId}`),
+      ]);
+      allAccounts = all;
+      enabledIds = new Set(enabled.map((a: any) => a.id));
+      trackingInfo = tracking;
+      if (project.baseCurrency) baseCurrency = project.baseCurrency;
+      if (project.websiteUrl) projectWebsite = project.websiteUrl;
+    } catch (e) {
+      console.error(e);
+    } finally {
+      loading = false;
+    }
+
+    if (isMobileApp) {
+      await fetchGpStatus();
+    }
+
+    await fetchGscConfig();
+  }
+
   const currencies = ['USD', 'EUR', 'GBP', 'PLN', 'RUB', 'UAH', 'BYN', 'KZT', 'TRY', 'JPY', 'CNY'];
   let baseCurrency = 'USD';
   let currencySaved = false;
@@ -129,6 +178,9 @@
 
     // Fetch GSC config
     await fetchGscConfig();
+
+    prevProjectId = projectId;
+    mounted = true;
   });
 
   async function saveBaseCurrency() {


### PR DESCRIPTION
## Problem

When switching the current project via the top project picker, project-scoped pages (Analytics and others) often kept showing the **previous project's data**.

**Root cause:** SvelteKit reuses the same component when navigating between `/projects/A/...` and `/projects/B/...` (same `[id]` route pattern), so `onMount` does **not** fire again. Pages that fetched their data only in `onMount` never re-requested it on a project switch — the URL and the picker store updated, but no new fetch happened.

## Fix

Added a guarded reactive watcher on `projectId` that reloads data (and resets stale display state / spinners) on every project switch — matching the pattern already used by `content` and `finances`:

```svelte
let mounted = false;
let prevProjectId: string | undefined = '';
$: if (mounted && projectId && projectId !== prevProjectId) {
  prevProjectId = projectId;
  reloadForProject();
}
// at end of onMount: prevProjectId = projectId; mounted = true;
```

The `mounted` guard prevents a double-fetch on the initial load.

### Pages updated (`apps/web/src/routes/(app)/projects/[id]/`)
- **analytics** — also resets cached tab data (UTM / Funnel / Pages) and refetches the active tab; delegates to the mobile dashboard for `MOBILE_APP` projects
- **checklists, seo, campaigns, competitors, documents, email, experiments, overview, sequences, settings**

### Components
- **MobileAnalyticsDashboard.svelte** — extracted init into `init()`, added `reinit()` on `projectId` change (resets metrics/status, recreates the sync interval)

### Already correct (untouched)
- `content`, `finances`, `calendar` already had equivalent refetch logic

## Verification
- `svelte-check` — no new type errors introduced (the `prevProjectId` declaration is typed `string | undefined` to stay clean). Remaining warnings are pre-existing project-wide `string | undefined`/`string | null` looseness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)