### PR TITLE
fix(web): refresh GSC panel when switching projects

### DIFF
--- a/apps/web/src/lib/components/analytics/SearchConsolePanel.svelte
+++ b/apps/web/src/lib/components/analytics/SearchConsolePanel.svelte
@@ -56,11 +56,33 @@
     const { Chart } = await import('chart.js/auto');
     ChartJS = Chart;
     await loadIntegration();
+    prevProjectId = projectId;
+    mounted = true;
   });
 
   onDestroy(() => {
     destroyCharts();
   });
+
+  // Reload when the parent passes a different project. This component is reused
+  // across project switches (the analytics page is not remounted), so without
+  // this watcher the panel keeps showing the previous project's GSC data.
+  let mounted = false;
+  let prevProjectId = '';
+  $: if (mounted && projectId && projectId !== prevProjectId) {
+    prevProjectId = projectId;
+    reloadForProject();
+  }
+
+  async function reloadForProject() {
+    destroyCharts();
+    integration = null;
+    summary = null;
+    error = null;
+    integrationLoading = true;
+    period = 28;
+    await loadIntegration();
+  }
 
   function destroyCharts() {
     sparklineCharts.forEach(c => c?.destroy());


### PR DESCRIPTION
## Problem (reproduced live)

After PR #81 fixed page-level data refresh on project switch, one panel was still stale: the **Google Search Console panel** (`SearchConsolePanel`) on the Analytics page kept showing the **previous project's** numbers.

Reproduced on production by switching **MiCode → eMarketingAI** (both web projects) via the project picker:

| | MiCode (project 1) | eMarketingAI (project 2) after switch |
|---|---|---|
| URL / picker | `/projects/cmnkafr4p…` | `/projects/cmnkacph9…` ✅ changed |
| Main analytics KPIs | 48 visitors | empty state ✅ refetched (`metrics` → `array(0)`) |
| **GSC panel** | clicks 2 / impr 23 / CTR 8.70% / pos 20.2, top queries `micode…` | **same 2 / 23 / 8.70% / 20.2, still `micode…`** ❌ stale |
| GSC `search-console/summary` request | fired for project 1 | ❌ **not fired** for project 2 |

**Root cause:** `SearchConsolePanel` fetches the integration + summary only in `onMount`. The Analytics page reuses the component across same-route project switches, so `onMount` never re-runs and the panel never refetches. (This is why web→mobile *looked* fine — the panel isn't rendered for mobile projects, so the stale data just disappeared.)

## Fix

Add the same guarded `projectId` watcher used elsewhere: on project change, reset state (`integration`, `summary`, charts, period) and reload.

```svelte
let mounted = false;
let prevProjectId = '';
$: if (mounted && projectId && projectId !== prevProjectId) {
  prevProjectId = projectId;
  reloadForProject();
}
// at end of onMount: prevProjectId = projectId; mounted = true;
```

## Verification
Reproduced the bug end-to-end via headless browser (login → load MiCode analytics → picker-switch to eMarketingAI → observed stale GSC panel + missing summary request). This patch makes the panel reset and refetch on every switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)