### PR TITLE
fix(meta-oauth): clear error when Instagram/Meta app not configured

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,15 @@ GOOGLE_CLIENT_ID="your-google-client-id"
 GOOGLE_CLIENT_SECRET="your-google-client-secret"
 GOOGLE_CALLBACK_URL="http://localhost:3000/auth/google/callback"
 
+# OAuth — Meta (Facebook Login + Instagram Graph API)
+# Required to connect Instagram accounts via /settings/integrations.
+# Create a Meta app at https://developers.facebook.com, add the "Facebook Login"
+# and "Instagram Graph API" products, and register the redirect URI
+# <API_URL>/api/meta/callback. Advanced scopes need Meta App Review before
+# non-test users can connect.
+FACEBOOK_APP_ID="your-meta-app-id"
+FACEBOOK_APP_SECRET="your-meta-app-secret"
+
 # OpenAI
 OPENAI_API_KEY="sk-your-openai-api-key"
 OPENAI_MODEL="gpt-4o"

--- a/apps/api/src/meta-oauth/meta-oauth.controller.spec.ts
+++ b/apps/api/src/meta-oauth/meta-oauth.controller.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import * as crypto from 'crypto';
-import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, ServiceUnavailableException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { MetaOAuthController } from './meta-oauth.controller';
 import { MetaOAuthService } from './meta-oauth.service';
@@ -47,6 +47,8 @@ describe('MetaOAuthController', () => {
                 API_URL: 'http://localhost:3000',
                 WEB_URL: 'http://localhost:5173',
                 ENCRYPTION_KEY: TEST_ENCRYPTION_KEY,
+                FACEBOOK_APP_ID: 'app-123',
+                FACEBOOK_APP_SECRET: 'secret-123',
               };
               return map[key];
             }),
@@ -85,6 +87,16 @@ describe('MetaOAuthController', () => {
 
     it('throws BadRequestException for unsupported platform', () => {
       expect(() => controller.getAuthUrl(mockUser('OWNER'), 'FACEBOOK')).toThrow(BadRequestException);
+    });
+
+    it('throws ServiceUnavailableException when Meta app credentials are not configured', () => {
+      const cfg = { get: jest.fn((k: string) => (k === 'ENCRYPTION_KEY' ? TEST_ENCRYPTION_KEY : undefined)) };
+      const ctrl = new MetaOAuthController(
+        { getInstagramAuthUrl: jest.fn() } as any,
+        { upsertOAuthAccount: jest.fn() } as any,
+        cfg as any,
+      );
+      expect(() => ctrl.getAuthUrl(mockUser('OWNER'), 'INSTAGRAM')).toThrow(ServiceUnavailableException);
     });
 
     it('throws BadRequestException when organizationId is passed for an org the user is not a member of', () => {

--- a/apps/api/src/meta-oauth/meta-oauth.controller.ts
+++ b/apps/api/src/meta-oauth/meta-oauth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, Res, BadRequestException, ForbiddenException } from '@nestjs/common';
+import { Controller, Get, Query, Res, BadRequestException, ForbiddenException, ServiceUnavailableException } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import { Response } from 'express';
@@ -72,6 +72,11 @@ export class MetaOAuthController {
     }
     const orgId = membership.organizationId;
     if (platform !== 'INSTAGRAM') throw new BadRequestException('Unsupported platform');
+    if (!this.config.get('FACEBOOK_APP_ID') || !this.config.get('FACEBOOK_APP_SECRET')) {
+      throw new ServiceUnavailableException(
+        'Instagram integration is not configured on this server yet. An administrator must set FACEBOOK_APP_ID and FACEBOOK_APP_SECRET.',
+      );
+    }
     const state = this.signState({ organizationId: orgId, platform });
     return { url: this.metaService.getInstagramAuthUrl(this.redirectUri(), state) };
   }


### PR DESCRIPTION
Follow-up to #93. Clicking **Connect Instagram** on a server without `FACEBOOK_APP_ID`/`FACEBOOK_APP_SECRET` returned a raw **500 "Internal server error"** (the service threw a plain `Error('FACEBOOK_APP_ID not configured')`).

## Change
- `GET /meta/auth-url` now throws `ServiceUnavailableException` (503) with an actionable message when the Meta app credentials are not set, so the UI shows *"Instagram integration is not configured on this server yet…"* instead of a generic 500.
- Documented `FACEBOOK_APP_ID` / `FACEBOOK_APP_SECRET` (+ setup notes) in `.env.example`.
- Controller spec: added a test for the unconfigured case; updated the shared ConfigService mock so existing happy-path tests still pass. **15/15 passing**, api build clean.

## Note — this does NOT make Instagram work yet
Enabling the integration still requires (devops/admin action, not code):
1. Create a Meta app (Facebook Login + Instagram Graph API products).
2. Register redirect URI `<API_URL>/api/meta/callback`.
3. Set `FACEBOOK_APP_ID` / `FACEBOOK_APP_SECRET` in the prod environment.
4. Meta App Review for advanced scopes before non-test users can connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)