### PR TITLE
feat(threads): Threads publishing (OAuth + text/image/video posts)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,14 @@ GOOGLE_CALLBACK_URL="http://localhost:3000/auth/google/callback"
 INSTAGRAM_APP_ID="your-instagram-app-id"
 INSTAGRAM_APP_SECRET="your-instagram-app-secret"
 
+# Threads API
+# Required to connect Threads accounts via /settings/integrations.
+# In your Meta app: Threads use case -> "API setup" -> copy the THREADS app ID +
+# secret (distinct from the Facebook and Instagram credentials), and add the OAuth
+# redirect URI <API_URL>/api/meta/callback there.
+THREADS_APP_ID="your-threads-app-id"
+THREADS_APP_SECRET="your-threads-app-secret"
+
 # OpenAI
 OPENAI_API_KEY="sk-your-openai-api-key"
 OPENAI_MODEL="gpt-4o"

--- a/apps/api/src/meta-oauth/meta-oauth.controller.spec.ts
+++ b/apps/api/src/meta-oauth/meta-oauth.controller.spec.ts
@@ -31,6 +31,10 @@ describe('MetaOAuthController', () => {
             exchangeCode: jest.fn(),
             getLongLivedToken: jest.fn(),
             getInstagramUser: jest.fn(),
+            getThreadsAuthUrl: jest.fn().mockReturnValue('https://threads.net/oauth/authorize?test=1'),
+            exchangeThreadsCode: jest.fn(),
+            getThreadsLongLivedToken: jest.fn(),
+            getThreadsUser: jest.fn(),
           },
         },
         {
@@ -49,6 +53,8 @@ describe('MetaOAuthController', () => {
                 ENCRYPTION_KEY: TEST_ENCRYPTION_KEY,
                 INSTAGRAM_APP_ID: 'ig-app-123',
                 INSTAGRAM_APP_SECRET: 'ig-secret-123',
+                THREADS_APP_ID: 'th-app-123',
+                THREADS_APP_SECRET: 'th-secret-123',
               };
               return map[key];
             }),
@@ -113,6 +119,23 @@ describe('MetaOAuthController', () => {
         ],
       };
       expect(() => controller.getAuthUrl(user, 'INSTAGRAM', 'org-2')).toThrow(ForbiddenException);
+    });
+
+    it('returns { url } for THREADS for OWNER', () => {
+      const result = controller.getAuthUrl(mockUser('OWNER'), 'THREADS');
+      expect(result).toHaveProperty('url');
+      expect(metaService.getThreadsAuthUrl).toHaveBeenCalled();
+      expect(metaService.getInstagramAuthUrl).not.toHaveBeenCalled();
+    });
+
+    it('throws ServiceUnavailableException when Threads app credentials are not configured', () => {
+      const cfg = { get: jest.fn((k: string) => (k === 'ENCRYPTION_KEY' ? TEST_ENCRYPTION_KEY : undefined)) };
+      const ctrl = new MetaOAuthController(
+        { getThreadsAuthUrl: jest.fn() } as any,
+        { upsertOAuthAccount: jest.fn() } as any,
+        cfg as any,
+      );
+      expect(() => ctrl.getAuthUrl(mockUser('OWNER'), 'THREADS')).toThrow(ServiceUnavailableException);
     });
   });
 
@@ -207,6 +230,42 @@ describe('MetaOAuthController', () => {
       );
       expect(res.redirect).toHaveBeenCalledWith(
         expect.stringContaining('instagram=connected'),
+      );
+    });
+
+    it('THREADS happy path: upserts a THREADS account and redirects to threads=connected', async () => {
+      const ctrl = controller as any;
+      const validState: string = ctrl.signState({ organizationId: 'org-1', platform: 'THREADS' });
+
+      (metaService.exchangeThreadsCode as jest.Mock).mockResolvedValue({
+        access_token: 'short-token',
+        user_id: 'th-123',
+      });
+      (metaService.getThreadsLongLivedToken as jest.Mock).mockResolvedValue({
+        access_token: 'long-token',
+        expires_in: 5184000,
+      });
+      (metaService.getThreadsUser as jest.Mock).mockResolvedValue({
+        threadsUserId: 'th-123',
+        username: 'threadsuser',
+        profilePictureUrl: 'https://example.com/pic.jpg',
+      });
+
+      const res = mockRes();
+      await controller.callback('auth-code', validState, res as any);
+
+      expect(socialService.upsertOAuthAccount).toHaveBeenCalledWith(
+        'org-1',
+        expect.objectContaining({
+          platform: 'THREADS',
+          accountId: 'th-123',
+          accountName: 'threadsuser',
+          tokens: expect.objectContaining({ accessToken: 'long-token', threadsUserId: 'th-123' }),
+        }),
+      );
+      expect(metaService.getInstagramUser).not.toHaveBeenCalled();
+      expect(res.redirect).toHaveBeenCalledWith(
+        expect.stringContaining('threads=connected'),
       );
     });
   });

--- a/apps/api/src/meta-oauth/meta-oauth.controller.ts
+++ b/apps/api/src/meta-oauth/meta-oauth.controller.ts
@@ -71,7 +71,20 @@ export class MetaOAuthController {
       throw new ForbiddenException('Only OWNER or ADMIN can connect social accounts');
     }
     const orgId = membership.organizationId;
