### PR TITLE
feat(legal): Privacy Policy & Data Deletion pages for Meta App Review

### DIFF
--- a/apps/web/static/data-deletion.html
+++ b/apps/web/static/data-deletion.html
@@ -1,0 +1,111 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="index, follow" />
+  <title>User Data Deletion — eMarketingAI</title>
+  <style>
+    :root { --ink:#1e293b; --muted:#64748b; --accent:#6d28d9; --line:#e2e8f0; }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      color: var(--ink);
+      line-height: 1.65;
+      background: #f8fafc;
+    }
+    .wrap { max-width: 820px; margin: 0 auto; padding: 48px 24px 96px; }
+    header { border-bottom: 1px solid var(--line); padding-bottom: 24px; margin-bottom: 32px; }
+    .brand { display: inline-flex; align-items: center; gap: 10px; font-weight: 700; font-size: 18px; color: var(--accent); text-decoration: none; }
+    .brand span { color: var(--ink); }
+    h1 { font-size: 32px; margin: 24px 0 4px; }
+    h2 { font-size: 21px; margin: 40px 0 8px; }
+    .muted { color: var(--muted); font-size: 14px; }
+    a { color: var(--accent); }
+    ol, ul { padding-left: 22px; }
+    li { margin: 8px 0; }
+    .card { background: #fff; border: 1px solid var(--line); border-radius: 12px; padding: 20px 24px; margin: 24px 0; }
+    code { background: #ede9fe; padding: 1px 6px; border-radius: 4px; font-size: 90%; }
+    footer { margin-top: 64px; padding-top: 24px; border-top: 1px solid var(--line); color: var(--muted); font-size: 14px; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <a class="brand" href="https://emarketingai.pl">eMarketing<span>AI</span></a>
+    </header>
+
+    <h1>User Data Deletion</h1>
+    <p class="muted">Last updated: 27 June 2026</p>
+
+    <p>
+      eMarketingAI (<a href="https://emarketingai.pl">https://emarketingai.pl</a>) respects your right
+      to control your personal data. This page explains how to request deletion of your data,
+      including any data obtained from connected accounts such as Instagram or Facebook.
+    </p>
+
+    <h2>Option 1 — Disconnect a single account</h2>
+    <p>
+      If you only want to remove the data associated with a connected platform (for example your
+      Instagram or Facebook connection), you can revoke it yourself at any time:
+    </p>
+    <ol>
+      <li>Sign in to eMarketingAI.</li>
+      <li>Go to <strong>Settings → Integrations</strong>.</li>
+      <li>Select the connected account and click <strong>Disconnect / Remove</strong>.</li>
+    </ol>
+    <p>
+      This immediately deletes the stored access tokens and platform profile data for that account.
+      You can also remove eMarketingAI directly from your
+      <a href="https://www.facebook.com/settings?tab=business_tools">Facebook</a> or Instagram
+      "Apps and Websites" settings.
+    </p>
+
+    <h2>Option 2 — Delete your entire account and data</h2>
+    <p>
+      To permanently delete your eMarketingAI account and all associated personal data, submit a
+      request as described below:
+    </p>
+
+    <div class="card">
+      <strong>By email</strong>
+      <p style="margin:8px 0 0;">
+        Send an email to
+        <a href="mailto:perevertkinma@gmail.com?subject=Data%20Deletion%20Request">perevertkinma@gmail.com</a>
+        from the email address registered to your account, with the subject
+        <code>Data Deletion Request</code>. Please include your account email so we can verify
+        ownership.
+      </p>
+    </div>
+
+    <h2>What gets deleted</h2>
+    <ul>
+      <li>Your account profile (name, email, credentials, preferences).</li>
+      <li>Access and refresh tokens for all connected accounts (Instagram, Facebook, LinkedIn, Google, etc.).</li>
+      <li>Profile data retrieved from connected platforms.</li>
+      <li>Content, projects, campaigns, analytics and other data you created in the platform.</li>
+    </ul>
+
+    <h2>Timeline</h2>
+    <p>
+      We confirm receipt of your request within 5 business days and complete deletion within
+      <strong>30 days</strong>. Some information may be retained only where required by law
+      (for example, billing records for tax purposes). Backups are purged on our regular rotation
+      cycle.
+    </p>
+
+    <h2>Contact</h2>
+    <p>
+      Questions about data deletion? Email
+      <a href="mailto:perevertkinma@gmail.com">perevertkinma@gmail.com</a>.
+      See also our <a href="https://emarketingai.pl/privacy.html">Privacy Policy</a>.
+    </p>
+
+    <footer>
+      © 2026 eMarketingAI — <a href="https://emarketingai.pl">emarketingai.pl</a> ·
+      <a href="https://emarketingai.pl/privacy.html">Privacy Policy</a>
+    </footer>
+  </div>
+</body>
+</html>

--- a/apps/web/static/privacy.html
+++ b/apps/web/static/privacy.html
@@ -1,0 +1,178 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="robots" content="index, follow" />
+  <title>Privacy Policy — eMarketingAI</title>
+  <style>
+    :root { --ink:#1e293b; --muted:#64748b; --accent:#6d28d9; --line:#e2e8f0; }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      color: var(--ink);
+      line-height: 1.65;
+      background: #f8fafc;
+    }
+    .wrap { max-width: 820px; margin: 0 auto; padding: 48px 24px 96px; }
+    header { border-bottom: 1px solid var(--line); padding-bottom: 24px; margin-bottom: 32px; }
+    .brand { display: inline-flex; align-items: center; gap: 10px; font-weight: 700; font-size: 18px; color: var(--accent); text-decoration: none; }
+    .brand span { color: var(--ink); }
+    h1 { font-size: 32px; margin: 24px 0 4px; }
+    h2 { font-size: 21px; margin: 40px 0 8px; }
+    h3 { font-size: 17px; margin: 24px 0 4px; }
+    .muted { color: var(--muted); font-size: 14px; }
+    a { color: var(--accent); }
+    ul { padding-left: 22px; }
+    li { margin: 6px 0; }
+    code { background: #ede9fe; padding: 1px 6px; border-radius: 4px; font-size: 90%; }
+    footer { margin-top: 64px; padding-top: 24px; border-top: 1px solid var(--line); color: var(--muted); font-size: 14px; }
+    table { border-collapse: collapse; width: 100%; margin: 12px 0; font-size: 14px; }
+    th, td { border: 1px solid var(--line); padding: 8px 12px; text-align: left; vertical-align: top; }
+    th { background: #f1f5f9; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <a class="brand" href="https://emarketingai.pl">eMarketing<span>AI</span></a>
+    </header>
+
+    <h1>Privacy Policy</h1>
+    <p class="muted">Last updated: 27 June 2026</p>
+
+    <p>
+      This Privacy Policy explains how <strong>eMarketingAI</strong> ("we", "us", "the Service"),
+      available at <a href="https://emarketingai.pl">https://emarketingai.pl</a>, collects, uses,
+      stores and protects your personal data when you use our marketing automation platform.
+      By creating an account or connecting a third-party service, you agree to the practices
+      described here.
+    </p>
+
+    <h2>1. Who we are</h2>
+    <p>
+      eMarketingAI is an AI-assisted marketing platform that helps users plan, create, schedule and
+      analyse marketing content across connected channels (social networks, search, email).
+      For any privacy-related question you can contact us at
+      <a href="mailto:perevertkinma@gmail.com">perevertkinma@gmail.com</a>.
+    </p>
+
+    <h2>2. Data we collect</h2>
+    <table>
+      <tr><th>Category</th><th>Examples</th></tr>
+      <tr>
+        <td>Account data</td>
+        <td>Name, email address, hashed password, organization and project details, language preference.</td>
+      </tr>
+      <tr>
+        <td>Connected-account credentials</td>
+        <td>OAuth access and refresh tokens for services you choose to connect (Instagram, Meta/Facebook, LinkedIn, Google Search Console, Google Play). Tokens are stored encrypted (AES-256) and used only to act on your behalf.</td>
+      </tr>
+      <tr>
+        <td>Platform profile data</td>
+        <td>Basic profile information returned by a connected account (e.g. Instagram business account ID and username) needed to publish and read analytics.</td>
+      </tr>
+      <tr>
+        <td>Content and marketing data</td>
+        <td>Posts, drafts, checklists, documents, campaigns, email subscribers and analytics you create or import into the platform.</td>
+      </tr>
+      <tr>
+        <td>Usage data</td>
+        <td>Log data, device/browser information and basic analytics used to operate and secure the Service.</td>
+      </tr>
+      <tr>
+        <td>Billing data</td>
+        <td>Subscription and payment information processed by our payment provider (Stripe). We do not store full card numbers.</td>
+      </tr>
+    </table>
+
+    <h2>3. How we use your data</h2>
+    <ul>
+      <li>To provide, maintain and improve the Service.</li>
+      <li>To publish content and retrieve analytics from the third-party accounts you connect, strictly on your instruction.</li>
+      <li>To generate AI content suggestions you request.</li>
+      <li>To manage your account, subscription and billing.</li>
+      <li>To send transactional and service notifications (e.g. failed scheduled posts, reauthentication required).</li>
+      <li>To protect the Service against fraud, abuse and security incidents.</li>
+    </ul>
+
+    <h2>4. Meta / Instagram data</h2>
+    <p>
+      When you connect an Instagram or Facebook account, we use Meta's official APIs
+      (Instagram API with Instagram Login, Facebook Graph API). With your authorization we may:
+    </p>
+    <ul>
+      <li>Read your basic business/creator profile information;</li>
+      <li>Publish content (images, carousels) that you create in eMarketingAI;</li>
+      <li>Read insights and analytics for content you publish.</li>
+    </ul>
+    <p>
+      We request only the permissions needed for these features
+      (<code>instagram_business_basic</code>, <code>instagram_business_content_publish</code>).
+      We never post without your explicit action, and we do not sell or share this data with third
+      parties for advertising. You can revoke access at any time from your eMarketingAI integration
+      settings or directly in your Instagram/Facebook account settings.
+    </p>
+
+    <h2>5. Third-party services (sub-processors)</h2>
+    <p>We share data with the following providers only to the extent necessary to operate the Service:</p>
+    <ul>
+      <li><strong>Meta Platforms</strong> — publishing and analytics for connected Instagram/Facebook accounts.</li>
+      <li><strong>Google</strong> — Search Console and Google Play data for connected projects.</li>
+      <li><strong>LinkedIn</strong> — publishing for connected LinkedIn accounts.</li>
+      <li><strong>OpenAI</strong> — generating AI content you request (prompts and context you submit).</li>
+      <li><strong>Stripe</strong> — subscription billing and payment processing.</li>
+      <li><strong>Cloud hosting and email delivery providers</strong> — running the Service and sending transactional email.</li>
+    </ul>
+
+    <h2>6. Data retention</h2>
+    <p>
+      We keep your personal data for as long as your account is active and as needed to provide the
+      Service. Connected-account tokens are kept until you disconnect the account or delete your
+      account. When you delete your account, or submit a data deletion request, we delete or
+      anonymise your personal data within 30 days, except where retention is required by law.
+    </p>
+
+    <h2>7. Your rights</h2>
+    <p>
+      Depending on your jurisdiction (including the EU/EEA under the GDPR) you may have the right to
+      access, correct, export, restrict or delete your personal data, and to withdraw consent.
+      To exercise these rights, contact
+      <a href="mailto:perevertkinma@gmail.com">perevertkinma@gmail.com</a> or follow our
+      <a href="https://emarketingai.pl/data-deletion.html">data deletion instructions</a>.
+    </p>
+
+    <h2>8. Data security</h2>
+    <p>
+      We use industry-standard safeguards including encryption in transit (HTTPS), encryption at
+      rest for sensitive credentials (AES-256), access controls and the principle of least
+      privilege. No method of transmission or storage is 100% secure, but we work continuously to
+      protect your information.
+    </p>
+
+    <h2>9. Children</h2>
+    <p>
+      The Service is not directed to children under 16, and we do not knowingly collect their
+      personal data.
+    </p>
+
+    <h2>10. Changes to this policy</h2>
+    <p>
+      We may update this Privacy Policy from time to time. Material changes will be reflected by the
+      "Last updated" date above and, where appropriate, communicated to you.
+    </p>
+
+    <h2>11. Contact</h2>
+    <p>
+      Questions about this policy or your data? Email
+      <a href="mailto:perevertkinma@gmail.com">perevertkinma@gmail.com</a>.
+    </p>
+
+    <footer>
+      © 2026 eMarketingAI — <a href="https://emarketingai.pl">emarketingai.pl</a> ·
+      <a href="https://emarketingai.pl/data-deletion.html">Data Deletion</a>
+    </footer>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
Closes #96

## What

Adds two public, crawlable pages required by Meta App Review for the Instagram/Meta integration (#92):

- **`/privacy.html`** — Privacy Policy, including a dedicated Meta/Instagram section (requested permissions `instagram_business_basic` / `instagram_business_content_publish`, how data is used, no posting without user action, how to revoke).
- **`/data-deletion.html`** — User data deletion instructions (disconnect a single connected account via Settings → Integrations, or delete the whole account by email).

## Why static HTML instead of SvelteKit routes

The root `apps/web/src/routes/+layout.svelte` renders page content only after client-side i18n finishes loading (`{#if ready}`). A JS-less crawler — including Meta's App Review crawler and the Developer URL Debugger — would otherwise see only the loading spinner. Static files in `apps/web/static/` are served from the site root by adapter-node, with no auth gate and no JS dependency.

## URLs after deploy

- Privacy Policy URL: `https://emarketingai.pl/privacy.html`
- Data Deletion URL: `https://emarketingai.pl/data-deletion.html` (type: "URL with instructions")

## Remaining manual steps in Meta (not code)

- [ ] Upload App Icon (512×512–1024×1024) — no logo asset in the repo.
- [ ] Select App Category (Business).
- [x] Contact email already set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)