### PR TITLE
fix(gsc): handle no-dimension totals rows (502 on Search Console page)

### DIFF
--- a/apps/api/src/google-integrations/gsc-insights.util.spec.ts
+++ b/apps/api/src/google-integrations/gsc-insights.util.spec.ts
@@ -82,6 +82,17 @@ describe('mergePreviousMetrics', () => {
     expect(merged[0].prevPosition).toBe(6);
     expect(mergePreviousMetrics([row(['new'], 1, 10, 0.1, 5)], [])[0].prevPosition).toBeNull();
   });
+
+  it('handles no-dimension (site totals) rows where GSC omits keys entirely', () => {
+    // GSC returns the aggregate row with NO `keys` field for a no-dimension query.
+    const current = [{ clicks: 100, impressions: 2000, ctr: 0.05, position: 8 } as any];
+    const previous = [{ clicks: 80, impressions: 1800, ctr: 0.044, position: 9 } as any];
+    const merged = mergePreviousMetrics(current, previous);
+    expect(merged[0].keys).toEqual([]);
+    expect(merged[0].clicks).toBe(100);
+    expect(merged[0].prevClicks).toBe(80);
+    expect(merged[0].prevPosition).toBe(9);
+  });
 });
 
 describe('expectedCtr', () => {

--- a/apps/api/src/google-integrations/gsc-insights.util.ts
+++ b/apps/api/src/google-integrations/gsc-insights.util.ts
@@ -26,7 +26,7 @@ export interface InsightRow {
 }
 
 function toInsightRow(r: GSCQueryRow): InsightRow {
-  return { key: r.keys[0] ?? '', clicks: r.clicks, impressions: r.impressions, ctr: r.ctr, position: r.position };
+  return { key: r.keys?.[0] ?? '', clicks: r.clicks, impressions: r.impressions, ctr: r.ctr, position: r.position };
 }
 
 export function strikingDistance(rows: GSCQueryRow[]): InsightRow[] {
@@ -61,9 +61,9 @@ export function cannibalization(rows: GSCQueryRow[]): CannibalRow[] {
   const byQuery = new Map<string, CannibalRow['pages']>();
   for (const r of rows) {
     if (r.impressions < CANNIBAL_MIN_IMPRESSIONS) continue;
-    const query = r.keys[0] ?? '';
+    const query = r.keys?.[0] ?? '';
     const list = byQuery.get(query) ?? [];
-    list.push({ page: r.keys[1] ?? '', clicks: r.clicks, impressions: r.impressions, position: r.position });
+    list.push({ page: r.keys?.[1] ?? '', clicks: r.clicks, impressions: r.impressions, position: r.position });
     byQuery.set(query, list);
   }
   const result: CannibalRow[] = [];
@@ -90,11 +90,11 @@ export interface MoverRow {
 
 export function movers(current: GSCQueryRow[], previous: GSCQueryRow[]): { gainers: MoverRow[]; losers: MoverRow[] } {
   const prev = new Map<string, GSCQueryRow>();
-  for (const r of previous) prev.set(r.keys[0] ?? '', r);
+  for (const r of previous) prev.set(r.keys?.[0] ?? '', r);
   const moves: MoverRow[] = [];
   const seen = new Set<string>();
   for (const r of current) {
-    const key = r.keys[0] ?? '';
+    const key = r.keys?.[0] ?? '';
     seen.add(key);
     const p = prev.get(key);
     if (Math.max(r.impressions, p?.impressions ?? 0) < MOVERS_MIN_IMPRESSIONS) continue;
@@ -109,7 +109,7 @@ export function movers(current: GSCQueryRow[], previous: GSCQueryRow[]): { gaine
   }
   // Previous-only keys: dropped off the current period entirely.
   for (const p of previous) {
-    const key = p.keys[0] ?? '';
+    const key = p.keys?.[0] ?? '';
     if (seen.has(key) || p.impressions < MOVERS_MIN_IMPRESSIONS) continue;
     moves.push({ key, clicks: 0, impressions: 0, position: 0, deltaClicks: -p.clicks, deltaPosition: 0 });
   }
@@ -132,11 +132,12 @@ export interface MergedRow {
 
 export function mergePreviousMetrics(current: GSCQueryRow[], previous: GSCQueryRow[]): MergedRow[] {
   const prev = new Map<string, GSCQueryRow>();
-  for (const r of previous) prev.set(r.keys.join('|'), r);
+  // GSC omits `keys` entirely for a no-dimension (site totals) query — guard it.
+  for (const r of previous) prev.set((r.keys ?? []).join('|'), r);
   return current.map((r) => {
-    const p = prev.get(r.keys.join('|'));
+    const p = prev.get((r.keys ?? []).join('|'));
     return {
-      keys: r.keys,
+      keys: r.keys ?? [],
       clicks: r.clicks,
       impressions: r.impressions,
       ctr: r.ctr,


### PR DESCRIPTION
## Problem
The new Search Console detail page failed with **"Failed to load Search Console data"**. The overview totals request returned **502**:

```
GET /api/google/search-console/query?...&dimensions=&type=web&compare=true
{ "code": "GSC_ERROR", "message": "Cannot read properties of undefined (reading 'join')" }
```
(The `dimensions=date` request returned 200 fine.)

## Root cause
For a **no-dimension** query (`dimensions=[]`, used for site-wide totals), the GSC Search Analytics API returns the aggregate row **without a `keys` field at all**. `mergePreviousMetrics` did `r.keys.join('|')`, so `keys` was `undefined` → throw → 502. (The final review had assumed `keys` would be `[]`; Google actually omits the field.)

## Fix
Guard every `keys` access in `gsc-insights.util.ts`: `(r.keys ?? []).join('|')` in `mergePreviousMetrics` and `r.keys?.[i] ?? ''` in the other readers. Added a regression test asserting `mergePreviousMetrics` handles a keyless totals row (current + previous) and yields `keys: []` with correct prev metrics.

## Testing
`npx jest src/google-integrations/gsc-insights.util.spec.ts` → 8/8 pass (incl. the new no-dimension case); `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)