-    if (platform !== 'INSTAGRAM') throw new BadRequestException('Unsupported platform');
+    if (platform !== 'INSTAGRAM' && platform !== 'THREADS') {
+      throw new BadRequestException('Unsupported platform');
+    }
+
+    if (platform === 'THREADS') {
+      if (!this.config.get('THREADS_APP_ID') || !this.config.get('THREADS_APP_SECRET')) {
+        throw new ServiceUnavailableException(
+          'Threads integration is not configured on this server yet. An administrator must set THREADS_APP_ID and THREADS_APP_SECRET.',
+        );
+      }
+      const state = this.signState({ organizationId: orgId, platform });
+      return { url: this.metaService.getThreadsAuthUrl(this.redirectUri(), state) };
+    }
+
     if (!this.config.get('INSTAGRAM_APP_ID') || !this.config.get('INSTAGRAM_APP_SECRET')) {
       throw new ServiceUnavailableException(
         'Instagram integration is not configured on this server yet. An administrator must set INSTAGRAM_APP_ID and INSTAGRAM_APP_SECRET.',
@@ -85,13 +98,38 @@ export class MetaOAuthController {
   @Public()
   async callback(@Query('code') code: string, @Query('state') state: string, @Res() res: Response) {
     const webUrl = (this.config.get('WEB_URL') || 'http://localhost:5173').replace(/\/$/, '');
-    const fail = (reason: string) => res.redirect(`${webUrl}/settings/integrations?instagram=error&reason=${reason}`);
 
     const parsed = this.verifyState(state);
+    const queryKey = parsed?.platform === 'THREADS' ? 'threads' : 'instagram';
+    const fail = (reason: string) =>
+      res.redirect(`${webUrl}/settings/integrations?${queryKey}=error&reason=${reason}`);
+
     if (!parsed) return fail('bad_state');
     if (!code) return fail('no_code');
 
     try {
+      if (parsed.platform === 'THREADS') {
+        const short = await this.metaService.exchangeThreadsCode(code, this.redirectUri());
+        const long = await this.metaService.getThreadsLongLivedToken(short.access_token);
+        const user = await this.metaService.getThreadsUser(long.access_token);
+        if (!user) return fail('no_threads_account');
+
+        await this.socialService.upsertOAuthAccount(parsed.organizationId, {
+          platform: 'THREADS',
+          accountId: user.threadsUserId,
+          accountName: user.username,
+          profileImageUrl: user.profilePictureUrl,
+          tokens: {
+            accessToken: long.access_token,
+            threadsUserId: user.threadsUserId,
+          },
+          scopes: ['threads_basic', 'threads_content_publish'],
+          expiresAt: long.expires_in ? new Date(Date.now() + long.expires_in * 1000) : null,
+        });
+
+        return res.redirect(`${webUrl}/settings/integrations?threads=connected`);
+      }
+
       const short = await this.metaService.exchangeCode(code, this.redirectUri());
       const long = await this.metaService.getLongLivedToken(short.access_token);
       const ig = await this.metaService.getInstagramUser(long.access_token);

--- a/apps/api/src/meta-oauth/meta-oauth.service.spec.ts
+++ b/apps/api/src/meta-oauth/meta-oauth.service.spec.ts
@@ -105,4 +105,93 @@ describe('MetaOAuthService (Instagram Login)', () => {
     global.fetch = jest.fn().mockResolvedValue({ ok: false, text: async () => 'bad token' }) as any;
     await expect(service.getInstagramUser('t')).rejects.toThrow(/Instagram \/me failed/);
   });
+
+  // ─── Threads ───────────────────────────────────────────────────────────────
+
+  describe('Threads', () => {
+    beforeEach(() => {
+      config.get.mockImplementation(
+        (k: string) =>
+          ({ THREADS_APP_ID: 'th-app-123', THREADS_APP_SECRET: 'th-secret-123' } as Record<string, string>)[k],
+      );
+    });
+
+    it('builds a Threads authorization URL with threads scopes, client_id and state', () => {
+      const url = service.getThreadsAuthUrl('https://api.test/api/meta/callback', 'STATE');
+      expect(url).toContain('https://threads.net/oauth/authorize');
+      expect(url).toContain('client_id=th-app-123');
+      expect(url).toContain('state=STATE');
+      const decoded = decodeURIComponent(url);
+      expect(decoded).toContain('threads_basic');
+      expect(decoded).toContain('threads_content_publish');
+      expect(url).not.toContain('facebook.com');
+      expect(url).not.toContain('instagram.com');
+    });
+
+    it('exchangeThreadsCode POSTs to graph.threads.net and returns access_token + user_id (stringified)', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ access_token: 'short-tok', user_id: 9988 }),
+      }) as any;
+
+      const result = await service.exchangeThreadsCode('the-code', 'https://api.test/api/meta/callback');
+      expect(result).toEqual({ access_token: 'short-tok', user_id: '9988' });
+      const [calledUrl, init] = (global.fetch as jest.Mock).mock.calls[0];
+      expect(calledUrl).toBe('https://graph.threads.net/oauth/access_token');
+      expect(init.method).toBe('POST');
+      expect(init.body.toString()).toContain('grant_type=authorization_code');
+    });
+
+    it('exchangeThreadsCode throws on a non-ok response', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, text: async () => 'bad code' }) as any;
+      await expect(service.exchangeThreadsCode('c', 'r')).rejects.toThrow(/Threads code exchange failed/);
+    });
+
+    it('exchangeThreadsCode throws when THREADS_APP_ID is missing', async () => {
+      config.get.mockImplementation((k: string) => (k === 'THREADS_APP_SECRET' ? 's' : undefined));
+      await expect(service.exchangeThreadsCode('c', 'r')).rejects.toThrow(/THREADS_APP_ID not configured/);
+    });
+
+    it('getThreadsLongLivedToken GETs graph.threads.net with th_exchange_token', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ access_token: 'long-tok', expires_in: 5184000 }),
+      }) as any;
+
+      const result = await service.getThreadsLongLivedToken('short-tok');
+      expect(result).toEqual({ access_token: 'long-tok', expires_in: 5184000 });
+      const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('https://graph.threads.net/access_token');
+      expect(calledUrl).toContain('grant_type=th_exchange_token');
+    });
+
+    it('getThreadsLongLivedToken throws on a non-ok response', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, text: async () => 'err' }) as any;
+      await expect(service.getThreadsLongLivedToken('x')).rejects.toThrow(
+        /Threads long-lived token exchange failed/,
+      );
+    });
+
+    it('getThreadsUser maps id/threads_profile_picture_url from graph.threads.net/me', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: '9988', username: 'brand', threads_profile_picture_url: 'http://x/p.jpg' }),
+      }) as any;
+
+      const result = await service.getThreadsUser('long-tok');
+      expect(result).toEqual({ threadsUserId: '9988', username: 'brand', profilePictureUrl: 'http://x/p.jpg' });
+      const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+      expect(calledUrl).toContain('https://graph.threads.net/me');
+    });
+
+    it('getThreadsUser returns null when username is missing', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ id: '1' }) }) as any;
+      expect(await service.getThreadsUser('t')).toBeNull();
+    });
+
+    it('getThreadsUser throws on a non-ok response', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, text: async () => 'bad token' }) as any;
+      await expect(service.getThreadsUser('t')).rejects.toThrow(/Threads \/me failed/);
+    });
+  });
 });

