### PR TITLE
fix(api): allow THREADS in content platform validation

### DIFF
--- a/apps/api/src/content/dto/create-content.dto.ts
+++ b/apps/api/src/content/dto/create-content.dto.ts
@@ -30,7 +30,7 @@ export class CreateContentDto {
 
   @ApiPropertyOptional()
   @IsOptional()
-  @IsEnum(['TWITTER', 'LINKEDIN', 'FACEBOOK', 'INSTAGRAM', 'GOOGLE', 'TELEGRAM'])
+  @IsEnum(['TWITTER', 'LINKEDIN', 'FACEBOOK', 'INSTAGRAM', 'THREADS', 'GOOGLE', 'TELEGRAM'])
   platform?: string;
 
   @ApiPropertyOptional()


### PR DESCRIPTION
Backend follow-up to #103. The create-content DTO validated `platform` against a list missing THREADS, so selecting Threads gave "platform must be one of the following values: …". Adds THREADS to the allowed values (UpdateContentDto inherits it). Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)