### PR TITLE
fix(meta-oauth): migrate Instagram to Instagram Login API (fixes Invalid Scopes)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,15 @@ GOOGLE_CLIENT_ID="your-google-client-id"
 GOOGLE_CLIENT_SECRET="your-google-client-secret"
 GOOGLE_CALLBACK_URL="http://localhost:3000/auth/google/callback"
 
+# Instagram — "Instagram API with Instagram Login" (Instagram Business Login)
+# Required to connect Instagram accounts via /settings/integrations.
+# In your Meta app: Instagram product -> "API setup with Instagram login" ->
+# copy the INSTAGRAM app ID + secret (distinct from the Facebook app id/secret),
+# and add the OAuth redirect URI <API_URL>/api/meta/callback there.
+# Advanced scopes need Meta App Review before non-test users can connect.
+INSTAGRAM_APP_ID="your-instagram-app-id"
+INSTAGRAM_APP_SECRET="your-instagram-app-secret"
+
 # OpenAI
 OPENAI_API_KEY="sk-your-openai-api-key"
 OPENAI_MODEL="gpt-4o"

--- a/apps/api/src/meta-oauth/meta-oauth.controller.spec.ts
+++ b/apps/api/src/meta-oauth/meta-oauth.controller.spec.ts
@@ -1,6 +1,6 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import * as crypto from 'crypto';
-import { BadRequestException, ForbiddenException } from '@nestjs/common';
+import { BadRequestException, ForbiddenException, ServiceUnavailableException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { MetaOAuthController } from './meta-oauth.controller';
 import { MetaOAuthService } from './meta-oauth.service';
@@ -27,10 +27,10 @@ describe('MetaOAuthController', () => {
         {
           provide: MetaOAuthService,
           useValue: {
-            getInstagramAuthUrl: jest.fn().mockReturnValue('https://fb.com/oauth?test=1'),
+            getInstagramAuthUrl: jest.fn().mockReturnValue('https://api.instagram.com/oauth/authorize?test=1'),
             exchangeCode: jest.fn(),
             getLongLivedToken: jest.fn(),
-            discoverInstagramAccount: jest.fn(),
+            getInstagramUser: jest.fn(),
           },
         },
         {
@@ -47,6 +47,8 @@ describe('MetaOAuthController', () => {
                 API_URL: 'http://localhost:3000',
                 WEB_URL: 'http://localhost:5173',
                 ENCRYPTION_KEY: TEST_ENCRYPTION_KEY,
+                INSTAGRAM_APP_ID: 'ig-app-123',
+                INSTAGRAM_APP_SECRET: 'ig-secret-123',
               };
               return map[key];
             }),
@@ -85,6 +87,16 @@ describe('MetaOAuthController', () => {
 
     it('throws BadRequestException for unsupported platform', () => {
       expect(() => controller.getAuthUrl(mockUser('OWNER'), 'FACEBOOK')).toThrow(BadRequestException);
+    });
+
+    it('throws ServiceUnavailableException when Instagram app credentials are not configured', () => {
+      const cfg = { get: jest.fn((k: string) => (k === 'ENCRYPTION_KEY' ? TEST_ENCRYPTION_KEY : undefined)) };
+      const ctrl = new MetaOAuthController(
+        { getInstagramAuthUrl: jest.fn() } as any,
+        { upsertOAuthAccount: jest.fn() } as any,
+        cfg as any,
+      );
+      expect(() => ctrl.getAuthUrl(mockUser('OWNER'), 'INSTAGRAM')).toThrow(ServiceUnavailableException);
     });
 
     it('throws BadRequestException when organizationId is passed for an org the user is not a member of', () => {
@@ -175,17 +187,15 @@ describe('MetaOAuthController', () => {
       const ctrl = controller as any;
       const validState: string = ctrl.signState({ organizationId: 'org-1', platform: 'INSTAGRAM' });
 
-      (metaService.exchangeCode as jest.Mock).mockResolvedValue({ access_token: 'short-token' });
+      (metaService.exchangeCode as jest.Mock).mockResolvedValue({ access_token: 'short-token', user_id: 'ig-123' });
       (metaService.getLongLivedToken as jest.Mock).mockResolvedValue({
         access_token: 'long-token',
         expires_in: 3600,
       });
-      (metaService.discoverInstagramAccount as jest.Mock).mockResolvedValue({
+      (metaService.getInstagramUser as jest.Mock).mockResolvedValue({
         igUserId: 'ig-123',
         username: 'testuser',
         profilePictureUrl: 'https://example.com/pic.jpg',
-        pageId: 'page-123',
-        pageAccessToken: 'page-token',
       });
 
       const res = mockRes();

--- a/apps/api/src/meta-oauth/meta-oauth.controller.ts
+++ b/apps/api/src/meta-oauth/meta-oauth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query, Res, BadRequestException, ForbiddenException } from '@nestjs/common';
+import { Controller, Get, Query, Res, BadRequestException, ForbiddenException, ServiceUnavailableException } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import { Response } from 'express';
@@ -72,6 +72,11 @@ export class MetaOAuthController {
     }
     const orgId = membership.organizationId;
     if (platform !== 'INSTAGRAM') throw new BadRequestException('Unsupported platform');
+    if (!this.config.get('INSTAGRAM_APP_ID') || !this.config.get('INSTAGRAM_APP_SECRET')) {
+      throw new ServiceUnavailableException(
+        'Instagram integration is not configured on this server yet. An administrator must set INSTAGRAM_APP_ID and INSTAGRAM_APP_SECRET.',
+      );
+    }
     const state = this.signState({ organizationId: orgId, platform });
     return { url: this.metaService.getInstagramAuthUrl(this.redirectUri(), state) };
   }
@@ -89,7 +94,7 @@ export class MetaOAuthController {
     try {
       const short = await this.metaService.exchangeCode(code, this.redirectUri());
       const long = await this.metaService.getLongLivedToken(short.access_token);
-      const ig = await this.metaService.discoverInstagramAccount(long.access_token);
+      const ig = await this.metaService.getInstagramUser(long.access_token);
       if (!ig) return fail('no_ig_account');
 
       await this.socialService.upsertOAuthAccount(parsed.organizationId, {
@@ -98,12 +103,10 @@ export class MetaOAuthController {
         accountName: ig.username,
         profileImageUrl: ig.profilePictureUrl,
         tokens: {
-          accessToken: ig.pageAccessToken,
-          userAccessToken: long.access_token,
+          accessToken: long.access_token,
           igUserId: ig.igUserId,
-          pageId: ig.pageId,
         },
-        scopes: ['instagram_basic', 'instagram_content_publish', 'instagram_manage_insights', 'instagram_manage_comments'],
+        scopes: ['instagram_business_basic', 'instagram_business_content_publish'],
         expiresAt: long.expires_in ? new Date(Date.now() + long.expires_in * 1000) : null,
       });
 

--- a/apps/api/src/meta-oauth/meta-oauth.service.spec.ts
+++ b/apps/api/src/meta-oauth/meta-oauth.service.spec.ts
@@ -2,17 +2,22 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { ConfigService } from '@nestjs/config';
 import { MetaOAuthService } from './meta-oauth.service';
 
-describe('MetaOAuthService', () => {
+describe('MetaOAuthService (Instagram Login)', () => {
   let service: MetaOAuthService;
   const config = {
-    get: jest.fn((k: string) => ({ FACEBOOK_APP_ID: 'app123', FACEBOOK_APP_SECRET: 'secret123' } as Record<string, string>)[k]),
+    get: jest.fn(
+      (k: string) =>
+        ({ INSTAGRAM_APP_ID: 'ig-app-123', INSTAGRAM_APP_SECRET: 'ig-secret-123' } as Record<string, string>)[k],
+    ),
   } as any;
 
+  const originalFetch = global.fetch;
+
   beforeEach(async () => {
-    jest.resetAllMocks();
-    // Restore default credential values after each reset
+    jest.clearAllMocks();
     config.get.mockImplementation(
-      (k: string) => ({ FACEBOOK_APP_ID: 'app123', FACEBOOK_APP_SECRET: 'secret123' } as Record<string, string>)[k],
+      (k: string) =>
+        ({ INSTAGRAM_APP_ID: 'ig-app-123', INSTAGRAM_APP_SECRET: 'ig-secret-123' } as Record<string, string>)[k],
     );
     const mod: TestingModule = await Test.createTestingModule({
       providers: [MetaOAuthService, { provide: ConfigService, useValue: config }],
@@ -21,127 +26,82 @@ describe('MetaOAuthService', () => {
   });
 
   afterEach(() => {
-    // Restore global.fetch so mocks do not leak between tests
-    (global as any).fetch = undefined;
+    global.fetch = originalFetch;
   });
 
-  // ── getInstagramAuthUrl ──────────────────────────────────────────────────────
-
-  it('builds an authorization URL with IG scopes and state', () => {
+  it('builds an Instagram Login authorization URL with instagram_business scopes and state', () => {
     const url = service.getInstagramAuthUrl('https://api.test/api/meta/callback', 'STATE');
-    expect(url).toContain('https://www.facebook.com/v21.0/dialog/oauth');
-    expect(url).toContain('client_id=app123');
+    expect(url).toContain('https://api.instagram.com/oauth/authorize');
+    expect(url).toContain('client_id=ig-app-123');
     expect(url).toContain('state=STATE');
-    expect(decodeURIComponent(url)).toContain('instagram_content_publish');
-    expect(decodeURIComponent(url)).toContain('instagram_basic');
+    const decoded = decodeURIComponent(url);
+    expect(decoded).toContain('instagram_business_basic');
+    expect(decoded).toContain('instagram_business_content_publish');
+    // must NOT use the deprecated Facebook-Login flow
+    expect(url).not.toContain('facebook.com');
   });
 
-  // ── exchangeCode ─────────────────────────────────────────────────────────────
-
-  it('exchangeCode: happy path returns access_token and expires_in', async () => {
+  it('exchangeCode POSTs to api.instagram.com and returns access_token + user_id (stringified)', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ access_token: 'short-tok', expires_in: 3600 }),
+      json: async () => ({ access_token: 'short-tok', user_id: 178414 }),
     }) as any;
 
-    const result = await service.exchangeCode('auth-code', 'https://api.test/callback');
-    expect(result).toEqual({ access_token: 'short-tok', expires_in: 3600 });
-    expect(global.fetch).toHaveBeenCalledTimes(1);
-    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
-    expect(calledUrl).toContain('client_id=app123');
-    expect(calledUrl).toContain('client_secret=secret123');
+    const result = await service.exchangeCode('the-code', 'https://api.test/api/meta/callback');
+    expect(result).toEqual({ access_token: 'short-tok', user_id: '178414' });
+    const [calledUrl, init] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(calledUrl).toBe('https://api.instagram.com/oauth/access_token');
+    expect(init.method).toBe('POST');
+    expect(init.body.toString()).toContain('grant_type=authorization_code');
   });
 
-  it('exchangeCode: non-ok response throws with body text', async () => {
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: false,
-      text: async () => 'invalid_client',
-    }) as any;
-
-    await expect(service.exchangeCode('bad-code', 'https://api.test/callback')).rejects.toThrow(
-      'invalid_client',
-    );
+  it('exchangeCode throws on a non-ok response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, text: async () => 'bad code' }) as any;
+    await expect(service.exchangeCode('c', 'r')).rejects.toThrow(/Instagram code exchange failed/);
   });
 
-  it('exchangeCode: throws when FACEBOOK_APP_ID is missing', async () => {
-    config.get.mockImplementation((k: string) =>
-      k === 'FACEBOOK_APP_SECRET' ? 'secret123' : undefined,
-    );
-
-    await expect(service.exchangeCode('code', 'https://api.test/callback')).rejects.toThrow(
-      /FACEBOOK_APP_ID not configured/,
-    );
+  it('exchangeCode throws when INSTAGRAM_APP_ID is missing', async () => {
+    config.get.mockImplementation((k: string) => (k === 'INSTAGRAM_APP_SECRET' ? 's' : undefined));
+    await expect(service.exchangeCode('c', 'r')).rejects.toThrow(/INSTAGRAM_APP_ID not configured/);
   });
 
-  // ── getLongLivedToken ────────────────────────────────────────────────────────
-
-  it('getLongLivedToken: happy path returns access_token and expires_in', async () => {
+  it('getLongLivedToken GETs graph.instagram.com with ig_exchange_token', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({ access_token: 'long-tok', expires_in: 5183944 }),
+      json: async () => ({ access_token: 'long-tok', expires_in: 5184000 }),
     }) as any;
 
     const result = await service.getLongLivedToken('short-tok');
-    expect(result).toEqual({ access_token: 'long-tok', expires_in: 5183944 });
+    expect(result).toEqual({ access_token: 'long-tok', expires_in: 5184000 });
     const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
-    expect(calledUrl).toContain('grant_type=fb_exchange_token');
-    expect(calledUrl).toContain('client_id=app123');
+    expect(calledUrl).toContain('https://graph.instagram.com/access_token');
+    expect(calledUrl).toContain('grant_type=ig_exchange_token');
   });
 
-  it('getLongLivedToken: non-ok response throws with body text', async () => {
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: false,
-      text: async () => 'token_expired',
-    }) as any;
-
-    await expect(service.getLongLivedToken('bad-tok')).rejects.toThrow('token_expired');
+  it('getLongLivedToken throws on a non-ok response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, text: async () => 'err' }) as any;
+    await expect(service.getLongLivedToken('x')).rejects.toThrow(/Instagram long-lived token exchange failed/);
   });
 
-  it('getLongLivedToken: throws when FACEBOOK_APP_ID is missing', async () => {
-    config.get.mockImplementation((k: string) =>
-      k === 'FACEBOOK_APP_SECRET' ? 'secret123' : undefined,
-    );
-
-    await expect(service.getLongLivedToken('tok')).rejects.toThrow(
-      /FACEBOOK_APP_ID not configured/,
-    );
-  });
-
-  // ── discoverInstagramAccount ─────────────────────────────────────────────────
-
-  it('discovers the first page that has a linked Instagram business account', async () => {
+  it('getInstagramUser returns the profile from graph.instagram.com/me', async () => {
     global.fetch = jest.fn().mockResolvedValue({
       ok: true,
-      json: async () => ({
-        data: [
-          { id: 'pageNoIg', name: 'No IG', access_token: 'pt0' },
-          { id: 'page1', name: 'Brand', access_token: 'pt1', instagram_business_account: { id: 'ig1', username: 'brand', profile_picture_url: 'http://x/p.jpg' } },
-        ],
-      }),
+      json: async () => ({ user_id: '178414', username: 'brand', profile_picture_url: 'http://x/p.jpg' }),
     }) as any;
 
-    const result = await service.discoverInstagramAccount('user-tok');
-    expect(result).toEqual({
-      igUserId: 'ig1', username: 'brand', profilePictureUrl: 'http://x/p.jpg',
-      pageId: 'page1', pageAccessToken: 'pt1',
-    });
+    const result = await service.getInstagramUser('long-tok');
+    expect(result).toEqual({ igUserId: '178414', username: 'brand', profilePictureUrl: 'http://x/p.jpg' });
+    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+    expect(calledUrl).toContain('https://graph.instagram.com/me');
   });
 
-  it('returns null when no page has an Instagram business account', async () => {
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: true, json: async () => ({ data: [{ id: 'p', name: 'x', access_token: 't' }] }),
-    }) as any;
-    expect(await service.discoverInstagramAccount('user-tok')).toBeNull();
+  it('getInstagramUser returns null when username is missing', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ user_id: '1' }) }) as any;
+    expect(await service.getInstagramUser('t')).toBeNull();
   });
 
-  it('discoverInstagramAccount: non-ok response throws with body text', async () => {
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: false,
-      text: async () => 'invalid_token',
-    }) as any;
-
-    await expect(service.discoverInstagramAccount('bad-tok')).rejects.toThrow(
-      /Meta \/me\/accounts failed: invalid_token/,
-    );
+  it('getInstagramUser throws on a non-ok response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, text: async () => 'bad token' }) as any;
+    await expect(service.getInstagramUser('t')).rejects.toThrow(/Instagram \/me failed/);
   });
 });

--- a/apps/api/src/meta-oauth/meta-oauth.service.ts
+++ b/apps/api/src/meta-oauth/meta-oauth.service.ts
@@ -1,16 +1,17 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 
-const GRAPH_VERSION = 'v21.0';
-const GRAPH = `https://graph.facebook.com/${GRAPH_VERSION}`;
+// "Instagram API with Instagram Login" (Instagram Business Login).
+// OAuth via api.instagram.com, Graph calls via graph.instagram.com.
+// Uses the Instagram app ID/secret (distinct from the Facebook app credentials).
+const IG_OAUTH = 'https://api.instagram.com/oauth';
+const IG_GRAPH = 'https://graph.instagram.com';
 
+// Phase 1 needs only basic + content publish. Comments/insights scopes
+// (instagram_business_manage_comments / _manage_insights) are added in Phase 2.
 const INSTAGRAM_SCOPES = [
-  'instagram_basic',
-  'instagram_content_publish',
-  'instagram_manage_insights',
-  'instagram_manage_comments',
-  'pages_show_list',
-  'pages_read_engagement',
+  'instagram_business_basic',
+  'instagram_business_content_publish',
 ];
 
 @Injectable()
@@ -19,9 +20,16 @@ export class MetaOAuthService {
 
   constructor(private config: ConfigService) {}
 
+  private creds(): { clientId: string; clientSecret: string } {
+    const clientId = this.config.get<string>('INSTAGRAM_APP_ID');
+    const clientSecret = this.config.get<string>('INSTAGRAM_APP_SECRET');
+    if (!clientId) throw new Error('INSTAGRAM_APP_ID not configured');
+    if (!clientSecret) throw new Error('INSTAGRAM_APP_SECRET not configured');
+    return { clientId, clientSecret };
+  }
+
   getInstagramAuthUrl(redirectUri: string, state: string): string {
-    const clientId = this.config.get('FACEBOOK_APP_ID');
-    if (!clientId) throw new Error('FACEBOOK_APP_ID not configured');
+    const { clientId } = this.creds();
     const params = new URLSearchParams({
       client_id: clientId,
       redirect_uri: redirectUri,
@@ -29,63 +37,57 @@ export class MetaOAuthService {
       scope: INSTAGRAM_SCOPES.join(','),
       state,
     });
-    return `https://www.facebook.com/${GRAPH_VERSION}/dialog/oauth?${params}`;
+    return `${IG_OAUTH}/authorize?${params}`;
   }
 
-  async exchangeCode(code: string, redirectUri: string): Promise<{ access_token: string; expires_in?: number }> {
-    const clientId = this.config.get('FACEBOOK_APP_ID');
-    const clientSecret = this.config.get('FACEBOOK_APP_SECRET');
-    if (!clientId) throw new Error('FACEBOOK_APP_ID not configured');
-    if (!clientSecret) throw new Error('FACEBOOK_APP_SECRET not configured');
-    const params = new URLSearchParams({
+  /** Exchange the auth code for a short-lived token. Returns the token + IG user id. */
+  async exchangeCode(code: string, redirectUri: string): Promise<{ access_token: string; user_id: string }> {
+    const { clientId, clientSecret } = this.creds();
+    const body = new URLSearchParams({
       client_id: clientId,
       client_secret: clientSecret,
+      grant_type: 'authorization_code',
       redirect_uri: redirectUri,
       code,
     });
-    const res = await fetch(`${GRAPH}/oauth/access_token?${params}`);
-    if (!res.ok) throw new Error(`Meta code exchange failed: ${await res.text()}`);
-    return res.json() as Promise<{ access_token: string; expires_in?: number }>;
+    const res = await fetch(`${IG_OAUTH}/access_token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+    if (!res.ok) throw new Error(`Instagram code exchange failed: ${await res.text()}`);
+    const data = (await res.json()) as { access_token: string; user_id?: number | string };
+    return { access_token: data.access_token, user_id: String(data.user_id ?? '') };
   }
 
+  /** Exchange a short-lived token for a long-lived (60-day) token. */
   async getLongLivedToken(shortLivedToken: string): Promise<{ access_token: string; expires_in: number }> {
-    const clientId = this.config.get('FACEBOOK_APP_ID');
-    const clientSecret = this.config.get('FACEBOOK_APP_SECRET');
-    if (!clientId) throw new Error('FACEBOOK_APP_ID not configured');
-    if (!clientSecret) throw new Error('FACEBOOK_APP_SECRET not configured');
+    const { clientSecret } = this.creds();
     const params = new URLSearchParams({
-      grant_type: 'fb_exchange_token',
-      client_id: clientId,
+      grant_type: 'ig_exchange_token',
       client_secret: clientSecret,
-      fb_exchange_token: shortLivedToken,
+      access_token: shortLivedToken,
     });
-    const res = await fetch(`${GRAPH}/oauth/access_token?${params}`);
-    if (!res.ok) throw new Error(`Meta long-lived token exchange failed: ${await res.text()}`);
+    const res = await fetch(`${IG_GRAPH}/access_token?${params}`);
+    if (!res.ok) throw new Error(`Instagram long-lived token exchange failed: ${await res.text()}`);
     return res.json() as Promise<{ access_token: string; expires_in: number }>;
   }
 
-  async discoverInstagramAccount(userAccessToken: string): Promise<{
-    igUserId: string; username: string; profilePictureUrl?: string; pageId: string; pageAccessToken: string;
-  } | null> {
+  /** Fetch the connected Instagram account profile. Returns null if the profile is incomplete. */
+  async getInstagramUser(
+    accessToken: string,
+  ): Promise<{ igUserId: string; username: string; profilePictureUrl?: string } | null> {
     const params = new URLSearchParams({
-      fields: 'id,name,access_token,instagram_business_account{id,username,profile_picture_url}',
-      access_token: userAccessToken,
+      fields: 'user_id,username,profile_picture_url',
+      access_token: accessToken,
     });
-    const res = await fetch(`${GRAPH}/me/accounts?${params}`);
-    if (!res.ok) {
-      throw new Error(`Meta /me/accounts failed: ${await res.text()}`);
-    }
+    const res = await fetch(`${IG_GRAPH}/me?${params}`);
+    if (!res.ok) throw new Error(`Instagram /me failed: ${await res.text()}`);
     const data = (await res.json()) as {
-      data?: Array<{ id: string; name: string; access_token: string; instagram_business_account?: { id: string; username: string; profile_picture_url?: string } }>;
+      user_id?: string; id?: string; username?: string; profile_picture_url?: string;
     };
-    const page = (data.data || []).find((p) => p.instagram_business_account?.id);
-    if (!page || !page.instagram_business_account) return null;
-    return {
-      igUserId: page.instagram_business_account.id,
-      username: page.instagram_business_account.username,
-      profilePictureUrl: page.instagram_business_account.profile_picture_url,
-      pageId: page.id,
-      pageAccessToken: page.access_token,
-    };
+    const igUserId = String(data.user_id ?? data.id ?? '');
+    if (!igUserId || !data.username) return null;
+    return { igUserId, username: data.username, profilePictureUrl: data.profile_picture_url };
   }
 }

--- a/apps/api/src/social/social.service.ts
+++ b/apps/api/src/social/social.service.ts
@@ -587,7 +587,7 @@ export class SocialService {
   }
 
   private async publishToInstagram(content: any, tokens: any) {
-    const GRAPH = 'https://graph.facebook.com/v21.0';
+    const GRAPH = 'https://graph.instagram.com';
     const igUserId = tokens.igUserId;
     const token = tokens.accessToken;
     if (!igUserId) throw new Error('Instagram account not fully connected (missing igUserId)');
@@ -636,7 +636,7 @@ export class SocialService {
   }
 
   private async waitForContainer(creationId: string, token: string, maxAttempts = 20, delayMs = 3000): Promise<void> {
-    const GRAPH = 'https://graph.facebook.com/v21.0';
+    const GRAPH = 'https://graph.instagram.com';
     for (let i = 0; i < maxAttempts; i++) {
       const r = await axios.get(`${GRAPH}/${creationId}`, { params: { fields: 'status_code', access_token: token } });
       const status = r.data?.status_code;


### PR DESCRIPTION
Follow-up to #93. Connecting Instagram failed at the consent screen with **"Invalid Scopes: instagram_basic, instagram_content_publish, …"** — Meta deprecated those Facebook-Login-based Instagram permissions. This migrates the integration to **"Instagram API with Instagram Login"** (the model our Meta app is configured for).

## Changes
- **OAuth flow** → `api.instagram.com/oauth/authorize` + `/access_token`; long-lived token via `graph.instagram.com/access_token` (`ig_exchange_token`).
- **Scopes** → `instagram_business_basic`, `instagram_business_content_publish` (Phase 1; comments/insights scopes come with Phase 2).
- **Credentials** → `INSTAGRAM_APP_ID` / `INSTAGRAM_APP_SECRET` (the Instagram app id/secret, **distinct** from the Facebook app id/secret). No Facebook Page required.
- **Account discovery** → `graph.instagram.com/me` (replaces the page→`instagram_business_account` lookup). Token payload is now `{ accessToken, igUserId }`.
- **Publishing** base URL → `graph.instagram.com` (container → publish → permalink; Reels still poll `status_code`).
- Clean **503** when the server isn't configured (keyed on `INSTAGRAM_APP_ID`), and `.env.example` documents the new vars.

**Supersedes #94** (which added the same 503 guard keyed on the now-unused Facebook app id). Close #94 in favor of this.

## Tests
api meta-oauth + social suites: **43 passing**; api build clean. (Graph calls mocked.)

## Deploy / config required
1. Get the **Instagram app id + secret** (Meta app → Instagram → "API setup with Instagram login").
2. Add OAuth redirect URI `https://emarketingai.pl/api/meta/callback` in that same Instagram-login section.
3. Set `INSTAGRAM_APP_ID` / `INSTAGRAM_APP_SECRET` in prod `.env.production`, recreate the api container.
4. Meta App Review still required for non-test users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)