### PR TITLE
feat(meta-oauth): proactive Instagram/Threads token refresh cron

### DIFF
--- a/apps/api/src/mail/cron-failure-email.ts
+++ b/apps/api/src/mail/cron-failure-email.ts
@@ -5,7 +5,8 @@ export type CronName =
   | 'email-sequences'
   | 'google-play-sync'
   | 'gsc-sync'
-  | 'instagram-sync';
+  | 'instagram-sync'
+  | 'meta-token-refresh';
 
 export interface CronFailureEmailInput {
   language: string;
@@ -42,6 +43,7 @@ const STRINGS: Record<'en' | 'pl' | 'ru', Strings> = {
       'google-play-sync': 'Google Play sync',
       'gsc-sync': 'GSC rank sync',
       'instagram-sync': 'Instagram analytics sync',
+      'meta-token-refresh': 'Meta token refresh',
     },
     resourceLabel: 'Resource',
     errorLabel: 'Error',
@@ -61,6 +63,7 @@ const STRINGS: Record<'en' | 'pl' | 'ru', Strings> = {
       'google-play-sync': 'Synchronizacja Google Play',
       'gsc-sync': 'Synchronizacja pozycji z GSC',
       'instagram-sync': 'Synchronizacja analityki Instagram',
+      'meta-token-refresh': 'Odświeżanie tokenów Meta',
     },
     resourceLabel: 'Zasób',
     errorLabel: 'Błąd',
@@ -80,6 +83,7 @@ const STRINGS: Record<'en' | 'pl' | 'ru', Strings> = {
       'google-play-sync': 'Синхронизация Google Play',
       'gsc-sync': 'Синхронизация позиций из GSC',
       'instagram-sync': 'Синхронизация аналитики Instagram',
+      'meta-token-refresh': 'Обновление токенов Meta',
     },
     resourceLabel: 'Ресурс',
     errorLabel: 'Ошибка',

--- a/apps/api/src/meta-oauth/meta-oauth.module.ts
+++ b/apps/api/src/meta-oauth/meta-oauth.module.ts
@@ -1,11 +1,13 @@
 import { Module } from '@nestjs/common';
 import { MetaOAuthController } from './meta-oauth.controller';
 import { MetaOAuthService } from './meta-oauth.service';
+import { MetaTokenRefreshService } from './meta-token-refresh.service';
 import { SocialModule } from '../social/social.module';
+import { DatabaseModule } from '../database/database.module';
 
 @Module({
-  imports: [SocialModule],
+  imports: [SocialModule, DatabaseModule],
   controllers: [MetaOAuthController],
-  providers: [MetaOAuthService],
+  providers: [MetaOAuthService, MetaTokenRefreshService],
 })
 export class MetaOAuthModule {}

--- a/apps/api/src/meta-oauth/meta-oauth.service.spec.ts
+++ b/apps/api/src/meta-oauth/meta-oauth.service.spec.ts
@@ -194,4 +194,42 @@ describe('MetaOAuthService (Instagram Login)', () => {
       await expect(service.getThreadsUser('t')).rejects.toThrow(/Threads \/me failed/);
     });
   });
+
+  it('refreshInstagramToken GETs graph.instagram.com with ig_refresh_token and returns the body', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: 'new-ig-tok', expires_in: 5184000 }),
+    }) as any;
+
+    const result = await service.refreshInstagramToken('old-ig-tok');
+    expect(result).toEqual({ access_token: 'new-ig-tok', expires_in: 5184000 });
+    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+    expect(calledUrl).toContain('https://graph.instagram.com/refresh_access_token');
+    expect(calledUrl).toContain('grant_type=ig_refresh_token');
+    expect(calledUrl).toContain('access_token=old-ig-tok');
+  });
+
+  it('refreshInstagramToken throws on a non-ok response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, text: async () => 'expired' }) as any;
+    await expect(service.refreshInstagramToken('x')).rejects.toThrow(/Instagram token refresh failed/);
+  });
+
+  it('refreshThreadsToken GETs graph.threads.net with th_refresh_token and returns the body', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ access_token: 'new-th-tok', expires_in: 5184000 }),
+    }) as any;
+
+    const result = await service.refreshThreadsToken('old-th-tok');
+    expect(result).toEqual({ access_token: 'new-th-tok', expires_in: 5184000 });
+    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string;
+    expect(calledUrl).toContain('https://graph.threads.net/refresh_access_token');
+    expect(calledUrl).toContain('grant_type=th_refresh_token');
+    expect(calledUrl).toContain('access_token=old-th-tok');
+  });
+
+  it('refreshThreadsToken throws on a non-ok response', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, text: async () => 'expired' }) as any;
+    await expect(service.refreshThreadsToken('x')).rejects.toThrow(/Threads token refresh failed/);
+  });
 });