--- a/apps/api/src/meta-oauth/meta-oauth.service.ts
+++ b/apps/api/src/meta-oauth/meta-oauth.service.ts
@@ -15,6 +15,13 @@ const INSTAGRAM_SCOPES = [
   'instagram_business_manage_insights',
 ];
 
+// Threads API. OAuth authorize via threads.net, Graph calls via graph.threads.net.
+// Uses the Threads app ID/secret (distinct from both the Facebook and Instagram credentials).
+const THREADS_OAUTH = 'https://threads.net/oauth';
+const THREADS_GRAPH = 'https://graph.threads.net';
+
+const THREADS_SCOPES = ['threads_basic', 'threads_content_publish'];
+
 @Injectable()
 export class MetaOAuthService {
   private readonly logger = new Logger(MetaOAuthService.name);
@@ -90,5 +97,78 @@ export class MetaOAuthService {
     const igUserId = String(data.user_id ?? data.id ?? '');
     if (!igUserId || !data.username) return null;
     return { igUserId, username: data.username, profilePictureUrl: data.profile_picture_url };
+  }
+
+  // ─── Threads ───────────────────────────────────────────────────────────────
+
+  private threadsCreds(): { clientId: string; clientSecret: string } {
+    const clientId = this.config.get<string>('THREADS_APP_ID');
+    const clientSecret = this.config.get<string>('THREADS_APP_SECRET');
+    if (!clientId) throw new Error('THREADS_APP_ID not configured');
+    if (!clientSecret) throw new Error('THREADS_APP_SECRET not configured');
+    return { clientId, clientSecret };
+  }
+
+  getThreadsAuthUrl(redirectUri: string, state: string): string {
+    const { clientId } = this.threadsCreds();
+    const params = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      response_type: 'code',
+      scope: THREADS_SCOPES.join(','),
+      state,
+    });
+    return `${THREADS_OAUTH}/authorize?${params}`;
+  }
+
+  /** Exchange the auth code for a short-lived token. Returns the token + Threads user id. */
+  async exchangeThreadsCode(code: string, redirectUri: string): Promise<{ access_token: string; user_id: string }> {
+    const { clientId, clientSecret } = this.threadsCreds();
+    const body = new URLSearchParams({
+      client_id: clientId,
+      client_secret: clientSecret,
+      grant_type: 'authorization_code',
+      redirect_uri: redirectUri,
+      code,
+    });
+    const res = await fetch(`${THREADS_GRAPH}/oauth/access_token`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+    if (!res.ok) throw new Error(`Threads code exchange failed: ${await res.text()}`);
+    const data = (await res.json()) as { access_token: string; user_id?: number | string };
+    return { access_token: data.access_token, user_id: String(data.user_id ?? '') };
+  }
+
+  /** Exchange a short-lived token for a long-lived (60-day) token. */
+  async getThreadsLongLivedToken(shortLivedToken: string): Promise<{ access_token: string; expires_in: number }> {
+    const { clientSecret } = this.threadsCreds();
+    const params = new URLSearchParams({
+      grant_type: 'th_exchange_token',
+      client_secret: clientSecret,
+      access_token: shortLivedToken,
+    });
+    const res = await fetch(`${THREADS_GRAPH}/access_token?${params}`);
+    if (!res.ok) throw new Error(`Threads long-lived token exchange failed: ${await res.text()}`);
+    return res.json() as Promise<{ access_token: string; expires_in: number }>;
+  }
+
+  /** Fetch the connected Threads account profile. Returns null if the profile is incomplete. */
+  async getThreadsUser(
+    accessToken: string,
+  ): Promise<{ threadsUserId: string; username: string; profilePictureUrl?: string } | null> {
+    const params = new URLSearchParams({
+      fields: 'id,username,threads_profile_picture_url',
+      access_token: accessToken,
+    });
+    const res = await fetch(`${THREADS_GRAPH}/me?${params}`);
+    if (!res.ok) throw new Error(`Threads /me failed: ${await res.text()}`);
+    const data = (await res.json()) as {
+      id?: string; username?: string; threads_profile_picture_url?: string;
+    };
+    const threadsUserId = String(data.id ?? '');
+    if (!threadsUserId || !data.username) return null;
+    return { threadsUserId, username: data.username, profilePictureUrl: data.threads_profile_picture_url };
   }
 }

