### PR TITLE
fix(meta-oauth): reliable Threads user id (fixes 'missing threadsUserId')

### DIFF
--- a/apps/api/src/meta-oauth/meta-oauth.controller.ts
+++ b/apps/api/src/meta-oauth/meta-oauth.controller.ts
@@ -111,17 +111,25 @@ export class MetaOAuthController {
       if (parsed.platform === 'THREADS') {
         const short = await this.metaService.exchangeThreadsCode(code, this.redirectUri());
         const long = await this.metaService.getThreadsLongLivedToken(short.access_token);
-        const user = await this.metaService.getThreadsUser(long.access_token);
-        if (!user) return fail('no_threads_account');
+        // The token-exchange user_id is the authoritative Threads user id; /me is
+        // only used for the display name/avatar and can be flaky, so don't abort on it.
+        let user: { threadsUserId: string; username: string; profilePictureUrl?: string } | null = null;
+        try {
+          user = await this.metaService.getThreadsUser(long.access_token);
+        } catch (e: any) {
+          console.warn('[threads.callback] getThreadsUser failed, using token user_id', e?.message || e);
+        }
+        const threadsUserId = user?.threadsUserId || short.user_id;
+        if (!threadsUserId) return fail('no_threads_account');
 
         await this.socialService.upsertOAuthAccount(parsed.organizationId, {
           platform: 'THREADS',
-          accountId: user.threadsUserId,
-          accountName: user.username,
-          profileImageUrl: user.profilePictureUrl,
+          accountId: threadsUserId,
+          accountName: user?.username || `threads_${threadsUserId}`,
+          profileImageUrl: user?.profilePictureUrl,
           tokens: {
             accessToken: long.access_token,
-            threadsUserId: user.threadsUserId,
+            threadsUserId,
           },
           scopes: ['threads_basic', 'threads_content_publish'],
           expiresAt: long.expires_in ? new Date(Date.now() + long.expires_in * 1000) : null,


### PR DESCRIPTION
Publishing to Threads failed with "Threads account not fully connected (missing threadsUserId)". Root cause: the callback derived the Threads user id from `/me?fields=id`, which wasn't reliably returning it, so the account was stored without `threadsUserId`.

Fix: use the **token-exchange `user_id`** (returned by `exchangeThreadsCode`, guaranteed by the OAuth flow) as the authoritative `threadsUserId`. `/me` is now only used for the display name/avatar and no longer aborts the connect if it's flaky.

After deploy, affected users must **disconnect + reconnect Threads** to re-store the id.

api meta-oauth: 18 tests pass, build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)