--- a/apps/api/src/meta-oauth/meta-oauth.service.ts
+++ b/apps/api/src/meta-oauth/meta-oauth.service.ts
@@ -81,6 +81,38 @@ export class MetaOAuthService {
     return res.json() as Promise<{ access_token: string; expires_in: number }>;
   }
 
+  /**
+   * Refresh a long-lived Instagram token (extends another ~60 days).
+   * The token must be at least 24h old and not yet expired. No client_secret needed.
+   */
+  async refreshInstagramToken(
+    longLivedToken: string,
+  ): Promise<{ access_token: string; expires_in: number }> {
+    const params = new URLSearchParams({
+      grant_type: 'ig_refresh_token',
+      access_token: longLivedToken,
+    });
+    const res = await fetch(`${IG_GRAPH}/refresh_access_token?${params}`);
+    if (!res.ok) throw new Error(`Instagram token refresh failed: ${await res.text()}`);
+    return res.json() as Promise<{ access_token: string; expires_in: number }>;
+  }
+
+  /**
+   * Refresh a long-lived Threads token (extends another ~60 days).
+   * The token must be at least 24h old and not yet expired. No client_secret needed.
+   */
+  async refreshThreadsToken(
+    longLivedToken: string,
+  ): Promise<{ access_token: string; expires_in: number }> {
+    const params = new URLSearchParams({
+      grant_type: 'th_refresh_token',
+      access_token: longLivedToken,
+    });
+    const res = await fetch(`${THREADS_GRAPH}/refresh_access_token?${params}`);
+    if (!res.ok) throw new Error(`Threads token refresh failed: ${await res.text()}`);
+    return res.json() as Promise<{ access_token: string; expires_in: number }>;
+  }
+
   /** Fetch the connected Instagram account profile. Returns null if the profile is incomplete. */
   async getInstagramUser(
     accessToken: string,

--- a/apps/api/src/meta-oauth/meta-token-refresh.service.spec.ts
+++ b/apps/api/src/meta-oauth/meta-token-refresh.service.spec.ts
@@ -1,0 +1,210 @@
+import { MetaTokenRefreshService } from './meta-token-refresh.service';
+import { encryptData, decryptData } from '../common/crypto.util';
+
+// Valid 64-char hex (32-byte) encryption key.
+const ENCRYPTION_KEY =
+  '0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef';
+
+const SIXTY_DAYS_SECONDS = 60 * 24 * 60 * 60;
+
+function makeEncryptedTokens(accessToken = 'old-long-lived-token'): string {
+  return encryptData(
+    { accessToken, igUserId: '17841400000000000' },
+    ENCRYPTION_KEY,
+  );
+}
+
+function makePrisma() {
+  return {
+    socialAccount: {
+      findMany: jest.fn().mockResolvedValue([]),
+      update: jest.fn().mockResolvedValue({}),
+    },
+  };
+}
+
+function makeConfig(overrides: Record<string, string> = {}) {
+  const values: Record<string, string> = {
+    ENCRYPTION_KEY,
+    WEB_URL: 'http://localhost:5173',
+    ...overrides,
+  };
+  return {
+    get: jest.fn((key: string, def?: string) => values[key] ?? def),
+  };
+}
+
+function makeNotifier() {
+  return { report: jest.fn().mockResolvedValue(undefined) };
+}
+
+function makeMeta() {
+  return {
+    refreshInstagramToken: jest.fn(),
+    refreshThreadsToken: jest.fn(),
+  };
+}
+
+function makeAccount(overrides: Partial<any> = {}) {
+  return {
+    id: 'acc_1',
+    organizationId: 'org_1',
+    platform: 'INSTAGRAM',
+    accountName: '@brand',
+    accountId: '17841400000000000',
+    encryptedTokens: makeEncryptedTokens(),
+    ...overrides,
+  };
+}
+
+describe('MetaTokenRefreshService', () => {
+  let prisma: ReturnType<typeof makePrisma>;
+  let config: ReturnType<typeof makeConfig>;
+  let notifier: ReturnType<typeof makeNotifier>;
+  let meta: ReturnType<typeof makeMeta>;
+  let service: MetaTokenRefreshService;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prisma = makePrisma();
+    config = makeConfig();
+    notifier = makeNotifier();
+    meta = makeMeta();
+    service = new MetaTokenRefreshService(
+      prisma as any,
+      config as any,
+      notifier as any,
+      meta as any,
+    );
+  });
+
+  describe('refreshAccount', () => {
+    it('INSTAGRAM: refreshes, re-encrypts the new token + sets ~60d expiry', async () => {
+      meta.refreshInstagramToken.mockResolvedValue({
+        access_token: 'new-ig-token',
+        expires_in: SIXTY_DAYS_SECONDS,
+      });
+
+      const before = Date.now();
+      const result = await service.refreshAccount(makeAccount());
+
+      expect(result).toEqual({ refreshed: true });
+      expect(meta.refreshInstagramToken).toHaveBeenCalledWith(
+        'old-long-lived-token',
+      );
+      expect(meta.refreshThreadsToken).not.toHaveBeenCalled();
+
+      const arg = prisma.socialAccount.update.mock.calls[0][0];
+      expect(arg.where).toEqual({ id: 'acc_1' });
+
+      // The re-encrypted payload must carry the NEW token, not plaintext.
+      expect(arg.data.encryptedTokens).not.toContain('new-ig-token');
+      const decrypted = decryptData(arg.data.encryptedTokens, ENCRYPTION_KEY);
+      expect(decrypted.accessToken).toBe('new-ig-token');
+      // igUserId preserved from the merge.
+      expect(decrypted.igUserId).toBe('17841400000000000');
+
+      // expiresAt ~60 days out.
+      const expiresAt: Date = arg.data.expiresAt;
+      const expectedMin = before + SIXTY_DAYS_SECONDS * 1000;
+      expect(expiresAt.getTime()).toBeGreaterThanOrEqual(expectedMin - 5000);
+      expect(expiresAt.getTime()).toBeLessThanOrEqual(
+        Date.now() + SIXTY_DAYS_SECONDS * 1000 + 5000,
+      );
+
+      expect(notifier.report).not.toHaveBeenCalled();
+    });
+
+    it('THREADS: calls refreshThreadsToken', async () => {
+      meta.refreshThreadsToken.mockResolvedValue({
+        access_token: 'new-th-token',
+        expires_in: SIXTY_DAYS_SECONDS,
+      });
+
+      const result = await service.refreshAccount(
+        makeAccount({ platform: 'THREADS' }),
+      );
+
+      expect(result).toEqual({ refreshed: true });
+      expect(meta.refreshThreadsToken).toHaveBeenCalledWith(
+        'old-long-lived-token',
+      );
+      expect(meta.refreshInstagramToken).not.toHaveBeenCalled();
+
+      const arg = prisma.socialAccount.update.mock.calls[0][0];
+      const decrypted = decryptData(arg.data.encryptedTokens, ENCRYPTION_KEY);
+      expect(decrypted.accessToken).toBe('new-th-token');
+    });
+
+    it('skips (no update) when the token payload has no accessToken', async () => {
+      const encryptedTokens = encryptData({ igUserId: 'x' }, ENCRYPTION_KEY);
+      const result = await service.refreshAccount(
+        makeAccount({ encryptedTokens }),
+      );
+      expect(result).toEqual({ refreshed: false });
+      expect(meta.refreshInstagramToken).not.toHaveBeenCalled();
+      expect(prisma.socialAccount.update).not.toHaveBeenCalled();
+    });
+
+    it('error path: flips to REAUTH_REQUIRED + reports IG_TOKEN_EXPIRED', async () => {
+      meta.refreshInstagramToken.mockRejectedValue(
+        new Error('Instagram token refresh failed: expired'),
+      );
+
+      const result = await service.refreshAccount(makeAccount());
+
+      expect(result).toEqual({ refreshed: false });
+      expect(prisma.socialAccount.update).toHaveBeenCalledWith({
+        where: { id: 'acc_1' },
+        data: { status: 'REAUTH_REQUIRED' },
+      });
+      expect(notifier.report).toHaveBeenCalledTimes(1);
+      const reported = notifier.report.mock.calls[0][0];
+      expect(reported).toMatchObject({
+        organizationId: 'org_1',
+        cronName: 'meta-token-refresh',
+        resourceType: 'SocialAccount',
+        resourceId: 'acc_1',
+        errorCode: 'IG_TOKEN_EXPIRED',
+      });
+      expect(reported.actionUrl).toContain('/settings/integrations');
+    });
+
+    it('error path for THREADS reports THREADS_TOKEN_EXPIRED', async () => {
+      meta.refreshThreadsToken.mockRejectedValue(new Error('boom'));
+
+      await service.refreshAccount(makeAccount({ platform: 'THREADS' }));
+
+      expect(notifier.report.mock.calls[0][0]).toMatchObject({
+        errorCode: 'THREADS_TOKEN_EXPIRED',
+      });
+    });
+  });
+
+  describe('handleCron', () => {
+    it('selects ACTIVE IG/Threads accounts expiring within the window and refreshes each', async () => {
+      meta.refreshInstagramToken.mockResolvedValue({
+        access_token: 'new-tok',
+        expires_in: SIXTY_DAYS_SECONDS,
+      });
+      prisma.socialAccount.findMany.mockResolvedValue([
+        makeAccount({ id: 'a1' }),
+        makeAccount({ id: 'a2', platform: 'THREADS' }),
+      ]);
+      meta.refreshThreadsToken.mockResolvedValue({
+        access_token: 'new-th',
+        expires_in: SIXTY_DAYS_SECONDS,
+      });
+
+      await service.handleCron();
+
+      const where = prisma.socialAccount.findMany.mock.calls[0][0].where;
+      expect(where.platform).toEqual({ in: ['INSTAGRAM', 'THREADS'] });
+      expect(where.status).toBe('ACTIVE');
+      expect(where.expiresAt.not).toBeNull();
+      expect(where.expiresAt.lte).toBeInstanceOf(Date);
+
+      expect(prisma.socialAccount.update).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/api/src/meta-oauth/meta-token-refresh.service.ts
+++ b/apps/api/src/meta-oauth/meta-token-refresh.service.ts
@@ -1,0 +1,171 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { ConfigService } from '@nestjs/config';
+import { PrismaService } from '../database/prisma.service';
+import { CronFailureNotifier } from '../common/cron-failure-notifier.service';
+import { MetaOAuthService } from './meta-oauth.service';
+import { decryptData, encryptData } from '../common/crypto.util';
+
+interface RefreshableAccount {
+  id: string;
+  organizationId: string;
+  platform: string;
+  accountName: string | null;
+  accountId: string | null;
+  encryptedTokens: string;
+}
+
+/**
+ * Proactively refreshes long-lived Instagram/Threads tokens before they expire
+ * (~60 days). Meta's refresh endpoints extend the token by another ~60 days as
+ * long as the current token is >24h old and not yet expired — so refreshing
+ * within a 10-day window keeps accounts alive indefinitely without re-auth.
+ *
+ * Mirrors `instagram-sync.service.ts`: daily cron, per-account try/catch, and a
+ * REAUTH_REQUIRED flip + CronFailureNotifier.report on failure.
+ */
+@Injectable()
+export class MetaTokenRefreshService {
+  private readonly logger = new Logger(MetaTokenRefreshService.name);
+
+  /** Refresh when the token is due to expire within 10 days. */
+  static readonly REFRESH_WINDOW_MS = 10 * 24 * 60 * 60 * 1000;
+
+  constructor(
+    private prisma: PrismaService,
+    private config: ConfigService,
+    private notifier: CronFailureNotifier,
+    private meta: MetaOAuthService,
+  ) {}
+
+  /**
+   * Core, testable unit: refresh one account's long-lived token. Decrypts the
+   * stored token, calls the platform refresh endpoint, re-encrypts and persists
+   * the new token + expiry. On failure, flips the account to REAUTH_REQUIRED and
+   * reports a cron failure.
+   */
+  async refreshAccount(account: RefreshableAccount): Promise<{ refreshed: boolean }> {
+    const encryptionKey = this.config.get<string>('ENCRYPTION_KEY', '');
+
+    let tokens: any;
+    try {
+      tokens = decryptData(account.encryptedTokens, encryptionKey);
+    } catch (e) {
+      this.logger.warn(
+        `Failed to decrypt tokens for ${account.platform} account ${account.id}: ${e}`,
+      );
+      return { refreshed: false };
+    }
+
+    if (!tokens?.accessToken) {
+      this.logger.warn(
+        `${account.platform} account ${account.id} has no accessToken — skipping`,
+      );
+      return { refreshed: false };
+    }
+
+    try {
+      const result =
+        account.platform === 'THREADS'
+          ? await this.meta.refreshThreadsToken(tokens.accessToken)
+          : account.platform === 'INSTAGRAM'
+            ? await this.meta.refreshInstagramToken(tokens.accessToken)
+            : null;
+
+      if (!result) {
+        // Unsupported platform — nothing to do.
+        return { refreshed: false };
+      }
+
+      tokens.accessToken = result.access_token;
+      const encryptedTokens = encryptData(tokens, encryptionKey);
+      await this.prisma.socialAccount.update({
+        where: { id: account.id },
+        data: {
+          encryptedTokens,
+          expiresAt: new Date(Date.now() + result.expires_in * 1000),
+        },
+      });
+
+      this.logger.log(
+        `Refreshed ${account.platform} token for account ${account.id}`,
+      );
+      return { refreshed: true };
+    } catch (error) {
+      await this.handleRefreshError(account, error);
+      return { refreshed: false };
+    }
+  }
+
+  /**
+   * Daily at 04:00. Selects ACTIVE Instagram/Threads accounts whose token is
+   * known to expire within REFRESH_WINDOW_MS and refreshes each in isolation.
+   */
+  @Cron('0 4 * * *')
+  async handleCron(): Promise<void> {
+    this.logger.log('Starting Meta (Instagram/Threads) token refresh');
+
+    const threshold = new Date(
+      Date.now() + MetaTokenRefreshService.REFRESH_WINDOW_MS,
+    );
+
+    const accounts = await this.prisma.socialAccount.findMany({
+      where: {
+        platform: { in: ['INSTAGRAM', 'THREADS'] },
+        status: 'ACTIVE',
+        expiresAt: { not: null, lte: threshold },
+      },
+    });
+
+    let refreshed = 0;
+    for (const account of accounts) {
+      try {
+        const result = await this.refreshAccount(account as RefreshableAccount);
+        if (result.refreshed) refreshed++;
+      } catch (error) {
+        // refreshAccount already handled its own reporting; swallow so a single
+        // failure doesn't abort refreshing the remaining accounts.
+        this.logger.error(
+          `Token refresh failed for account ${account.id}: ${error}`,
+        );
+      }
+    }
+
+    this.logger.log(
+      `Meta token refresh complete: ${refreshed}/${accounts.length} refreshed`,
+    );
+  }
+
+  private async handleRefreshError(
+    account: RefreshableAccount,
+    error: unknown,
+  ): Promise<void> {
+    this.logger.warn(
+      `${account.platform} token refresh failed for account ${account.id} — marking REAUTH_REQUIRED`,
+    );
+    await this.prisma.socialAccount
+      .update({
+        where: { id: account.id },
+        data: { status: 'REAUTH_REQUIRED' },
+      })
+      .catch(() => {});
+
+    const webUrl = (
+      this.config.get<string>('WEB_URL') || 'http://localhost:5173'
+    ).replace(/\/$/, '');
+
+    await this.notifier.report({
+      organizationId: account.organizationId,
+      cronName: 'meta-token-refresh',
+      resourceType: 'SocialAccount',
+      resourceId: account.id,
+      resourceLabel: `${account.platform}: ${account.accountName || account.accountId}`,
+      errorCode:
+        account.platform === 'THREADS'
+          ? 'THREADS_TOKEN_EXPIRED'
+          : 'IG_TOKEN_EXPIRED',
+      error: error instanceof Error ? error.message : String(error),
+      actionUrl: `${webUrl}/settings/integrations`,
+    });
+  }
+}


### PR DESCRIPTION
Reliability follow-up to the Instagram/Threads work (#92). Meta long-lived tokens expire ~60 days; today the only signal is reactive `REAUTH_REQUIRED`. This refreshes them before expiry so connected accounts don't silently die.

## What's included
- `MetaOAuthService.refreshInstagramToken` / `refreshThreadsToken` — `GET …/refresh_access_token?grant_type=ig_refresh_token|th_refresh_token` (no client secret; returns a fresh 60-day token).
- `MetaTokenRefreshService` — `@Cron('0 4 * * *')` daily. Selects ACTIVE INSTAGRAM/THREADS accounts whose `expiresAt` is within 10 days, refreshes each, re-encrypts the token payload (preserving igUserId/threadsUserId), updates `expiresAt`. On failure → `REAUTH_REQUIRED` + `CronFailureNotifier` (`IG_/THREADS_TOKEN_EXPIRED`). Registered in `meta-oauth.module`; `meta-token-refresh` added to the cron-failure notifier names (en/pl/ru).

## Tests / build
api meta-oauth: **46 passing** (refresh-method + cron service tests; the cron test decrypts the re-encrypted payload to assert the new token is stored, and covers the REAUTH error path). api build + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)