--- a/apps/api/src/social/social.service.spec.ts
+++ b/apps/api/src/social/social.service.spec.ts
@@ -234,6 +234,84 @@ describe('SocialService.publishToInstagram', () => {
   });
 });
 
+describe('SocialService.publishToThreads', () => {
+  let service: SocialService;
+  const prisma = { socialAccount: { update: jest.fn().mockResolvedValue({}) } } as any;
+  const config = { get: jest.fn().mockReturnValue('https://app.example.com') } as any;
+  const notifier = { report: jest.fn().mockResolvedValue(undefined) } as any;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        SocialService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: ConfigService, useValue: config },
+        { provide: CronFailureNotifier, useValue: notifier },
+      ],
+    }).compile();
+    service = mod.get(SocialService);
+    jest.spyOn(SocialService.prototype as any, 'decryptTokens')
+      .mockReturnValue({ accessToken: 'th-tok', threadsUserId: 'th1' });
+  });
+
+  it('publishes a text-only post: creates a TEXT container then publishes it', async () => {
+    mockedAxios.post
+      .mockResolvedValueOnce({ data: { id: 'container1' } })  // /threads
+      .mockResolvedValueOnce({ data: { id: 'post1' } });      // /threads_publish
+    mockedAxios.get.mockResolvedValueOnce({ data: { permalink: 'https://threads.net/t/abc' } });
+
+    const result = await (service as any).publishToAccount(
+      { id: 'c1', body: 'just some thoughts', mediaUrls: [] },
+      { id: 'a1', organizationId: 'o1', platform: 'THREADS', encryptedTokens: '{}', status: 'ACTIVE' },
+    );
+
+    expect(result.status).toBe('PUBLISHED');
+    expect(result.platformPostId).toBe('post1');
+    expect(result.platformPostUrl).toBe('https://threads.net/t/abc');
+    const createCall = mockedAxios.post.mock.calls[0];
+    expect(createCall[0]).toContain('/th1/threads');
+    expect(createCall[1]).toMatchObject({ media_type: 'TEXT', text: 'just some thoughts' });
+    const publishCall = mockedAxios.post.mock.calls[1];
+    expect(publishCall[0]).toContain('/th1/threads_publish');
+    expect(publishCall[1]).toEqual({ creation_id: 'container1' });
+  });
+
+  it('publishes a single image post: IMAGE container with absolute image_url then publishes', async () => {
+    mockedAxios.post
+      .mockResolvedValueOnce({ data: { id: 'container1' } })  // /threads
+      .mockResolvedValueOnce({ data: { id: 'post1' } });      // /threads_publish
+    mockedAxios.get.mockResolvedValueOnce({ data: { permalink: 'https://threads.net/t/img' } });
+
+    const result = await (service as any).publishToAccount(
+      { id: 'c1', body: 'Look ![x](/uploads/images/x.png)', mediaUrls: [] },
+      { id: 'a1', organizationId: 'o1', platform: 'THREADS', encryptedTokens: '{}', status: 'ACTIVE' },
+    );
+
+    expect(result.status).toBe('PUBLISHED');
+    expect(result.platformPostId).toBe('post1');
+    const createCall = mockedAxios.post.mock.calls[0];
+    expect(createCall[0]).toContain('/th1/threads');
+    expect(createCall[1]).toMatchObject({ media_type: 'IMAGE', image_url: 'https://app.example.com/uploads/images/x.png' });
+  });
+
+  it('flips Threads account to REAUTH_REQUIRED and reports THREADS_TOKEN_EXPIRED on OAuthException', async () => {
+    const err: any = new Error('bad token');
+    err.response = { status: 400, data: { error: { code: 190, type: 'OAuthException', message: 'expired' } } };
+    mockedAxios.post.mockRejectedValue(err);
+
+    const result = await (service as any).publishToAccount(
+      { id: 'c1', body: 'hello threads', mediaUrls: [] },
+      { id: 'a1', organizationId: 'o1', platform: 'THREADS', accountName: 'brand', accountId: 'th1', encryptedTokens: '{}', status: 'ACTIVE' },
+    );
+    expect(result.status).toBe('FAILED');
+    expect(prisma.socialAccount.update).toHaveBeenCalledWith({ where: { id: 'a1' }, data: { status: 'REAUTH_REQUIRED' } });
+    expect(notifier.report).toHaveBeenCalledWith(
+      expect.objectContaining({ errorCode: 'THREADS_TOKEN_EXPIRED', resourceId: 'a1' }),
+    );
+  });
+});
+
 describe('SocialService.cancelPublication', () => {
   let service: SocialService;
   const prisma = {

--- a/apps/api/src/social/social.service.ts
+++ b/apps/api/src/social/social.service.ts
@@ -244,7 +244,7 @@ export class SocialService {
       return { status: 'FAILED', error: 'Account requires reauthentication' };
     }
     try {
-      const supported = ['LINKEDIN', 'TWITTER', 'FACEBOOK', 'TELEGRAM', 'INSTAGRAM'];
+      const supported = ['LINKEDIN', 'TWITTER', 'FACEBOOK', 'TELEGRAM', 'INSTAGRAM', 'THREADS'];
       if (!supported.includes(account.platform)) {
         throw new Error(`Publishing to ${account.platform} is not yet supported`);
       }
@@ -254,6 +254,7 @@ export class SocialService {
       else if (account.platform === 'TWITTER')   result = await this.publishToTwitter(content, tokens);
       else if (account.platform === 'FACEBOOK')  result = await this.publishToFacebook(content, tokens);
       else if (account.platform === 'INSTAGRAM') result = await this.publishToInstagram(content, tokens);
+      else if (account.platform === 'THREADS')   result = await this.publishToThreads(content, tokens);
       else                                       result = await this.publishToTelegram(content, tokens);
       return { status: 'PUBLISHED', platformPostId: result.postId, platformPostUrl: result.postUrl };
     } catch (err: any) {
@@ -262,7 +263,7 @@ export class SocialService {
 
       const metaCode = data?.error?.code;
       const isMetaTokenExpired =
-        ['FACEBOOK', 'INSTAGRAM'].includes(account.platform) &&
+        ['FACEBOOK', 'INSTAGRAM', 'THREADS'].includes(account.platform) &&
         (metaCode === 190 || data?.error?.type === 'OAuthException');
 
       if (isMetaTokenExpired) {
@@ -281,7 +282,12 @@ export class SocialService {
           resourceType: 'SocialAccount',
           resourceId: account.id,
           resourceLabel: `${account.platform}: ${account.accountName || account.accountId}`,
-          errorCode: account.platform === 'INSTAGRAM' ? 'IG_TOKEN_EXPIRED' : 'FB_TOKEN_EXPIRED',
+          errorCode:
+            account.platform === 'INSTAGRAM'
+              ? 'IG_TOKEN_EXPIRED'
+              : account.platform === 'THREADS'
+                ? 'THREADS_TOKEN_EXPIRED'
+                : 'FB_TOKEN_EXPIRED',
           error,
           actionUrl: `${webUrl}/settings/integrations`,
         });
@@ -645,6 +651,62 @@ export class SocialService {
       await new Promise((res) => setTimeout(res, delayMs));
     }
     throw new Error('Instagram media processing timed out');
+  }
+
+  private async publishToThreads(content: any, tokens: any) {
+    const GRAPH = 'https://graph.threads.net';
+    const userId = tokens.threadsUserId;
+    const token = tokens.accessToken;
+    if (!userId) throw new Error('Threads account not fully connected (missing threadsUserId)');
+
+    const { images, videos } = resolvePublishMedia(content, this.publicUrl);
+    const text = stripMarkdown(content.body || '').slice(0, 500);
+    const params = { access_token: token };
+
+    let createParams: Record<string, any>;
+    let isVideo = false;
+    if (videos.length > 0) {
+      createParams = { media_type: 'VIDEO', video_url: videos[0], text };
+      isVideo = true;
+    } else if (images.length > 0) {
+      createParams = { media_type: 'IMAGE', image_url: images[0], text };
+    } else {
+      // Threads allows text-only posts (unlike Instagram)
+      if (!text) throw new Error('Threads post requires text or media');
+      createParams = { media_type: 'TEXT', text };
+    }
+
+    const create = await axios.post(`${GRAPH}/${userId}/threads`, createParams, { params });
+    const creationId: string = create.data.id;
+
+    if (isVideo) {
+      await this.waitForThreadsContainer(creationId, token);
+    }
+
+    const publish = await axios.post(`${GRAPH}/${userId}/threads_publish`,
+      { creation_id: creationId }, { params });
+    const postId: string = publish.data?.id || '';
+
+    let postUrl = '';
+    try {
+      const info = await axios.get(`${GRAPH}/${postId}`, { params: { fields: 'permalink', access_token: token } });
+      postUrl = info.data?.permalink || '';
+    } catch {
+      // permalink is best-effort
+    }
+    return { postId, postUrl };
+  }
+
+  private async waitForThreadsContainer(creationId: string, token: string, maxAttempts = 20, delayMs = 3000): Promise<void> {
+    const GRAPH = 'https://graph.threads.net';
+    for (let i = 0; i < maxAttempts; i++) {
+      const r = await axios.get(`${GRAPH}/${creationId}`, { params: { fields: 'status', access_token: token } });
+      const status = r.data?.status;
+      if (status === 'FINISHED') return;
+      if (status === 'ERROR' || status === 'EXPIRED') throw new Error(`Threads media processing ${status}`);
+      await new Promise((res) => setTimeout(res, delayMs));
+    }
+    throw new Error('Threads media processing timed out');
   }
 
   private async publishToTelegram(content: any, tokens: any) {

--- a/apps/web/src/routes/(app)/settings/integrations/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/integrations/+page.svelte
@@ -53,6 +53,13 @@
       const reason = params.get('reason');
       showToast(reason === 'no_ig_account' ? $_('social.instagram.noAccount') : $_('social.instagram.error'), 'error');
       history.replaceState(null, '', window.location.pathname);
+    } else if (params.get('threads') === 'connected') {
+      showToast($_('social.threads.connected'), 'success');
+      history.replaceState(null, '', window.location.pathname);
+    } else if (params.get('threads') === 'error') {
+      const reason = params.get('reason');
+      showToast(reason === 'no_threads_account' ? $_('social.threads.noAccount') : $_('social.threads.error'), 'error');
+      history.replaceState(null, '', window.location.pathname);
     }
   });
 
@@ -235,6 +242,15 @@
     }
   }
 
+  async function connectThreads() {
+    try {
+      const result = await api.get<{ url: string }>('/meta/auth-url', { platform: 'THREADS', organizationId: $organizationIdStore });
+      window.location.href = result.url;
+    } catch (e: any) {
+      showToast(e.message || $_('social.threads.error'));
+    }
+  }
+
   async function disconnectAccount(id: string) {
     try {
       await api.delete(`/social/accounts/${id}`);
@@ -265,6 +281,7 @@
     FACEBOOK: `<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M24 12.073c0-6.627-5.373-12-12-12s-12 5.373-12 12c0 5.99 4.388 10.954 10.125 11.854v-8.385H7.078v-3.47h3.047V9.43c0-3.007 1.792-4.669 4.533-4.669 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874v2.25h3.328l-.532 3.47h-2.796v8.385C19.612 23.027 24 18.062 24 12.073z"/></svg>`,
     TELEGRAM: `<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M11.944 0A12 12 0 0 0 0 12a12 12 0 0 0 12 12 12 12 0 0 0 12-12A12 12 0 0 0 12 0a12 12 0 0 0-.056 0zm4.962 7.224c.1-.002.321.023.465.14a.506.506 0 0 1 .171.325c.016.093.036.306.02.472-.18 1.898-.962 6.502-1.36 8.627-.168.9-.499 1.201-.82 1.23-.696.065-1.225-.46-1.9-.902-1.056-.693-1.653-1.124-2.678-1.8-1.185-.78-.417-1.21.258-1.91.177-.184 3.247-2.977 3.307-3.23.007-.032.014-.15-.056-.212s-.174-.041-.249-.024c-.106.024-1.793 1.14-5.061 3.345-.48.33-.913.49-1.302.48-.428-.008-1.252-.241-1.865-.44-.752-.245-1.349-.374-1.297-.789.027-.216.325-.437.893-.663 3.498-1.524 5.83-2.529 6.998-3.014 3.332-1.386 4.025-1.627 4.476-1.635z"/></svg>`,
     INSTAGRAM: `<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 1 0 0 12.324 6.162 6.162 0 0 0 0-12.324zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.406-11.845a1.44 1.44 0 1 0 0 2.881 1.44 1.44 0 0 0 0-2.881z"/></svg>`,
+    THREADS: `<svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24"><path d="M12.186 24h-.007c-3.581-.024-6.334-1.205-8.184-3.509C2.35 18.44 1.5 15.586 1.472 12.01v-.017c.03-3.579.879-6.43 2.525-8.482C5.845 1.205 8.6.024 12.18 0h.014c2.746.02 5.043.725 6.826 2.098 1.677 1.29 2.858 3.13 3.509 5.467l-2.04.569c-1.104-3.96-3.898-5.984-8.304-6.015-2.91.022-5.11.936-6.54 2.717C4.307 6.504 3.616 8.914 3.589 12c.027 3.086.718 5.496 2.057 7.164 1.43 1.781 3.631 2.695 6.54 2.717 2.623-.02 4.358-.631 5.8-2.045 1.647-1.613 1.618-3.593 1.09-4.798-.31-.71-.873-1.3-1.634-1.75-.192 1.352-.622 2.446-1.284 3.272-.886 1.102-2.14 1.704-3.73 1.79-1.202.065-2.361-.218-3.259-.801-1.063-.689-1.685-1.74-1.752-2.964-.065-1.19.408-2.285 1.33-3.082.88-.76 2.119-1.207 3.583-1.291a13.853 13.853 0 0 1 3.02.142c-.126-.742-.375-1.332-.75-1.757-.513-.586-1.308-.883-2.359-.89h-.029c-.844 0-1.992.232-2.721 1.32L9.295 7.575c.98-1.452 2.568-2.246 4.476-2.246h.044c3.194.02 5.097 1.978 5.287 5.388.108.046.216.094.323.143 1.504.708 2.604 1.78 3.182 3.099.806 1.837.881 4.83-1.55 7.208-1.86 1.82-4.118 2.64-7.31 2.663Zm1.036-11.564c-.318 0-.64.01-.965.027-1.84.103-2.991.95-2.928 2.157.067 1.27 1.466 1.853 2.748 1.784 1.183-.064 2.751-.524 3.013-3.727a10.49 10.49 0 0 0-1.868-.241Z"/></svg>`,
   };
 
   const platformColor: Record<string, string> = {
@@ -273,6 +290,7 @@
     FACEBOOK: 'text-[#1877F2] bg-[#1877F2]/10',
     TELEGRAM: 'text-[#26A5E4] bg-[#26A5E4]/10',
     INSTAGRAM: 'text-[#E1306C] bg-[#E1306C]/10',
+    THREADS: 'text-white bg-black',
   };
 </script>
 
@@ -479,6 +497,55 @@
         {/each}
         <button on:click={connectInstagram} class="text-sm px-4 py-2 bg-[#E1306C] text-white rounded-lg hover:bg-[#c1255a] transition-colors duration-150 cursor-pointer font-medium self-start mt-1">
           {accounts.some(a => a.platform === 'INSTAGRAM') ? $_('social.addAnother') : $_('social.instagram.connect')}
+        </button>
+      </div>
+    </div>
+
+    <!-- Threads -->
+    <div class="bg-white rounded-xl border border-gray-200 p-5 mb-3">
+      <div class="flex items-center gap-3 mb-3">
+        <div class="w-10 h-10 rounded-lg {platformColor['THREADS']} flex items-center justify-center flex-shrink-0">
+          {@html platformIcon['THREADS']}
+        </div>
+        <div>
+          <div class="font-medium text-gray-900">Threads</div>
+          <div class="text-xs text-gray-500">{$_('social.threads.description')}</div>
+        </div>
+      </div>
+      <div class="flex flex-col gap-2">
+        {#each accounts.filter(a => a.platform === 'THREADS') as account}
+          <div class="flex flex-wrap items-center justify-between gap-2 p-2.5 rounded-lg border border-gray-100 bg-gray-50/50">
+            <div class="flex items-center gap-2 min-w-0">
+              {#if account.profileImageUrl}
+                <img src={account.profileImageUrl} alt={account.accountName} class="w-7 h-7 rounded-full flex-shrink-0" />
+              {/if}
+              <div class="flex flex-col min-w-0">
+                <div class="flex items-center gap-2">
+                  <span class="text-sm text-gray-800 font-medium truncate" title={account.accountName}>{account.accountName}</span>
+                  <span class="text-xs px-2 py-0.5 bg-green-100 text-green-700 rounded-full flex-shrink-0">{$_('social.connected')}</span>
+                </div>
+                <span class="text-xs text-gray-500 font-mono truncate" title={account.accountId}>{account.accountId}</span>
+              </div>
+            </div>
+            <div class="flex items-center gap-2 flex-shrink-0">
+              <select
+                bind:value={account.language}
+                on:change={() => updateAccountLanguage(account)}
+                class="text-sm border border-gray-300 rounded px-2 py-1 bg-white"
+              >
+                <option value="">{$_('social.noLanguage')}</option>
+                <option value="en">English</option>
+                <option value="pl">Polski</option>
+                <option value="ru">Русский</option>
+              </select>
+              <button on:click={() => disconnectingId = account.id} class="text-xs px-3 py-1.5 border border-red-200 text-red-500 rounded-lg hover:bg-red-50 transition-colors duration-150 cursor-pointer bg-white">
+                {$_('social.disconnect')}
+              </button>
+            </div>
+          </div>
+        {/each}
+        <button on:click={connectThreads} class="text-sm px-4 py-2 bg-black text-white rounded-lg hover:bg-gray-800 transition-colors duration-150 cursor-pointer font-medium self-start mt-1">
+          {accounts.some(a => a.platform === 'THREADS') ? $_('social.addAnother') : $_('social.threads.connect')}
         </button>
       </div>
     </div>

--- a/docs/superpowers/plans/2026-06-27-threads-publishing-phase-3.md
+++ b/docs/superpowers/plans/2026-06-27-threads-publishing-phase-3.md
@@ -1,0 +1,30 @@
+# Threads Publishing (Phase 3) Implementation Plan
+
+> SUB-SKILL: superpowers:subagent-driven-development. Part of #92. Design spec: `docs/superpowers/specs/2026-06-26-instagram-threads-design.md`.
+
+**Goal:** Connect a Threads account via OAuth and publish text/image/video posts through the existing `social/` publishing pipeline.
+
+**Architecture:** Mirror the Instagram-Login flow exactly, on Threads endpoints. Extend `meta-oauth` to handle the `THREADS` platform (separate app credentials + threads.net OAuth). Extend `SocialService` with `publishToThreads`. Threads appears automatically in the per-project "Social Networks" selector and the content publish flow. Add a Threads connect card to `/settings/integrations`.
+
+## Global Constraints
+- **Threads API:** OAuth authorize `https://threads.net/oauth/authorize` (scope `threads_basic,threads_content_publish`, `response_type=code`); token exchange `POST https://graph.threads.net/oauth/access_token` (returns `{access_token, user_id}`, short-lived 1h); long-lived `GET https://graph.threads.net/access_token?grant_type=th_exchange_token&client_secret=…&access_token=…` (60 days); profile `GET https://graph.threads.net/me?fields=id,username,threads_profile_picture_url`; publish create `POST https://graph.threads.net/{userId}/threads` (`media_type=TEXT|IMAGE|VIDEO`, `text`, `image_url`/`video_url`) then `POST https://graph.threads.net/{userId}/threads_publish` (`creation_id`). Video needs status polling like IG.
+- **Credentials:** `THREADS_APP_ID` / `THREADS_APP_SECRET` (the Threads use-case app id/secret in the Meta app, distinct from FACEBOOK_* and INSTAGRAM_*). Clean 503 when unconfigured.
+- **`THREADS` enum** already exists (PR #93) — no migration.
+- **Token payload:** `{ accessToken, threadsUserId }`; accountId = threadsUserId, accountName = username.
+- **Text limit** 500 chars; Threads ALLOWS text-only posts (unlike Instagram).
+- **OAuth state** HMAC-signed (existing); `state.platform` drives the callback branch. OWNER/ADMIN gate (existing).
+- GitHub artefacts English.
+
+## Tasks
+1. **MetaOAuthService Threads methods** — `getThreadsAuthUrl`, `exchangeThreadsCode` (→`{access_token,user_id}`), `getThreadsLongLivedToken`, `getThreadsUser` (→`{threadsUserId,username,profilePictureUrl}`), reading `THREADS_APP_ID/SECRET`; auth-error throwing like the IG methods. Service spec.
+2. **Controller** — `getAuthUrl` accepts `platform ∈ {INSTAGRAM, THREADS}`; per-platform unconfigured guard; `callback` branches on `state.platform`: THREADS → exchangeThreadsCode → getThreadsLongLivedToken → getThreadsUser → `upsertOAuthAccount(platform:'THREADS', tokens:{accessToken, threadsUserId}, scopes:['threads_basic','threads_content_publish'])`. Controller spec.
+3. **social.service `publishToThreads`** — add `'THREADS'` to supported list + switch; container→(poll if video)→publish; text from `stripMarkdown` capped 500; image/video from `resolvePublishMedia`; postUrl from `permalink` (GET `/{id}?fields=permalink`). Generalize the Meta token-expiry catch to include `THREADS`. Tests (text post, image post, reauth).
+4. **Frontend** — Threads connect card on `/settings/integrations` (mirror Instagram card; `connectThreads()` → `GET /meta/auth-url?platform=THREADS`), `platformIcon/Color['THREADS']`, `?threads=connected|error` toast handling, i18n `social.threads.*` en/pl/ru.
+
+## Out of scope / manual
+- Threads analytics (`/threads_insights`) — later.
+- Meta-side: get Threads app id/secret, add OAuth redirect URI `https://emarketingai.pl/api/meta/callback` under the Threads use case, App Review for production.
+
+## Verify
+- api meta-oauth + social tests green; api + web build clean.
+- Live: connect Threads (test user) → publish a text post.

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -855,6 +855,13 @@
       "connected": "Instagram connected successfully",
       "error": "Could not connect Instagram. Please try again.",
       "noAccount": "No Instagram Business account is linked to your Facebook Page."
+    },
+    "threads": {
+      "connect": "Connect Threads",
+      "description": "Connect a Threads account to publish text posts and threads.",
+      "connected": "Threads connected successfully",
+      "error": "Could not connect Threads. Please try again.",
+      "noAccount": "No Threads account is linked to this profile."
     }
   },
   "analytics": {

--- a/packages/i18n/src/locales/pl.json
+++ b/packages/i18n/src/locales/pl.json
@@ -835,6 +835,13 @@
       "connected": "Instagram połączony pomyślnie",
       "error": "Nie udało się połączyć Instagrama. Spróbuj ponownie.",
       "noAccount": "Żadne konto Instagram Business nie jest połączone z Twoją stroną na Facebooku."
+    },
+    "threads": {
+      "connect": "Połącz Threads",
+      "description": "Połącz konto Threads, aby publikować posty tekstowe i wątki.",
+      "connected": "Threads połączony pomyślnie",
+      "error": "Nie udało się połączyć Threads. Spróbuj ponownie.",
+      "noAccount": "Żadne konto Threads nie jest połączone z tym profilem."
     }
   },
   "analytics": {

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -949,6 +949,13 @@
       "connected": "Instagram успешно подключён",
       "error": "Не удалось подключить Instagram. Попробуйте снова.",
       "noAccount": "К вашей странице Facebook не привязан аккаунт Instagram Business."
+    },
+    "threads": {
+      "connect": "Подключить Threads",
+      "description": "Подключите аккаунт Threads для публикации текстовых постов и тредов.",
+      "connected": "Threads успешно подключён",
+      "error": "Не удалось подключить Threads. Попробуйте снова.",
+      "noAccount": "К этому профилю не привязан аккаунт Threads."
     }
   },
   "tracking": {


### PR DESCRIPTION
Phase 3 of #92 — Threads publishing. Completes the original three-part request (Instagram analytics ✓, Instagram posting ✓, **Threads posting** ✓).

## What's included
- **OAuth** (extends `meta-oauth`): Threads flow on `threads.net` / `graph.threads.net` — `getThreadsAuthUrl`, `exchangeThreadsCode`, `getThreadsLongLivedToken` (`th_exchange_token`), `getThreadsUser`. Scopes `threads_basic,threads_content_publish`. Creds `THREADS_APP_ID`/`THREADS_APP_SECRET` (distinct from FB/IG). Controller `getAuthUrl`/`callback` branch on `state.platform`; clean 503 when unconfigured; OWNER/ADMIN gate + HMAC-signed state reused.
- **Publishing** (`SocialService.publishToThreads`): text-only, single image, single video posts — container → (poll `status` for video via `waitForThreadsContainer`) → publish → permalink. Text capped 500. Wired into the existing publish dispatch + scheduler. Token-expiry generalized to THREADS (`THREADS_TOKEN_EXPIRED` → REAUTH_REQUIRED).
- **Frontend**: Threads connect card on `/settings/integrations` (toast feedback, `?threads=connected|error`), Threads icon/colour, i18n `social.threads.*` en/pl/ru. Threads appears automatically in the per-project "Social Networks" selector and the content publish flow.
- `THREADS` enum already existed (PR #93) — no migration.

## Tests / build
api meta-oauth + social: **58 passing**; api + web build clean; api + web lint clean.

## Deploy / config required (Meta side)
1. Get the **Threads app id + secret** (Meta app → Threads use case → API setup).
2. Add OAuth redirect URI `https://emarketingai.pl/api/meta/callback` there.
3. Set `THREADS_APP_ID` / `THREADS_APP_SECRET` in prod `.env.production` + recreate api container.
4. Add your Threads account as a tester until App Review.

## Out of scope
Threads analytics (`/threads_insights`), carousels — later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)