### PR TITLE
Enterprise/2026 UI redesign — "Iris" (dark-first, semantic tokens, two-mode nav)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ docker/data/
 
 # stray screenshots from Win Snipping Tool
 Без имени*.png
+
+# Brainstorming visual companion
+.superpowers/

--- a/apps/web/scripts/iris-codemod.mjs
+++ b/apps/web/scripts/iris-codemod.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// Iris redesign codemod: migrate hardcoded neutral/`primary` Tailwind utilities
+// to semantic Iris tokens across the logged-in app + shared components.
+//
+// Scope: apps/web/src/routes/(app) and apps/web/src/lib (*.svelte).
+// Skipped: (auth) group, root +layout/+page, auth/callback (out of redesign scope).
+//
+// Safe by construction: each utility is matched as a whole class token with
+// boundary guards, longest/prefixed-first, with optional `/<opacity>` preserved
+// (except where the target already carries an opacity).
+//
+// Run: node apps/web/scripts/iris-codemod.mjs
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..'); // apps/web
+const targets = [join(root, 'src', 'routes', '(app)'), join(root, 'src', 'lib')];
+
+// from → to. keepOpacity=false when the target already includes an opacity suffix.
+const MAP = [
+  // prefixed / longest first
+  ['hover:bg-gray-50', 'hover:bg-surface-2'],
+  ['hover:bg-gray-100', 'hover:bg-surface-2'],
+  ['hover:bg-primary-700', 'hover:brightness-110'],
+  ['bg-primary-600', 'bg-brand'],
+  ['bg-primary-50', 'bg-brand-subtle/10', false],
+  ['text-primary-600', 'text-brand'],
+  ['text-primary-700', 'text-brand'],
+  // backgrounds
+  ['bg-gray-100', 'bg-surface-2'],
+  ['bg-gray-50', 'bg-surface-2'],
+  ['bg-white', 'bg-surface'],
+  // text
+  ['text-gray-900', 'text-ink'],
+  ['text-gray-800', 'text-ink'],
+  ['text-gray-700', 'text-ink'],
+  ['text-gray-600', 'text-ink-muted'],
+  ['text-gray-500', 'text-ink-muted'],
+  ['text-gray-400', 'text-ink-subtle'],
+  ['text-gray-300', 'text-ink-subtle'],
+  // borders / dividers
+  ['border-gray-200', 'border-border'],
+  ['border-gray-100', 'border-border'],
+  ['border-gray-300', 'border-border'],
+  ['divide-gray-200', 'divide-border'],
+  ['divide-gray-100', 'divide-border'],
+];
+
+const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+// leading: not preceded by a class-token char; trailing handled with optional /opacity
+const lead = '(?<![\\w:/\\[\\]._-])';
+const rules = MAP.map(([from, to, keepOpacity = true]) => {
+  const tail = keepOpacity
+    ? '(\\/\\d+)?(?![\\w\\[\\]._-])'
+    : '(?![\\w\\[\\]/._-])';
+  return {
+    re: new RegExp(lead + esc(from) + tail, 'g'),
+    to: keepOpacity ? to + '$1' : to,
+  };
+});
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    const st = statSync(p);
+    if (st.isDirectory()) walk(p, out);
+    else if (name.endsWith('.svelte')) out.push(p);
+  }
+  return out;
+}
+
+// Tokens now drive light+dark, so `dark:` neutral overrides on tokenized base
+// classes are redundant/conflicting. Strip them (keep `black` — used for modal
+// overlays — and gradient from/to/via stops untouched).
+const stripDark = /\s+dark:(?:hover:|focus:|group-hover:)?(?:bg|text|border|divide|ring|placeholder:text)-(?:gray|white|slate|zinc|neutral|stone)[-/0-9a-z]*/g;
+
+let totalFiles = 0;
+let totalReplacements = 0;
+for (const base of targets) {
+  for (const file of walk(base)) {
+    const src = readFileSync(file, 'utf8');
+    let out = src;
+    let count = 0;
+    for (const { re, to } of rules) {
+      out = out.replace(re, (_full, opacity) => {
+        count++;
+        return to.replace('$1', opacity || '');
+      });
+    }
+    out = out.replace(stripDark, () => { count++; return ''; });
+    // primary-50 family (any variant prefix, any opacity) → theme-aware brand tint
+    out = out.replace(/((?:[a-z-]+:)*)bg-primary-50(?:\/\d+)?(?![\w/])/g, (_m, pre) => {
+      count++;
+      return `${pre}bg-brand-subtle/10`;
+    });
+    if (out !== src) {
+      writeFileSync(file, out, 'utf8');
+      totalFiles++;
+      totalReplacements += count;
+      console.log(`${count.toString().padStart(4)}  ${file.replace(root, 'apps/web')}`);
+    }
+  }
+}
+console.log(`\nDone: ${totalReplacements} replacements across ${totalFiles} files.`);

--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1,18 +1,52 @@
-/* Google Fonts — Space Grotesk (display/headings) + DM Sans (body/UI) */
-@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&display=swap');
+/* Google Fonts — Space Grotesk (display/headings) + Inter (body/UI) */
+@import url('https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&family=Inter:wght@400;500;600;700&display=swap');
 
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
 @layer base {
+  /* ── Iris design tokens — light (RGB channel triplets for Tailwind alpha) ── */
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
-    --primary: 262.1 83.3% 57.8%;
-    --primary-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --radius: 0.5rem;
+    --canvas: 246 246 251;        /* #F6F6FB */
+    --surface: 255 255 255;       /* #FFFFFF */
+    --surface-2: 243 243 248;     /* #F3F3F8 */
+    --border: 236 236 244;        /* #ECECF4 */
+    --border-strong: 221 221 232; /* #DDDDE8 */
+    --text: 26 23 38;             /* #1A1726 */
+    --text-muted: 116 112 138;    /* #74708A */
+    --text-subtle: 152 147 168;   /* #9893A8 */
+    --brand: 91 61 232;           /* iris-600 #5B3DE8 */
+    --brand-fg: 255 255 255;
+    --brand-subtle: 238 240 255;  /* iris-50  #EEF0FF */
+    --brand-subtle-fg: 75 47 196; /* iris-700 #4B2FC4 */
+    --iris-700: 75 47 196;        /* gradient stop */
+    --ring: 110 86 240;           /* iris-500 #6E56F0 */
+    --ok: 22 163 74;              /* #16A34A */
+    --warn: 245 158 11;           /* #F59E0B */
+    --bad: 229 72 77;             /* #E5484D */
+    --radius: 0.625rem;           /* 10px */
+  }
+
+  /* ── Iris design tokens — dark (default interior theme) ── */
+  .dark {
+    --canvas: 11 11 20;           /* #0B0B14 */
+    --surface: 19 19 30;          /* #13131E */
+    --surface-2: 22 22 31;        /* #16161F */
+    --border: 32 32 46;           /* #20202E */
+    --border-strong: 42 42 58;    /* #2A2A3A */
+    --text: 237 237 246;          /* #EDEDF6 */
+    --text-muted: 148 148 174;    /* #9494AE */
+    --text-subtle: 108 108 134;   /* #6C6C86 */
+    --brand: 110 86 240;          /* iris-500 #6E56F0 (brighter for dark) */
+    --brand-fg: 255 255 255;
+    --brand-subtle: 110 86 240;   /* used at low alpha in dark */
+    --brand-subtle-fg: 201 194 255;
+    --iris-700: 75 47 196;
+    --ring: 138 130 251;          /* iris-400-ish */
+    --ok: 74 222 128;
+    --warn: 251 191 36;
+    --bad: 248 113 113;
   }
 
   /* Respect user's motion preferences */
@@ -26,13 +60,13 @@
 }
 
 * {
-  border-color: hsl(var(--border));
+  border-color: rgb(var(--border));
 }
 
 body {
-  font-family: 'DM Sans', system-ui, sans-serif;
-  background-color: hsl(var(--background));
-  color: hsl(var(--foreground));
+  font-family: 'Inter', system-ui, sans-serif;
+  background-color: rgb(var(--canvas));
+  color: rgb(var(--text));
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
@@ -50,11 +84,13 @@ h1, h2, h3, h4 {
 }
 
 .prose {
-  @apply text-gray-700 leading-relaxed;
+  color: rgb(var(--text-muted));
+  line-height: 1.7;
 }
 
 .prose h1, .prose h2, .prose h3 {
-  @apply font-semibold text-gray-900;
+  color: rgb(var(--text));
+  font-weight: 600;
   font-family: 'Space Grotesk', system-ui, sans-serif;
 }
 
@@ -70,9 +106,73 @@ h1, h2, h3, h4 {
   background: transparent;
 }
 .custom-scroll::-webkit-scrollbar-thumb {
-  background-color: #e5e7eb;
+  background-color: rgb(var(--border-strong));
   border-radius: 9999px;
 }
 .custom-scroll::-webkit-scrollbar-thumb:hover {
-  background-color: #d1d5db;
+  background-color: rgb(var(--text-subtle));
+}
+
+/* ── Iris component primitives ───────────────────────────────────────── */
+@layer components {
+  .btn {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold transition-colors duration-150 cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed;
+  }
+  .btn-primary {
+    @apply bg-brand text-brand-fg shadow-glow hover:brightness-110;
+  }
+  .btn-secondary {
+    @apply bg-surface text-ink border border-border hover:bg-surface-2;
+  }
+  .btn-ghost {
+    @apply text-ink-muted hover:bg-surface-2 hover:text-ink;
+  }
+  .btn-danger {
+    @apply bg-bad text-white hover:brightness-110;
+  }
+
+  .card {
+    @apply bg-surface border border-border rounded-xl;
+  }
+
+  .kpi {
+    @apply bg-surface border border-border rounded-xl p-4;
+  }
+  .kpi-feature {
+    @apply rounded-xl p-4 text-white;
+    background-image: linear-gradient(135deg, rgb(var(--brand)), rgb(var(--iris-700)));
+    box-shadow: 0 20px 50px -24px rgb(var(--brand) / 0.6);
+  }
+
+  .badge {
+    @apply inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold;
+  }
+  .badge-ok { @apply bg-ok/15 text-ok; }
+  .badge-warn { @apply bg-warn/15 text-warn; }
+  .badge-bad { @apply bg-bad/15 text-bad; }
+  .badge-brand { @apply bg-brand-subtle/15 text-brand-subtle-fg; }
+  .badge-neutral { @apply bg-surface-2 text-ink-muted; }
+
+  .input, .select, .textarea {
+    @apply w-full rounded-lg bg-surface border border-border text-ink placeholder:text-ink-subtle px-3 py-2 text-sm transition-colors duration-150 focus:outline-none focus:ring-2 focus:ring-ring/50 focus:border-brand;
+  }
+
+  .modal-overlay {
+    @apply fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-50 p-4;
+  }
+  .modal-panel {
+    @apply bg-surface border border-border rounded-2xl shadow-xl w-full;
+  }
+
+  .nav-item {
+    @apply flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium text-ink-muted hover:bg-surface-2 hover:text-ink transition-colors duration-150 cursor-pointer;
+  }
+  .nav-item.is-active {
+    @apply bg-brand-subtle/15 text-brand-subtle-fg font-semibold;
+    box-shadow: inset 2px 0 0 rgb(var(--brand));
+  }
+
+  .glow-brand {
+    box-shadow: 0 8px 20px -8px rgb(var(--brand) / 0.6);
+  }
 }

--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -7,14 +7,14 @@
     <meta name="description" content="AI-powered marketing automation platform" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="" />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">
     <script>
       (function() {
+        // Iris: interior defaults to dark unless the user explicitly chose light.
         var theme = localStorage.getItem('theme');
-        if (theme === 'dark' || (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+        if (theme !== 'light') {
           document.documentElement.classList.add('dark');
         }
       })();

--- a/apps/web/src/lib/components/DashboardKpiCards.svelte
+++ b/apps/web/src/lib/components/DashboardKpiCards.svelte
@@ -72,7 +72,7 @@
   function trendClass(trend: string | undefined): string {
     if (trend === 'up') return 'text-green-600';
     if (trend === 'down') return 'text-red-600';
-    return 'text-gray-400';
+    return 'text-ink-subtle';
   }
 
   function trendArrow(trend: string | undefined): string {
@@ -96,20 +96,20 @@
       { label: $_('dashboard.kpiSubscribers'), value: summary?.subscriberCount, icon: kpiIconSubs, bg: 'bg-emerald-50', fg: 'text-emerald-600' },
       { label: $_('dashboard.kpiSocialAccounts'), value: summary?.socialAccountCount, icon: kpiIconSocial, bg: 'bg-violet-50', fg: 'text-violet-600' },
     ] as card}
-      <div class="bg-white border border-gray-200 rounded-xl p-4 flex items-center gap-3">
+      <div class="bg-surface border border-border rounded-xl p-4 flex items-center gap-3">
         <div class="w-10 h-10 {card.bg} rounded-lg flex items-center justify-center flex-shrink-0">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 {card.fg}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8">
             <path stroke-linecap="round" stroke-linejoin="round" d={card.icon} />
           </svg>
         </div>
         <div class="min-w-0">
-          <p class="text-xs text-gray-500 truncate">{card.label}</p>
+          <p class="text-xs text-ink-muted truncate">{card.label}</p>
           {#if summaryLoading}
-            <div class="h-6 w-14 bg-gray-100 rounded animate-pulse mt-1"></div>
+            <div class="h-6 w-14 bg-surface-2 rounded animate-pulse mt-1"></div>
           {:else if summaryError}
-            <p class="text-base font-semibold text-gray-300">—</p>
+            <p class="text-base font-semibold text-ink-subtle">—</p>
           {:else}
-            <p class="text-xl font-bold text-gray-900">{formatNumber(card.value ?? 0)}</p>
+            <p class="text-xl font-bold text-ink">{formatNumber(card.value ?? 0)}</p>
           {/if}
         </div>
       </div>
@@ -117,14 +117,14 @@
   </div>
 
   <!-- Activity block -->
-  <div class="bg-white border border-gray-200 rounded-xl p-4">
+  <div class="bg-surface border border-border rounded-xl p-4">
     <div class="flex items-center justify-between flex-wrap gap-2 mb-4">
-      <h2 class="text-sm font-semibold text-gray-700">{$_('dashboard.activityTitle')}</h2>
-      <div class="inline-flex items-center border border-gray-200 rounded-lg overflow-hidden text-xs">
+      <h2 class="text-sm font-semibold text-ink">{$_('dashboard.activityTitle')}</h2>
+      <div class="inline-flex items-center border border-border rounded-lg overflow-hidden text-xs">
         {#each [{ v: 7, label: $_('analytics.period7') }, { v: 30, label: $_('analytics.period30') }, { v: 90, label: $_('analytics.period90') }] as opt}
           <button
             type="button"
-            class="px-3 py-1.5 transition-colors cursor-pointer {period === opt.v ? 'bg-primary-600 text-white' : 'text-gray-600 hover:bg-gray-50'}"
+            class="px-3 py-1.5 transition-colors cursor-pointer {period === opt.v ? 'bg-brand text-white' : 'text-ink-muted hover:bg-surface-2'}"
             on:click={() => setPeriod(opt.v as 7 | 30 | 90)}
           >
             {opt.label}
@@ -140,23 +140,23 @@
         { key: 'conversions', label: $_('analytics.conversions') },
         { key: 'emailOpens', label: $_('analytics.emailOpens') },
       ] as metric}
-        <div class="rounded-lg border border-gray-100 bg-gray-50/50 px-3 py-3">
-          <p class="text-xs text-gray-500 truncate">{metric.label}</p>
+        <div class="rounded-lg border border-border bg-surface-2/50 px-3 py-3">
+          <p class="text-xs text-ink-muted truncate">{metric.label}</p>
           {#if totalsLoading}
             <div class="h-6 w-16 bg-gray-200 rounded animate-pulse mt-1.5"></div>
-            <div class="h-3 w-10 bg-gray-100 rounded animate-pulse mt-2"></div>
+            <div class="h-3 w-10 bg-surface-2 rounded animate-pulse mt-2"></div>
           {:else if totalsError || !totals}
-            <p class="text-lg font-semibold text-gray-300 mt-1">—</p>
+            <p class="text-lg font-semibold text-ink-subtle mt-1">—</p>
           {:else}
-            <p class="text-lg font-bold text-gray-900 mt-1">{formatNumber(totals.total[metric.key] ?? 0)}</p>
+            <p class="text-lg font-bold text-ink mt-1">{formatNumber(totals.total[metric.key] ?? 0)}</p>
             <p class="text-xs mt-1 flex items-center gap-1 {trendClass(totals.trend[metric.key])}">
               <span>{trendArrow(totals.trend[metric.key])}</span>
               {#if (totals.change[metric.key] ?? 0) !== 0}
                 <span>{Math.abs(totals.change[metric.key] ?? 0)}%</span>
               {:else}
-                <span class="text-gray-400">{$_('analytics.noChange')}</span>
+                <span class="text-ink-subtle">{$_('analytics.noChange')}</span>
               {/if}
-              <span class="text-gray-400 ml-1 truncate">{$_('analytics.vsLastPeriod')}</span>
+              <span class="text-ink-subtle ml-1 truncate">{$_('analytics.vsLastPeriod')}</span>
             </p>
           {/if}
         </div>

--- a/apps/web/src/lib/components/DashboardKpiCards.svelte
+++ b/apps/web/src/lib/components/DashboardKpiCards.svelte
@@ -70,8 +70,8 @@
   }
 
   function trendClass(trend: string | undefined): string {
-    if (trend === 'up') return 'text-green-600';
-    if (trend === 'down') return 'text-red-600';
+    if (trend === 'up') return 'text-ok';
+    if (trend === 'down') return 'text-bad';
     return 'text-ink-subtle';
   }
 
@@ -91,10 +91,10 @@
   <!-- KPI block -->
   <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
     {#each [
-      { label: $_('dashboard.kpiTotalContent'), value: summary?.contentCountAll, icon: kpiIconContent, bg: 'bg-blue-50', fg: 'text-blue-600' },
-      { label: $_('dashboard.kpiCampaigns'), value: summary?.campaignCount, icon: kpiIconCampaign, bg: 'bg-amber-50', fg: 'text-amber-600' },
-      { label: $_('dashboard.kpiSubscribers'), value: summary?.subscriberCount, icon: kpiIconSubs, bg: 'bg-emerald-50', fg: 'text-emerald-600' },
-      { label: $_('dashboard.kpiSocialAccounts'), value: summary?.socialAccountCount, icon: kpiIconSocial, bg: 'bg-violet-50', fg: 'text-violet-600' },
+      { label: $_('dashboard.kpiTotalContent'), value: summary?.contentCountAll, icon: kpiIconContent, bg: 'bg-brand-subtle/12', fg: 'text-brand' },
+      { label: $_('dashboard.kpiCampaigns'), value: summary?.campaignCount, icon: kpiIconCampaign, bg: 'bg-warn/12', fg: 'text-warn' },
+      { label: $_('dashboard.kpiSubscribers'), value: summary?.subscriberCount, icon: kpiIconSubs, bg: 'bg-ok/12', fg: 'text-ok' },
+      { label: $_('dashboard.kpiSocialAccounts'), value: summary?.socialAccountCount, icon: kpiIconSocial, bg: 'bg-brand-subtle/12', fg: 'text-brand-subtle-fg' },
     ] as card}
       <div class="bg-surface border border-border rounded-xl p-4 flex items-center gap-3">
         <div class="w-10 h-10 {card.bg} rounded-lg flex items-center justify-center flex-shrink-0">
@@ -124,7 +124,7 @@
         {#each [{ v: 7, label: $_('analytics.period7') }, { v: 30, label: $_('analytics.period30') }, { v: 90, label: $_('analytics.period90') }] as opt}
           <button
             type="button"
-            class="px-3 py-1.5 transition-colors cursor-pointer {period === opt.v ? 'bg-brand text-white' : 'text-ink-muted hover:bg-surface-2'}"
+            class="px-3 py-1.5 transition-colors cursor-pointer {period === opt.v ? 'bg-brand text-brand-fg' : 'text-ink-muted hover:bg-surface-2'}"
             on:click={() => setPeriod(opt.v as 7 | 30 | 90)}
           >
             {opt.label}
@@ -143,7 +143,7 @@
         <div class="rounded-lg border border-border bg-surface-2/50 px-3 py-3">
           <p class="text-xs text-ink-muted truncate">{metric.label}</p>
           {#if totalsLoading}
-            <div class="h-6 w-16 bg-gray-200 rounded animate-pulse mt-1.5"></div>
+            <div class="h-6 w-16 bg-surface-2 rounded animate-pulse mt-1.5"></div>
             <div class="h-3 w-10 bg-surface-2 rounded animate-pulse mt-2"></div>
           {:else if totalsError || !totals}
             <p class="text-lg font-semibold text-ink-subtle mt-1">—</p>

--- a/apps/web/src/lib/components/HelpDrawer.svelte
+++ b/apps/web/src/lib/components/HelpDrawer.svelte
@@ -65,17 +65,17 @@
 
   <!-- Drawer panel -->
   <div
-    class="fixed top-0 right-0 h-full z-50 w-full sm:w-[400px] bg-white shadow-2xl border-l border-gray-200 flex flex-col transform transition-transform duration-300"
+    class="fixed top-0 right-0 h-full z-50 w-full sm:w-[400px] bg-surface shadow-2xl border-l border-border flex flex-col transform transition-transform duration-300"
     class:translate-x-0={show}
   >
     <!-- Header -->
-    <div class="sticky top-0 bg-white border-b border-gray-200 px-5 py-4 flex items-center justify-between flex-shrink-0">
-      <h2 class="text-lg font-semibold text-gray-900 truncate">
+    <div class="sticky top-0 bg-surface border-b border-border px-5 py-4 flex items-center justify-between flex-shrink-0">
+      <h2 class="text-lg font-semibold text-ink truncate">
         {title || $_('help.drawer.title')}
       </h2>
       <button
         on:click={close}
-        class="text-gray-400 hover:text-gray-600 transition-colors duration-150 cursor-pointer p-1 -mr-1"
+        class="text-ink-subtle hover:text-gray-600 transition-colors duration-150 cursor-pointer p-1 -mr-1"
         aria-label="Close"
       >
         <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -89,11 +89,11 @@
       {#if loading}
         <div class="flex items-center justify-center py-12">
           <div class="flex flex-col items-center gap-3">
-            <svg class="animate-spin h-6 w-6 text-primary-600" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+            <svg class="animate-spin h-6 w-6 text-brand" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
               <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
               <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
             </svg>
-            <span class="text-sm text-gray-500">{$_('help.loading')}</span>
+            <span class="text-sm text-ink-muted">{$_('help.loading')}</span>
           </div>
         </div>
       {:else}
@@ -104,10 +104,10 @@
     </div>
 
     <!-- Footer -->
-    <div class="sticky bottom-0 bg-white border-t border-gray-200 px-5 py-3 flex-shrink-0">
+    <div class="sticky bottom-0 bg-surface border-t border-border px-5 py-3 flex-shrink-0">
       <button
         on:click={openFull}
-        class="text-sm text-primary-600 hover:text-primary-700 font-medium transition-colors duration-150 cursor-pointer"
+        class="text-sm text-brand hover:text-primary-700 font-medium transition-colors duration-150 cursor-pointer"
       >
         {$_('help.openFull')} &rarr;
       </button>

--- a/apps/web/src/lib/components/MarkdownEditor.svelte
+++ b/apps/web/src/lib/components/MarkdownEditor.svelte
@@ -70,9 +70,9 @@
   function handleDragOver(e: DragEvent) { e.preventDefault(); }
 </script>
 
-<div class="markdown-editor border border-gray-300 dark:border-gray-600 rounded-lg overflow-hidden flex flex-col h-full">
+<div class="markdown-editor border border-border rounded-lg overflow-hidden flex flex-col h-full">
   <!-- Toolbar -->
-  <div class="flex items-center gap-1 px-2 py-1 bg-gray-50 dark:bg-gray-700 border-b border-gray-300 dark:border-gray-600 flex-shrink-0">
+  <div class="flex items-center gap-1 px-2 py-1 bg-surface-2 border-b border-border flex-shrink-0">
     <button type="button" on:click={bold} class="toolbar-btn" title="Bold"><b>B</b></button>
     <button type="button" on:click={italic} class="toolbar-btn" title="Italic"><i>I</i></button>
     <button type="button" on:click={h1} class="toolbar-btn" title="H1">H1</button>
@@ -87,18 +87,18 @@
   <!-- Split view -->
   <div class="flex flex-1 min-h-[300px]">
     <!-- Editor -->
-    <div class="w-1/2 border-r border-gray-300 dark:border-gray-600 flex"
+    <div class="w-1/2 border-r border-border flex"
          on:drop={handleDrop} on:dragover={handleDragOver} role="textbox" tabindex="-1">
       <textarea
         bind:this={textarea}
         bind:value
         {placeholder}
-        class="w-full h-full p-3 resize-none bg-white dark:bg-gray-800 text-sm font-mono focus:outline-none"
+        class="w-full h-full p-3 resize-none bg-surface text-sm font-mono focus:outline-none"
       />
     </div>
 
     <!-- Preview -->
-    <div class="w-1/2 p-3 prose dark:prose-invert prose-sm max-w-none overflow-y-auto bg-gray-50 dark:bg-gray-900">
+    <div class="w-1/2 p-3 prose dark:prose-invert prose-sm max-w-none overflow-y-auto bg-surface-2">
       {@html html}
     </div>
   </div>
@@ -109,6 +109,6 @@
 
 <style>
   .toolbar-btn {
-    @apply px-2 py-1 text-sm rounded hover:bg-gray-200 dark:hover:bg-gray-600 text-gray-700 dark:text-gray-300;
+    @apply px-2 py-1 text-sm rounded hover:bg-gray-200 text-ink;
   }
 </style>

--- a/apps/web/src/lib/components/ProjectCardStats.svelte
+++ b/apps/web/src/lib/components/ProjectCardStats.svelte
@@ -14,43 +14,43 @@
   $: hasAnyActivity = stats && (stats.pageViews + stats.emailsSent + stats.conversions + stats.content > 0);
 </script>
 
-<div class="border-t border-gray-100 pt-3 mt-3">
-  <p class="text-[11px] uppercase tracking-wide text-gray-400 mb-2">
+<div class="border-t border-border pt-3 mt-3">
+  <p class="text-[11px] uppercase tracking-wide text-ink-subtle mb-2">
     {$_('dashboard.lastNDays').replace('{n}', String(period))}
   </p>
   {#if loading}
     <div class="grid grid-cols-4 gap-2">
       {#each [0, 1, 2, 3] as _i}
-        <div class="h-5 bg-gray-100 rounded animate-pulse"></div>
+        <div class="h-5 bg-surface-2 rounded animate-pulse"></div>
       {/each}
     </div>
   {:else if !stats || !hasAnyActivity}
-    <p class="text-xs text-gray-400">{$_('dashboard.noActivity')}</p>
+    <p class="text-xs text-ink-subtle">{$_('dashboard.noActivity')}</p>
   {:else}
     <div class="grid grid-cols-4 gap-2 text-xs">
       <div class="flex flex-col items-start">
-        <span class="flex items-center gap-1 text-gray-500" title={$_('analytics.pageViews')}>
+        <span class="flex items-center gap-1 text-ink-muted" title={$_('analytics.pageViews')}>
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8"><path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"/><path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/></svg>
         </span>
-        <span class="text-gray-900 font-semibold mt-0.5">{formatNumber(stats.pageViews)}</span>
+        <span class="text-ink font-semibold mt-0.5">{formatNumber(stats.pageViews)}</span>
       </div>
       <div class="flex flex-col items-start">
-        <span class="flex items-center gap-1 text-gray-500" title={$_('analytics.emailOpens')}>
+        <span class="flex items-center gap-1 text-ink-muted" title={$_('analytics.emailOpens')}>
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8"><path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75"/></svg>
         </span>
-        <span class="text-gray-900 font-semibold mt-0.5">{formatNumber(stats.emailsSent)}</span>
+        <span class="text-ink font-semibold mt-0.5">{formatNumber(stats.emailsSent)}</span>
       </div>
       <div class="flex flex-col items-start">
-        <span class="flex items-center gap-1 text-gray-500" title={$_('analytics.conversions')}>
+        <span class="flex items-center gap-1 text-ink-muted" title={$_('analytics.conversions')}>
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
         </span>
-        <span class="text-gray-900 font-semibold mt-0.5">{formatNumber(stats.conversions)}</span>
+        <span class="text-ink font-semibold mt-0.5">{formatNumber(stats.conversions)}</span>
       </div>
       <div class="flex flex-col items-start">
-        <span class="flex items-center gap-1 text-gray-500" title={$_('content.content')}>
+        <span class="flex items-center gap-1 text-ink-muted" title={$_('content.content')}>
           <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.8"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z"/></svg>
         </span>
-        <span class="text-gray-900 font-semibold mt-0.5">{formatNumber(stats.content)}</span>
+        <span class="text-ink font-semibold mt-0.5">{formatNumber(stats.content)}</span>
       </div>
     </div>
   {/if}

--- a/apps/web/src/lib/components/analytics/InstagramAnalyticsDashboard.svelte
+++ b/apps/web/src/lib/components/analytics/InstagramAnalyticsDashboard.svelte
@@ -310,9 +310,9 @@
   </div>
 {:else}
   <!-- Connected with insights -->
-  <div class="bg-white rounded-xl border border-gray-200 overflow-hidden mb-6">
+  <div class="bg-surface rounded-xl border border-border overflow-hidden mb-6">
     <!-- Header -->
-    <div class="flex items-center justify-between px-5 py-4 border-b border-gray-100">
+    <div class="flex items-center justify-between px-5 py-4 border-b border-border">
       <div class="flex items-center gap-3">
         <div class="w-9 h-9 bg-pink-50 rounded-lg flex items-center justify-center flex-shrink-0">
           <svg class="w-5 h-5 text-pink-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
@@ -322,15 +322,15 @@
           </svg>
         </div>
         <div>
-          <h2 class="text-sm font-semibold text-gray-900">{$_('instagram.title')}</h2>
-          <p class="text-xs text-gray-500">
+          <h2 class="text-sm font-semibold text-ink">{$_('instagram.title')}</h2>
+          <p class="text-xs text-ink-muted">
             {status?.accountName ? '@' + status.accountName : $_('instagram.subtitle')}
           </p>
         </div>
       </div>
       <div class="flex items-center gap-3">
         <button on:click={syncAndRefresh} disabled={syncing}
-          class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-600 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-40 cursor-pointer">
+          class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-ink-muted border border-border rounded-lg hover:bg-surface-2 transition-colors disabled:opacity-40 cursor-pointer">
           {#if syncing}
             <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
               <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
@@ -344,11 +344,11 @@
             {$_('instagram.syncNow')}
           {/if}
         </button>
-        <div class="flex bg-gray-100 rounded-lg p-0.5">
+        <div class="flex bg-surface-2 rounded-lg p-0.5">
           {#each PERIODS as p}
             <button on:click={() => changePeriod(p)} disabled={dataLoading}
               class="px-2.5 py-1 text-xs font-medium rounded-md transition-colors
-                {period === p ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'}">
+                {period === p ? 'bg-surface text-ink shadow-sm' : 'text-ink-muted hover:text-gray-700'}">
               {$_(`instagram.period${p}`)}
             </button>
           {/each}
@@ -359,33 +359,33 @@
     {#if dataLoading && metrics.account.length === 0}
       <div class="p-5 space-y-6 animate-pulse">
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          {#each Array(3) as _skeleton}<div class="bg-gray-100 rounded-xl h-24"></div>{/each}
+          {#each Array(3) as _skeleton}<div class="bg-surface-2 rounded-xl h-24"></div>{/each}
         </div>
-        <div class="bg-gray-100 rounded-xl h-64"></div>
+        <div class="bg-surface-2 rounded-xl h-64"></div>
       </div>
     {:else if metrics.account.length === 0}
-      <div class="px-5 py-12 text-center text-sm text-gray-500">{$_('instagram.noData')}</div>
+      <div class="px-5 py-12 text-center text-sm text-ink-muted">{$_('instagram.noData')}</div>
     {:else}
       <div class="p-5 space-y-6">
         <!-- KPI cards -->
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
-          <div class="bg-white border border-gray-200 rounded-xl p-4 border-t-4 border-t-pink-400">
-            <div class="text-xs text-gray-500 mb-1">{$_('instagram.currentFollowers')}</div>
-            <div class="text-2xl font-bold text-gray-900">{formatNumber(currentFollowers)}</div>
+          <div class="bg-surface border border-border rounded-xl p-4 border-t-4 border-t-pink-400">
+            <div class="text-xs text-ink-muted mb-1">{$_('instagram.currentFollowers')}</div>
+            <div class="text-2xl font-bold text-ink">{formatNumber(currentFollowers)}</div>
           </div>
-          <div class="bg-white border border-gray-200 rounded-xl p-4 border-t-4 border-t-purple-400">
-            <div class="text-xs text-gray-500 mb-1">{$_('instagram.totalReach')}</div>
-            <div class="text-2xl font-bold text-gray-900">{formatNumber(totalReach)}</div>
+          <div class="bg-surface border border-border rounded-xl p-4 border-t-4 border-t-purple-400">
+            <div class="text-xs text-ink-muted mb-1">{$_('instagram.totalReach')}</div>
+            <div class="text-2xl font-bold text-ink">{formatNumber(totalReach)}</div>
           </div>
-          <div class="bg-white border border-gray-200 rounded-xl p-4 border-t-4 border-t-blue-400">
-            <div class="text-xs text-gray-500 mb-1">{$_('instagram.totalViews')}</div>
-            <div class="text-2xl font-bold text-gray-900">{formatNumber(totalViews)}</div>
+          <div class="bg-surface border border-border rounded-xl p-4 border-t-4 border-t-blue-400">
+            <div class="text-xs text-ink-muted mb-1">{$_('instagram.totalViews')}</div>
+            <div class="text-2xl font-bold text-ink">{formatNumber(totalViews)}</div>
           </div>
         </div>
 
         <!-- Trend chart -->
         <div>
-          <h3 class="text-sm font-semibold text-gray-700 mb-3">{$_('instagram.trend')}</h3>
+          <h3 class="text-sm font-semibold text-ink mb-3">{$_('instagram.trend')}</h3>
           <div class="relative" style="height: 264px;">
             <canvas bind:this={chartCanvas} style="width: 100%; height: 100%;"></canvas>
           </div>
@@ -395,29 +395,29 @@
         <div class="grid grid-cols-1 xl:grid-cols-2 gap-5">
           {#each [{ key: 'best', title: 'instagram.bestPosts', rows: metrics.topPosts }, { key: 'worst', title: 'instagram.worstPosts', rows: metrics.worstPosts }] as group (group.key)}
             <div>
-              <h3 class="text-sm font-semibold text-gray-700 mb-3">{$_(group.title)}</h3>
+              <h3 class="text-sm font-semibold text-ink mb-3">{$_(group.title)}</h3>
               {#if group.rows.length === 0}
-                <div class="text-sm text-gray-400 py-6 text-center bg-gray-50 rounded-xl">{$_('instagram.noPosts')}</div>
+                <div class="text-sm text-ink-subtle py-6 text-center bg-surface-2 rounded-xl">{$_('instagram.noPosts')}</div>
               {:else}
-                <div class="rounded-xl border border-gray-200 overflow-x-auto">
+                <div class="rounded-xl border border-border overflow-x-auto">
                   <table class="w-full text-sm min-w-[460px]">
                     <thead>
-                      <tr class="bg-gray-50 border-b border-gray-200">
-                        <th class="text-left px-3 py-2.5 text-xs font-semibold text-gray-500">{$_('instagram.caption')}</th>
-                        <th class="text-left px-3 py-2.5 text-xs font-semibold text-gray-500">{$_('instagram.type')}</th>
-                        <th class="text-right px-3 py-2.5 text-xs font-semibold text-gray-500">{$_('instagram.likes')}</th>
-                        <th class="text-right px-3 py-2.5 text-xs font-semibold text-gray-500">{$_('instagram.comments')}</th>
-                        <th class="text-right px-3 py-2.5 text-xs font-semibold text-gray-500">{$_('instagram.reach')}</th>
-                        <th class="text-right px-3 py-2.5 text-xs font-semibold text-gray-500">{$_('instagram.engagement')}</th>
+                      <tr class="bg-surface-2 border-b border-border">
+                        <th class="text-left px-3 py-2.5 text-xs font-semibold text-ink-muted">{$_('instagram.caption')}</th>
+                        <th class="text-left px-3 py-2.5 text-xs font-semibold text-ink-muted">{$_('instagram.type')}</th>
+                        <th class="text-right px-3 py-2.5 text-xs font-semibold text-ink-muted">{$_('instagram.likes')}</th>
+                        <th class="text-right px-3 py-2.5 text-xs font-semibold text-ink-muted">{$_('instagram.comments')}</th>
+                        <th class="text-right px-3 py-2.5 text-xs font-semibold text-ink-muted">{$_('instagram.reach')}</th>
+                        <th class="text-right px-3 py-2.5 text-xs font-semibold text-ink-muted">{$_('instagram.engagement')}</th>
                       </tr>
                     </thead>
                     <tbody>
                       {#each group.rows as post (post.id)}
-                        <tr class="border-b border-gray-100 hover:bg-gray-50">
-                          <td class="px-3 py-2 text-gray-800 max-w-[180px] truncate" title={post.caption ?? ''}>
+                        <tr class="border-b border-border hover:bg-surface-2">
+                          <td class="px-3 py-2 text-ink max-w-[180px] truncate" title={post.caption ?? ''}>
                             {#if post.permalink}
                               <a href={post.permalink} target="_blank" rel="noopener noreferrer"
-                                 class="text-primary-600 hover:underline">{truncate(post.caption)}</a>
+                                 class="text-brand hover:underline">{truncate(post.caption)}</a>
                             {:else}
                               {truncate(post.caption)}
                             {/if}
@@ -425,10 +425,10 @@
                           <td class="px-3 py-2">
                             <span class="inline-block px-2 py-0.5 text-[10px] font-medium rounded-full bg-pink-50 text-pink-700">{post.mediaType}</span>
                           </td>
-                          <td class="px-3 py-2 text-right text-gray-700 font-medium">{formatNumber(post.likeCount)}</td>
-                          <td class="px-3 py-2 text-right text-gray-600">{formatNumber(post.commentsCount)}</td>
-                          <td class="px-3 py-2 text-right text-gray-600">{formatNumber(post.reach)}</td>
-                          <td class="px-3 py-2 text-right text-gray-600">{formatEngagement(post.engagementRate)}</td>
+                          <td class="px-3 py-2 text-right text-ink font-medium">{formatNumber(post.likeCount)}</td>
+                          <td class="px-3 py-2 text-right text-ink-muted">{formatNumber(post.commentsCount)}</td>
+                          <td class="px-3 py-2 text-right text-ink-muted">{formatNumber(post.reach)}</td>
+                          <td class="px-3 py-2 text-right text-ink-muted">{formatEngagement(post.engagementRate)}</td>
                         </tr>
                       {/each}
                     </tbody>
@@ -440,26 +440,26 @@
         </div>
 
         <!-- AI advice -->
-        <div class="bg-gray-50 rounded-xl border border-gray-100 p-5">
+        <div class="bg-surface-2 rounded-xl border border-border p-5">
           <div class="flex items-center justify-between mb-3">
-            <h3 class="text-sm font-semibold text-gray-700">{$_('instagram.advice')}</h3>
+            <h3 class="text-sm font-semibold text-ink">{$_('instagram.advice')}</h3>
             {#if !advice}
               <button on:click={getAdvice} disabled={adviceLoading}
-                class="px-3 py-1.5 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50 cursor-pointer">
+                class="px-3 py-1.5 text-sm font-medium text-white bg-brand rounded-lg hover:brightness-110 disabled:opacity-50 cursor-pointer">
                 {adviceLoading ? $_('instagram.generating') : $_('instagram.generateAdvice')}
               </button>
             {/if}
           </div>
           {#if adviceError}<p class="text-sm text-red-600">{adviceError}</p>{/if}
           {#if advice}
-            <div class="prose prose-sm max-w-none text-gray-700">{@html DOMPurify.sanitize(marked.parse(advice, { async: false }) as string)}</div>
+            <div class="prose prose-sm max-w-none text-ink">{@html DOMPurify.sanitize(marked.parse(advice, { async: false }) as string)}</div>
             <div class="flex items-center gap-2 mt-4">
               <button on:click={continueInChat} disabled={openingChat}
-                class="px-3 py-1.5 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50 cursor-pointer">
+                class="px-3 py-1.5 text-sm font-medium text-white bg-brand rounded-lg hover:brightness-110 disabled:opacity-50 cursor-pointer">
                 {$_('instagram.continueInChat')}
               </button>
               <button on:click={getAdvice} disabled={adviceLoading}
-                class="px-3 py-1.5 text-sm text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50 cursor-pointer">
+                class="px-3 py-1.5 text-sm text-ink-muted border border-border rounded-lg hover:bg-surface-2 cursor-pointer">
                 {adviceLoading ? $_('instagram.generating') : $_('instagram.regenerate')}
               </button>
             </div>

--- a/apps/web/src/lib/components/analytics/InstallsChart.svelte
+++ b/apps/web/src/lib/components/analytics/InstallsChart.svelte
@@ -86,8 +86,8 @@
   }
 </script>
 
-<div class="bg-white rounded-xl border border-gray-200 p-5">
-  <h3 class="text-sm font-semibold text-gray-700 mb-4">{$_('googlePlay.metrics.installs')}</h3>
+<div class="bg-surface rounded-xl border border-border p-5">
+  <h3 class="text-sm font-semibold text-ink mb-4">{$_('googlePlay.metrics.installs')}</h3>
   <div class="relative" style="height: 288px;">
     <canvas bind:this={canvas} style="width: 100%; height: 100%;"></canvas>
   </div>

--- a/apps/web/src/lib/components/analytics/MobileAnalyticsDashboard.svelte
+++ b/apps/web/src/lib/components/analytics/MobileAnalyticsDashboard.svelte
@@ -162,11 +162,11 @@
         <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3" />
       </svg>
     </div>
-    <h2 class="text-xl font-semibold text-gray-900 mb-2">{$_('googlePlay.notConnected.title')}</h2>
-    <p class="text-gray-500 max-w-md mb-6">{$_('googlePlay.notConnected.description')}</p>
+    <h2 class="text-xl font-semibold text-ink mb-2">{$_('googlePlay.notConnected.title')}</h2>
+    <p class="text-ink-muted max-w-md mb-6">{$_('googlePlay.notConnected.description')}</p>
     <a
       href="/projects/{projectId}/settings"
-      class="px-5 py-2.5 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150"
+      class="px-5 py-2.5 bg-brand text-white rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150"
     >
       {$_('googlePlay.notConnected.connectButton')}
     </a>
@@ -176,7 +176,7 @@
   <div class="flex items-center justify-between mb-6">
     <div>
       <div class="flex items-center gap-3">
-        <h1 class="text-2xl font-bold text-gray-900">{$_('googlePlay.title')}</h1>
+        <h1 class="text-2xl font-bold text-ink">{$_('googlePlay.title')}</h1>
         {#if syncing}
           <span class="inline-flex items-center gap-1.5 px-2.5 py-1 bg-blue-50 text-blue-600 rounded-full text-xs font-medium">
             <svg class="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
@@ -189,10 +189,10 @@
       </div>
       <div class="flex items-center gap-2 mt-1">
         {#if status.packageName}
-          <span class="text-sm text-gray-500">{status.packageName}</span>
+          <span class="text-sm text-ink-muted">{status.packageName}</span>
         {/if}
         {#if lastSyncLabel}
-          <span class="text-xs text-gray-400">· {$_('googlePlay.connection.lastSync', { values: { time: lastSyncLabel } })}</span>
+          <span class="text-xs text-ink-subtle">· {$_('googlePlay.connection.lastSync', { values: { time: lastSyncLabel } })}</span>
         {/if}
       </div>
     </div>
@@ -200,7 +200,7 @@
       <button
         on:click={syncAndRefresh}
         disabled={syncing}
-        class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-600 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors duration-150 disabled:opacity-40 cursor-pointer"
+        class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-ink-muted border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 disabled:opacity-40 cursor-pointer"
       >
         {#if syncing}
           <svg class="w-4 h-4 animate-spin" fill="none" viewBox="0 0 24 24">
@@ -214,11 +214,11 @@
         {/if}
         {$_('googlePlay.connection.syncNow')}
       </button>
-      <div class="flex bg-gray-100 rounded-lg p-0.5">
+      <div class="flex bg-surface-2 rounded-lg p-0.5">
         {#each [7, 30, 90] as period}
           <button on:click={() => switchPeriod(period)}
             class="px-3 py-1.5 text-sm font-medium rounded-md transition-colors duration-150 cursor-pointer
-              {selectedPeriod === period ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'}">
+              {selectedPeriod === period ? 'bg-surface text-ink shadow-sm' : 'text-ink-muted hover:text-gray-700'}">
             {$_('analytics.period' + period)}
           </button>
         {/each}
@@ -227,11 +227,11 @@
   </div>
 
   <!-- Tabs -->
-  <div class="flex border-b border-gray-200 mb-6 overflow-x-auto">
+  <div class="flex border-b border-border mb-6 overflow-x-auto">
     {#each tabs as tab}
       <button on:click={() => switchTab(tab.id)}
         class="px-4 py-2.5 text-sm font-medium border-b-2 transition-colors duration-150 -mb-px cursor-pointer whitespace-nowrap
-          {activeTab === tab.id ? 'border-primary-600 text-primary-600' : 'border-transparent text-gray-500 hover:text-gray-700'}">
+          {activeTab === tab.id ? 'border-primary-600 text-brand' : 'border-transparent text-ink-muted hover:text-gray-700'}">
         {$_(tab.labelKey)}
       </button>
     {/each}

--- a/apps/web/src/lib/components/analytics/MobileKpiCards.svelte
+++ b/apps/web/src/lib/components/analytics/MobileKpiCards.svelte
@@ -88,11 +88,11 @@
 
 <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
   {#each cards as card}
-    <div class="bg-white rounded-xl border border-gray-200 p-4 border-t-4 {card.borderColor}">
+    <div class="bg-surface rounded-xl border border-border p-4 border-t-4 {card.borderColor}">
       <div class="flex items-center justify-between mb-3">
         <div class="w-9 h-9 {card.color} rounded-lg flex items-center justify-center flex-shrink-0">{@html card.icon}</div>
         {#if card.change != null && card.change !== 0}
-          <span class="text-xs font-medium flex items-center gap-0.5 {card.trend === 'up' ? 'text-green-600' : card.trend === 'down' ? 'text-red-500' : 'text-gray-400'}">
+          <span class="text-xs font-medium flex items-center gap-0.5 {card.trend === 'up' ? 'text-green-600' : card.trend === 'down' ? 'text-red-500' : 'text-ink-subtle'}">
             {#if card.trend === 'up'}
               <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 19.5l15-15m0 0H8.25m11.25 0v11.25" /></svg>
             {:else if card.trend === 'down'}
@@ -102,8 +102,8 @@
           </span>
         {/if}
       </div>
-      <div class="text-2xl font-bold text-gray-900">{card.value}</div>
-      <div class="text-xs text-gray-500 mt-1">{$_(card.labelKey)}</div>
+      <div class="text-2xl font-bold text-ink">{card.value}</div>
+      <div class="text-xs text-ink-muted mt-1">{$_(card.labelKey)}</div>
     </div>
   {/each}
 </div>

--- a/apps/web/src/lib/components/analytics/RevenueChart.svelte
+++ b/apps/web/src/lib/components/analytics/RevenueChart.svelte
@@ -101,8 +101,8 @@
   }
 </script>
 
-<div class="bg-white rounded-xl border border-gray-200 p-5">
-  <h3 class="text-sm font-semibold text-gray-700 mb-4">{$_('googlePlay.kpi.revenue')}</h3>
+<div class="bg-surface rounded-xl border border-border p-5">
+  <h3 class="text-sm font-semibold text-ink mb-4">{$_('googlePlay.kpi.revenue')}</h3>
   <div class="relative" style="height: 288px;">
     <canvas bind:this={canvas} style="width: 100%; height: 100%;"></canvas>
   </div>

--- a/apps/web/src/lib/components/analytics/ReviewCard.svelte
+++ b/apps/web/src/lib/components/analytics/ReviewCard.svelte
@@ -48,16 +48,16 @@
   }
 </script>
 
-<div class="bg-white rounded-xl border border-gray-200 p-5">
+<div class="bg-surface rounded-xl border border-border p-5">
   <!-- Header: author + rating -->
   <div class="flex items-start justify-between mb-3">
     <div class="flex items-center gap-3">
-      <div class="w-10 h-10 bg-gray-100 rounded-full flex items-center justify-center text-gray-500 font-bold text-sm flex-shrink-0">
+      <div class="w-10 h-10 bg-surface-2 rounded-full flex items-center justify-center text-ink-muted font-bold text-sm flex-shrink-0">
         {(review.authorName || '?').charAt(0).toUpperCase()}
       </div>
       <div>
-        <div class="text-sm font-medium text-gray-900">{review.authorName || $_('googlePlay.reviews.anonymous')}</div>
-        <div class="text-xs text-gray-500">{formatDate(review.reviewCreatedAt)}</div>
+        <div class="text-sm font-medium text-ink">{review.authorName || $_('googlePlay.reviews.anonymous')}</div>
+        <div class="text-xs text-ink-muted">{formatDate(review.reviewCreatedAt)}</div>
       </div>
     </div>
     <div class="flex items-center gap-0.5">
@@ -70,40 +70,40 @@
   </div>
 
   <!-- Review text -->
-  <p class="text-sm text-gray-700 mb-3 whitespace-pre-wrap">{review.text}</p>
+  <p class="text-sm text-ink mb-3 whitespace-pre-wrap">{review.text}</p>
 
   <!-- Metadata badges -->
   {#if review.metadata}
     {@const meta = review.metadata}
     <div class="flex flex-wrap gap-2 mb-3">
       {#if meta['device']}
-        <span class="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">{meta['device']}</span>
+        <span class="text-xs bg-surface-2 text-ink-muted px-2 py-0.5 rounded-full">{meta['device']}</span>
       {/if}
       {#if meta['appVersionName']}
-        <span class="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">v{meta['appVersionName']}</span>
+        <span class="text-xs bg-surface-2 text-ink-muted px-2 py-0.5 rounded-full">v{meta['appVersionName']}</span>
       {/if}
       {#if meta['androidOsVersion']}
-        <span class="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">Android {meta['androidOsVersion']}</span>
+        <span class="text-xs bg-surface-2 text-ink-muted px-2 py-0.5 rounded-full">Android {meta['androidOsVersion']}</span>
       {/if}
       {#if review.language}
-        <span class="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">{review.language}</span>
+        <span class="text-xs bg-surface-2 text-ink-muted px-2 py-0.5 rounded-full">{review.language}</span>
       {/if}
     </div>
   {/if}
 
   <!-- Existing reply -->
   {#if review.isReplied && review.replyText && !showReplyBox}
-    <div class="bg-gray-50 rounded-lg p-3 border border-gray-100 mb-3">
+    <div class="bg-surface-2 rounded-lg p-3 border border-border mb-3">
       <div class="flex items-center gap-1.5 mb-1">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-ink-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3" />
         </svg>
-        <span class="text-xs font-medium text-gray-500">Developer reply</span>
+        <span class="text-xs font-medium text-ink-muted">Developer reply</span>
         {#if review.replyCreatedAt}
-          <span class="text-xs text-gray-400">- {formatDate(review.replyCreatedAt)}</span>
+          <span class="text-xs text-ink-subtle">- {formatDate(review.replyCreatedAt)}</span>
         {/if}
       </div>
-      <p class="text-sm text-gray-600 whitespace-pre-wrap">{review.replyText}</p>
+      <p class="text-sm text-ink-muted whitespace-pre-wrap">{review.replyText}</p>
     </div>
   {/if}
 
@@ -121,7 +121,7 @@
       <button
         on:click={generateAiReply}
         disabled={generating}
-        class="px-3 py-1.5 text-sm font-medium text-primary-600 border border-primary-200 rounded-lg hover:bg-primary-50 transition-colors duration-150 disabled:opacity-50 cursor-pointer flex items-center gap-1.5"
+        class="px-3 py-1.5 text-sm font-medium text-brand border border-primary-200 rounded-lg hover:bg-brand-subtle/10 transition-colors duration-150 disabled:opacity-50 cursor-pointer flex items-center gap-1.5"
       >
         {#if generating}
           <svg class="animate-spin w-3.5 h-3.5" fill="none" viewBox="0 0 24 24">
@@ -142,21 +142,21 @@
         <textarea
           bind:value={replyText}
           rows="3"
-          class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 resize-y"
+          class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 resize-y"
           placeholder="Type your reply..."
         ></textarea>
         <div class="flex items-center gap-2">
           <button
             on:click={sendReply}
             disabled={sending || !replyText || !replyText.trim()}
-            class="px-4 py-1.5 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 cursor-pointer"
+            class="px-4 py-1.5 bg-brand text-white rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 cursor-pointer"
           >
             {sending ? $_('googlePlay.reviews.sending') : $_('googlePlay.reviews.sendReply')}
           </button>
           <button
             on:click={generateAiReply}
             disabled={generating}
-            class="px-3 py-1.5 text-sm font-medium text-primary-600 border border-primary-200 rounded-lg hover:bg-primary-50 transition-colors duration-150 disabled:opacity-50 cursor-pointer flex items-center gap-1.5"
+            class="px-3 py-1.5 text-sm font-medium text-brand border border-primary-200 rounded-lg hover:bg-brand-subtle/10 transition-colors duration-150 disabled:opacity-50 cursor-pointer flex items-center gap-1.5"
           >
             {#if generating}
               <svg class="animate-spin w-3.5 h-3.5" fill="none" viewBox="0 0 24 24">
@@ -170,7 +170,7 @@
           </button>
           <button
             on:click={() => { showReplyBox = false; replyText = ''; }}
-            class="px-3 py-1.5 text-sm text-gray-500 hover:text-gray-700 cursor-pointer"
+            class="px-3 py-1.5 text-sm text-ink-muted hover:text-gray-700 cursor-pointer"
           >
             {$_('common.cancel')}
           </button>

--- a/apps/web/src/lib/components/analytics/ReviewsList.svelte
+++ b/apps/web/src/lib/components/analytics/ReviewsList.svelte
@@ -72,11 +72,11 @@
   <!-- Filters -->
   <div class="flex flex-wrap items-center gap-3 mb-5">
     <div class="flex items-center gap-1.5">
-      <span class="text-xs font-medium text-gray-500">{$_('googlePlay.reviews.filterByRating')}:</span>
+      <span class="text-xs font-medium text-ink-muted">{$_('googlePlay.reviews.filterByRating')}:</span>
       <button
         on:click={() => applyFilter(null)}
         class="px-2.5 py-1 text-xs font-medium rounded-full transition-colors duration-150 cursor-pointer
-          {filterRating === null && !filterUnreplied ? 'bg-primary-100 text-primary-700' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}"
+          {filterRating === null && !filterUnreplied ? 'bg-primary-100 text-brand' : 'bg-surface-2 text-ink-muted hover:bg-gray-200'}"
       >
         {$_('googlePlay.reviews.allRatings')}
       </button>
@@ -84,7 +84,7 @@
         <button
           on:click={() => applyFilter(star)}
           class="px-2.5 py-1 text-xs font-medium rounded-full transition-colors duration-150 cursor-pointer flex items-center gap-0.5
-            {filterRating === star ? 'bg-yellow-100 text-yellow-700' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}"
+            {filterRating === star ? 'bg-yellow-100 text-yellow-700' : 'bg-surface-2 text-ink-muted hover:bg-gray-200'}"
         >
           {star}
           <svg class="w-3 h-3 text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
@@ -97,24 +97,24 @@
     <button
       on:click={toggleUnreplied}
       class="px-2.5 py-1 text-xs font-medium rounded-full transition-colors duration-150 cursor-pointer
-        {filterUnreplied ? 'bg-orange-100 text-orange-700' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}"
+        {filterUnreplied ? 'bg-orange-100 text-orange-700' : 'bg-surface-2 text-ink-muted hover:bg-gray-200'}"
     >
       {$_('googlePlay.reviews.unreplied')}
     </button>
 
     <div class="ml-auto flex items-center gap-1.5">
-      <span class="text-xs text-gray-500">Sort:</span>
+      <span class="text-xs text-ink-muted">Sort:</span>
       <button
         on:click={() => changeSort('date')}
         class="px-2.5 py-1 text-xs font-medium rounded-full transition-colors duration-150 cursor-pointer
-          {sortBy === 'date' ? 'bg-primary-100 text-primary-700' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}"
+          {sortBy === 'date' ? 'bg-primary-100 text-brand' : 'bg-surface-2 text-ink-muted hover:bg-gray-200'}"
       >
         Date
       </button>
       <button
         on:click={() => changeSort('rating')}
         class="px-2.5 py-1 text-xs font-medium rounded-full transition-colors duration-150 cursor-pointer
-          {sortBy === 'rating' ? 'bg-primary-100 text-primary-700' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}"
+          {sortBy === 'rating' ? 'bg-primary-100 text-brand' : 'bg-surface-2 text-ink-muted hover:bg-gray-200'}"
       >
         Rating
       </button>
@@ -135,7 +135,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M7.5 8.25h9m-9 3H12m-9.75 1.51c0 1.6 1.123 2.994 2.707 3.227 1.129.166 2.27.293 3.423.379.35.026.67.21.865.501L12 21l2.755-4.133a1.14 1.14 0 01.865-.501 48.172 48.172 0 003.423-.379c1.584-.233 2.707-1.626 2.707-3.228V6.741c0-1.602-1.123-2.995-2.707-3.228A48.394 48.394 0 0012 3c-2.392 0-4.744.175-7.043.513C3.373 3.746 2.25 5.14 2.25 6.741v6.018z" />
         </svg>
       </div>
-      <h2 class="text-lg font-semibold text-gray-900 mb-2">{$_('googlePlay.reviews.noReviews')}</h2>
+      <h2 class="text-lg font-semibold text-ink mb-2">{$_('googlePlay.reviews.noReviews')}</h2>
     </div>
   {:else}
     <div class="space-y-4">
@@ -150,17 +150,17 @@
         <button
           on:click={() => goToPage(currentPage - 1)}
           disabled={currentPage <= 1}
-          class="px-3 py-1.5 text-sm text-gray-600 border border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+          class="px-3 py-1.5 text-sm text-ink-muted border border-border rounded-lg hover:bg-surface-2 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
         >
           Previous
         </button>
-        <span class="text-sm text-gray-500">
+        <span class="text-sm text-ink-muted">
           {currentPage} / {totalPages}
         </span>
         <button
           on:click={() => goToPage(currentPage + 1)}
           disabled={currentPage >= totalPages}
-          class="px-3 py-1.5 text-sm text-gray-600 border border-gray-200 rounded-lg hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
+          class="px-3 py-1.5 text-sm text-ink-muted border border-border rounded-lg hover:bg-surface-2 disabled:opacity-30 disabled:cursor-not-allowed cursor-pointer"
         >
           Next
         </button>

--- a/apps/web/src/lib/components/analytics/SearchConsolePanel.svelte
+++ b/apps/web/src/lib/components/analytics/SearchConsolePanel.svelte
@@ -265,9 +265,9 @@
   $: settingsUrl = `/projects/${projectId}/settings`;
 </script>
 
-<div class="bg-white rounded-xl border border-gray-200 overflow-hidden mb-6">
+<div class="bg-surface rounded-xl border border-border overflow-hidden mb-6">
   <!-- Header -->
-  <div class="flex items-center justify-between px-5 py-4 border-b border-gray-100">
+  <div class="flex items-center justify-between px-5 py-4 border-b border-border">
     <div class="flex items-center gap-3">
       <div class="w-9 h-9 bg-blue-50 rounded-lg flex items-center justify-center flex-shrink-0">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-blue-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
@@ -275,25 +275,25 @@
         </svg>
       </div>
       <div>
-        <h2 class="text-sm font-semibold text-gray-900">{$_('seo.searchConsolePanel.title')}</h2>
-        <p class="text-xs text-gray-500">{$_('seo.searchConsolePanel.description')}</p>
+        <h2 class="text-sm font-semibold text-ink">{$_('seo.searchConsolePanel.title')}</h2>
+        <p class="text-xs text-ink-muted">{$_('seo.searchConsolePanel.description')}</p>
       </div>
     </div>
 
     {#if isConnected}
       <div class="flex items-center gap-3">
         <a href={`/projects/${projectId}/search-console`}
-           class="text-sm font-medium text-primary-600 hover:text-primary-700 hover:underline cursor-pointer">
+           class="text-sm font-medium text-brand hover:text-primary-700 hover:underline cursor-pointer">
           {$_('gscDetail.details')} →
         </a>
         <!-- Period selector -->
-        <div class="flex bg-gray-100 rounded-lg p-0.5">
+        <div class="flex bg-surface-2 rounded-lg p-0.5">
           {#each PERIOD_OPTIONS as p}
             <button
               on:click={() => changePeriod(p)}
               disabled={dataLoading}
               class="px-2.5 py-1 text-xs font-medium rounded-md transition-colors duration-150
-                {period === p ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'}">
+                {period === p ? 'bg-surface text-ink shadow-sm' : 'text-ink-muted hover:text-gray-700'}">
               {$_(`seo.searchConsolePanel.period${p}d`)}
             </button>
           {/each}
@@ -319,11 +319,11 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35M17 11A6 6 0 115 11a6 6 0 0112 0z" />
         </svg>
       </div>
-      <h3 class="text-base font-semibold text-gray-900 mb-1">{$_('seo.searchConsolePanel.notConnectedTitle')}</h3>
-      <p class="text-sm text-gray-500 max-w-sm mb-4">{$_('seo.searchConsolePanel.notConnectedDescription')}</p>
+      <h3 class="text-base font-semibold text-ink mb-1">{$_('seo.searchConsolePanel.notConnectedTitle')}</h3>
+      <p class="text-sm text-ink-muted max-w-sm mb-4">{$_('seo.searchConsolePanel.notConnectedDescription')}</p>
       <a
         href={settingsUrl}
-        class="inline-flex items-center gap-1.5 px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium rounded-lg transition-colors">
+        class="inline-flex items-center gap-1.5 px-4 py-2 bg-brand hover:brightness-110 text-white text-sm font-medium rounded-lg transition-colors">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93.398.164.855.142 1.205-.108l.737-.527a1.125 1.125 0 011.45.12l.773.774c.39.389.44 1.002.12 1.45l-.527.737c-.25.35-.272.806-.107 1.204.165.397.505.71.93.78l.893.15c.543.09.94.56.94 1.109v1.094c0 .55-.397 1.02-.94 1.11l-.893.149c-.425.07-.765.383-.93.78-.165.398-.143.854.107 1.204l.527.738c.32.447.269 1.06-.12 1.45l-.774.773a1.125 1.125 0 01-1.449.12l-.738-.527c-.35-.25-.806-.272-1.203-.107-.397.165-.71.505-.781.929l-.149.894c-.09.542-.56.94-1.11.94h-1.094c-.55 0-1.019-.398-1.11-.94l-.148-.894c-.071-.424-.384-.764-.781-.93-.398-.164-.854-.142-1.204.108l-.738.527c-.447.32-1.06.269-1.45-.12l-.773-.774a1.125 1.125 0 01-.12-1.45l.527-.737c.25-.35.273-.806.108-1.204-.165-.397-.505-.71-.93-.78l-.894-.15c-.542-.09-.94-.56-.94-1.109v-1.094c0-.55.398-1.02.94-1.11l.894-.149c.424-.07.765-.383.93-.78.165-.398.143-.854-.107-1.204l-.527-.738a1.125 1.125 0 01.12-1.45l.773-.773a1.125 1.125 0 011.45-.12l.737.527c.35.25.807.272 1.204.107.397-.165.71-.505.78-.929l.15-.894z" />
           <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -339,10 +339,10 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
         </svg>
       </div>
-      <p class="text-sm text-gray-700 mb-3">{error}</p>
+      <p class="text-sm text-ink mb-3">{error}</p>
       <button
         on:click={loadSummary}
-        class="px-4 py-1.5 text-sm font-medium bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg transition-colors">
+        class="px-4 py-1.5 text-sm font-medium bg-surface-2 hover:bg-gray-200 text-ink rounded-lg transition-colors">
         {$_('seo.searchConsolePanel.retry')}
       </button>
     </div>
@@ -352,12 +352,12 @@
     <div class="p-5 space-y-6 animate-pulse">
       <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
         {#each Array(4) as _}
-          <div class="bg-gray-100 rounded-xl h-24"></div>
+          <div class="bg-surface-2 rounded-xl h-24"></div>
         {/each}
       </div>
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-5">
-        <div class="bg-gray-100 rounded-xl h-56"></div>
-        <div class="bg-gray-100 rounded-xl h-56"></div>
+        <div class="bg-surface-2 rounded-xl h-56"></div>
+        <div class="bg-surface-2 rounded-xl h-56"></div>
       </div>
     </div>
 
@@ -367,36 +367,36 @@
       <!-- KPI Metric Cards with sparklines -->
       <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
         <!-- Clicks -->
-        <div class="bg-white border border-gray-200 rounded-xl p-4 border-t-4 border-t-blue-400">
-          <div class="text-xs text-gray-500 mb-1">{$_('seo.searchConsolePanel.totalClicks')}</div>
-          <div class="text-2xl font-bold text-gray-900">{formatNumber(summary.totals.clicks)}</div>
+        <div class="bg-surface border border-border rounded-xl p-4 border-t-4 border-t-blue-400">
+          <div class="text-xs text-ink-muted mb-1">{$_('seo.searchConsolePanel.totalClicks')}</div>
+          <div class="text-2xl font-bold text-ink">{formatNumber(summary.totals.clicks)}</div>
           <div class="relative mt-2" style="height: 40px;">
             <canvas bind:this={sparklineCanvases[0]} style="width: 100%; height: 100%;"></canvas>
           </div>
         </div>
 
         <!-- Impressions -->
-        <div class="bg-white border border-gray-200 rounded-xl p-4 border-t-4 border-t-purple-400">
-          <div class="text-xs text-gray-500 mb-1">{$_('seo.searchConsolePanel.totalImpressions')}</div>
-          <div class="text-2xl font-bold text-gray-900">{formatNumber(summary.totals.impressions)}</div>
+        <div class="bg-surface border border-border rounded-xl p-4 border-t-4 border-t-purple-400">
+          <div class="text-xs text-ink-muted mb-1">{$_('seo.searchConsolePanel.totalImpressions')}</div>
+          <div class="text-2xl font-bold text-ink">{formatNumber(summary.totals.impressions)}</div>
           <div class="relative mt-2" style="height: 40px;">
             <canvas bind:this={sparklineCanvases[1]} style="width: 100%; height: 100%;"></canvas>
           </div>
         </div>
 
         <!-- CTR -->
-        <div class="bg-white border border-gray-200 rounded-xl p-4 border-t-4 border-t-green-400">
-          <div class="text-xs text-gray-500 mb-1">{$_('seo.searchConsolePanel.avgCtr')}</div>
-          <div class="text-2xl font-bold text-gray-900">{formatCtr(summary.totals.ctr)}</div>
+        <div class="bg-surface border border-border rounded-xl p-4 border-t-4 border-t-green-400">
+          <div class="text-xs text-ink-muted mb-1">{$_('seo.searchConsolePanel.avgCtr')}</div>
+          <div class="text-2xl font-bold text-ink">{formatCtr(summary.totals.ctr)}</div>
           <div class="relative mt-2" style="height: 40px;">
             <canvas bind:this={sparklineCanvases[2]} style="width: 100%; height: 100%;"></canvas>
           </div>
         </div>
 
         <!-- Position -->
-        <div class="bg-white border border-gray-200 rounded-xl p-4 border-t-4 border-t-amber-400">
-          <div class="text-xs text-gray-500 mb-1">{$_('seo.searchConsolePanel.avgPosition')}</div>
-          <div class="text-2xl font-bold text-gray-900">{formatPosition(summary.totals.position)}</div>
+        <div class="bg-surface border border-border rounded-xl p-4 border-t-4 border-t-amber-400">
+          <div class="text-xs text-ink-muted mb-1">{$_('seo.searchConsolePanel.avgPosition')}</div>
+          <div class="text-2xl font-bold text-ink">{formatPosition(summary.totals.position)}</div>
           <div class="relative mt-2" style="height: 40px;">
             <canvas bind:this={sparklineCanvases[3]} style="width: 100%; height: 100%;"></canvas>
           </div>
@@ -408,29 +408,29 @@
 
         <!-- Top Queries -->
         <div>
-          <h3 class="text-sm font-semibold text-gray-700 mb-3">{$_('seo.searchConsolePanel.topQueries')}</h3>
+          <h3 class="text-sm font-semibold text-ink mb-3">{$_('seo.searchConsolePanel.topQueries')}</h3>
           {#if sortedQueries.length === 0}
-            <div class="text-sm text-gray-400 py-6 text-center bg-gray-50 rounded-xl">{$_('seo.searchConsolePanel.loadError')}</div>
+            <div class="text-sm text-ink-subtle py-6 text-center bg-surface-2 rounded-xl">{$_('seo.searchConsolePanel.loadError')}</div>
           {:else}
-            <div class="rounded-xl border border-gray-200 overflow-x-auto">
+            <div class="rounded-xl border border-border overflow-x-auto">
               <table class="w-full text-sm min-w-[420px]">
                 <thead>
-                  <tr class="bg-gray-50 border-b border-gray-200">
-                    <th class="text-left px-3 py-2.5 text-xs font-semibold text-gray-500">{$_('seo.searchConsolePanel.query')}</th>
-                    <th class="text-right px-3 py-2.5 text-xs font-semibold text-gray-500 cursor-pointer hover:text-gray-700 whitespace-nowrap select-none" on:click={() => toggleQuerySort('clicks')}>{$_('seo.searchConsolePanel.clicks')} {sortIcon('clicks', querySort, querySortDir)}</th>
-                    <th class="text-right px-3 py-2.5 text-xs font-semibold text-gray-500 cursor-pointer hover:text-gray-700 whitespace-nowrap select-none" on:click={() => toggleQuerySort('impressions')}>{$_('seo.searchConsolePanel.impressions')} {sortIcon('impressions', querySort, querySortDir)}</th>
-                    <th class="text-right px-3 py-2.5 text-xs font-semibold text-gray-500 cursor-pointer hover:text-gray-700 whitespace-nowrap select-none" on:click={() => toggleQuerySort('ctr')}>{$_('seo.searchConsolePanel.ctr')} {sortIcon('ctr', querySort, querySortDir)}</th>
-                    <th class="text-right px-3 py-2.5 text-xs font-semibold text-gray-500 cursor-pointer hover:text-gray-700 whitespace-nowrap select-none" on:click={() => toggleQuerySort('position')}>{$_('seo.searchConsolePanel.position')} {sortIcon('position', querySort, querySortDir)}</th>
+                  <tr class="bg-surface-2 border-b border-border">
+                    <th class="text-left px-3 py-2.5 text-xs font-semibold text-ink-muted">{$_('seo.searchConsolePanel.query')}</th>
+                    <th class="text-right px-3 py-2.5 text-xs font-semibold text-ink-muted cursor-pointer hover:text-gray-700 whitespace-nowrap select-none" on:click={() => toggleQuerySort('clicks')}>{$_('seo.searchConsolePanel.clicks')} {sortIcon('clicks', querySort, querySortDir)}</th>
+                    <th class="text-right px-3 py-2.5 text-xs font-semibold text-ink-muted cursor-pointer hover:text-gray-700 whitespace-nowrap select-none" on:click={() => toggleQuerySort('impressions')}>{$_('seo.searchConsolePanel.impressions')} {sortIcon('impressions', querySort, querySortDir)}</th>
+                    <th class="text-right px-3 py-2.5 text-xs font-semibold text-ink-muted cursor-pointer hover:text-gray-700 whitespace-nowrap select-none" on:click={() => toggleQuerySort('ctr')}>{$_('seo.searchConsolePanel.ctr')} {sortIcon('ctr', querySort, querySortDir)}</th>
+                    <th class="text-right px-3 py-2.5 text-xs font-semibold text-ink-muted cursor-pointer hover:text-gray-700 whitespace-nowrap select-none" on:click={() => toggleQuerySort('position')}>{$_('seo.searchConsolePanel.position')} {sortIcon('position', querySort, querySortDir)}</th>
                   </tr>
                 </thead>
                 <tbody>
                   {#each sortedQueries as row}
-                    <tr class="border-b border-gray-100 hover:bg-gray-50">
-                      <td class="px-3 py-2 text-gray-800 max-w-[160px] truncate" title={row.query}>{row.query}</td>
-                      <td class="px-3 py-2 text-right text-gray-700 font-medium">{formatNumber(row.clicks)}</td>
-                      <td class="px-3 py-2 text-right text-gray-600">{formatNumber(row.impressions)}</td>
-                      <td class="px-3 py-2 text-right text-gray-600">{formatCtr(row.ctr)}</td>
-                      <td class="px-3 py-2 text-right text-gray-600">{formatPosition(row.position)}</td>
+                    <tr class="border-b border-border hover:bg-surface-2">
+                      <td class="px-3 py-2 text-ink max-w-[160px] truncate" title={row.query}>{row.query}</td>
+                      <td class="px-3 py-2 text-right text-ink font-medium">{formatNumber(row.clicks)}</td>
+                      <td class="px-3 py-2 text-right text-ink-muted">{formatNumber(row.impressions)}</td>
+                      <td class="px-3 py-2 text-right text-ink-muted">{formatCtr(row.ctr)}</td>
+                      <td class="px-3 py-2 text-right text-ink-muted">{formatPosition(row.position)}</td>
                     </tr>
                   {/each}
                 </tbody>
@@ -441,31 +441,31 @@
 
         <!-- Top Pages -->
         <div>
-          <h3 class="text-sm font-semibold text-gray-700 mb-3">{$_('seo.searchConsolePanel.topPages')}</h3>
+          <h3 class="text-sm font-semibold text-ink mb-3">{$_('seo.searchConsolePanel.topPages')}</h3>
           {#if sortedPages.length === 0}
-            <div class="text-sm text-gray-400 py-6 text-center bg-gray-50 rounded-xl">{$_('seo.searchConsolePanel.loadError')}</div>
+            <div class="text-sm text-ink-subtle py-6 text-center bg-surface-2 rounded-xl">{$_('seo.searchConsolePanel.loadError')}</div>
           {:else}
-            <div class="rounded-xl border border-gray-200 overflow-x-auto">
+            <div class="rounded-xl border border-border overflow-x-auto">
               <table class="w-full text-sm min-w-[420px]">
                 <thead>
-                  <tr class="bg-gray-50 border-b border-gray-200">
-                    <th class="text-left px-3 py-2.5 text-xs font-semibold text-gray-500">{$_('seo.searchConsolePanel.page')}</th>
-                    <th class="text-right px-3 py-2.5 text-xs font-semibold text-gray-500 cursor-pointer hover:text-gray-700 whitespace-nowrap select-none" on:click={() => togglePageSort('clicks')}>{$_('seo.searchConsolePanel.clicks')} {sortIcon('clicks', pageSort, pageSortDir)}</th>
-                    <th class="text-right px-3 py-2.5 text-xs font-semibold text-gray-500 cursor-pointer hover:text-gray-700 whitespace-nowrap select-none" on:click={() => togglePageSort('impressions')}>{$_('seo.searchConsolePanel.impressions')} {sortIcon('impressions', pageSort, pageSortDir)}</th>
-                    <th class="text-right px-3 py-2.5 text-xs font-semibold text-gray-500 cursor-pointer hover:text-gray-700 whitespace-nowrap select-none" on:click={() => togglePageSort('ctr')}>{$_('seo.searchConsolePanel.ctr')} {sortIcon('ctr', pageSort, pageSortDir)}</th>
-                    <th class="text-right px-3 py-2.5 text-xs font-semibold text-gray-500 cursor-pointer hover:text-gray-700 whitespace-nowrap select-none" on:click={() => togglePageSort('position')}>{$_('seo.searchConsolePanel.position')} {sortIcon('position', pageSort, pageSortDir)}</th>
+                  <tr class="bg-surface-2 border-b border-border">
+                    <th class="text-left px-3 py-2.5 text-xs font-semibold text-ink-muted">{$_('seo.searchConsolePanel.page')}</th>
+                    <th class="text-right px-3 py-2.5 text-xs font-semibold text-ink-muted cursor-pointer hover:text-gray-700 whitespace-nowrap select-none" on:click={() => togglePageSort('clicks')}>{$_('seo.searchConsolePanel.clicks')} {sortIcon('clicks', pageSort, pageSortDir)}</th>
+                    <th class="text-right px-3 py-2.5 text-xs font-semibold text-ink-muted cursor-pointer hover:text-gray-700 whitespace-nowrap select-none" on:click={() => togglePageSort('impressions')}>{$_('seo.searchConsolePanel.impressions')} {sortIcon('impressions', pageSort, pageSortDir)}</th>
+                    <th class="text-right px-3 py-2.5 text-xs font-semibold text-ink-muted cursor-pointer hover:text-gray-700 whitespace-nowrap select-none" on:click={() => togglePageSort('ctr')}>{$_('seo.searchConsolePanel.ctr')} {sortIcon('ctr', pageSort, pageSortDir)}</th>
+                    <th class="text-right px-3 py-2.5 text-xs font-semibold text-ink-muted cursor-pointer hover:text-gray-700 whitespace-nowrap select-none" on:click={() => togglePageSort('position')}>{$_('seo.searchConsolePanel.position')} {sortIcon('position', pageSort, pageSortDir)}</th>
                   </tr>
                 </thead>
                 <tbody>
                   {#each sortedPages as row}
-                    <tr class="border-b border-gray-100 hover:bg-gray-50">
+                    <tr class="border-b border-border hover:bg-surface-2">
                       <td class="px-3 py-2 max-w-[160px]">
-                        <span class="text-gray-800 truncate block" title={row.page}>{getPath(row.page)}</span>
+                        <span class="text-ink truncate block" title={row.page}>{getPath(row.page)}</span>
                       </td>
-                      <td class="px-3 py-2 text-right text-gray-700 font-medium">{formatNumber(row.clicks)}</td>
-                      <td class="px-3 py-2 text-right text-gray-600">{formatNumber(row.impressions)}</td>
-                      <td class="px-3 py-2 text-right text-gray-600">{formatCtr(row.ctr)}</td>
-                      <td class="px-3 py-2 text-right text-gray-600">{formatPosition(row.position)}</td>
+                      <td class="px-3 py-2 text-right text-ink font-medium">{formatNumber(row.clicks)}</td>
+                      <td class="px-3 py-2 text-right text-ink-muted">{formatNumber(row.impressions)}</td>
+                      <td class="px-3 py-2 text-right text-ink-muted">{formatCtr(row.ctr)}</td>
+                      <td class="px-3 py-2 text-right text-ink-muted">{formatPosition(row.position)}</td>
                     </tr>
                   {/each}
                 </tbody>
@@ -479,10 +479,10 @@
       <div class="grid grid-cols-1 lg:grid-cols-2 gap-5">
 
         <!-- Devices donut -->
-        <div class="bg-gray-50 rounded-xl p-4 border border-gray-100">
-          <h3 class="text-sm font-semibold text-gray-700 mb-3">{$_('seo.searchConsolePanel.devices')}</h3>
+        <div class="bg-surface-2 rounded-xl p-4 border border-border">
+          <h3 class="text-sm font-semibold text-ink mb-3">{$_('seo.searchConsolePanel.devices')}</h3>
           {#if summary.byDevice.length === 0}
-            <div class="text-sm text-gray-400 py-6 text-center">{$_('seo.searchConsolePanel.loadError')}</div>
+            <div class="text-sm text-ink-subtle py-6 text-center">{$_('seo.searchConsolePanel.loadError')}</div>
           {:else}
             <div class="relative mx-auto" style="height: 180px; max-width: 240px;">
               <canvas bind:this={deviceCanvas} style="width: 100%; height: 100%;"></canvas>
@@ -491,23 +491,23 @@
         </div>
 
         <!-- Countries table -->
-        <div class="bg-gray-50 rounded-xl p-4 border border-gray-100">
-          <h3 class="text-sm font-semibold text-gray-700 mb-3">{$_('seo.searchConsolePanel.countries')}</h3>
+        <div class="bg-surface-2 rounded-xl p-4 border border-border">
+          <h3 class="text-sm font-semibold text-ink mb-3">{$_('seo.searchConsolePanel.countries')}</h3>
           {#if summary.byCountry.length === 0}
-            <div class="text-sm text-gray-400 py-6 text-center">{$_('seo.searchConsolePanel.loadError')}</div>
+            <div class="text-sm text-ink-subtle py-6 text-center">{$_('seo.searchConsolePanel.loadError')}</div>
           {:else}
             <div class="space-y-1.5">
               {#each summary.byCountry as row}
                 {@const maxClicks = summary.byCountry[0]?.clicks || 1}
                 <div class="flex items-center gap-2">
-                  <span class="text-xs text-gray-600 w-28 flex-shrink-0">{getCountryName(row.country)}</span>
+                  <span class="text-xs text-ink-muted w-28 flex-shrink-0">{getCountryName(row.country)}</span>
                   <div class="flex-1 bg-gray-200 rounded-full h-2">
                     <div
                       class="h-2 rounded-full bg-blue-400 transition-all duration-300"
                       style="width: {Math.max(2, (row.clicks / maxClicks) * 100)}%">
                     </div>
                   </div>
-                  <span class="text-xs font-medium text-gray-700 w-12 text-right">{formatNumber(row.clicks)}</span>
+                  <span class="text-xs font-medium text-ink w-12 text-right">{formatNumber(row.clicks)}</span>
                 </div>
               {/each}
             </div>

--- a/apps/web/src/lib/components/analytics/StabilityChart.svelte
+++ b/apps/web/src/lib/components/analytics/StabilityChart.svelte
@@ -91,8 +91,8 @@
   }
 </script>
 
-<div class="bg-white rounded-xl border border-gray-200 p-5">
-  <h3 class="text-sm font-semibold text-gray-700 mb-4">{$_('googlePlay.metrics.crashes')} & {$_('googlePlay.metrics.anrs')}</h3>
+<div class="bg-surface rounded-xl border border-border p-5">
+  <h3 class="text-sm font-semibold text-ink mb-4">{$_('googlePlay.metrics.crashes')} & {$_('googlePlay.metrics.anrs')}</h3>
   <div class="relative" style="height: 288px;">
     <canvas bind:this={canvas} style="width: 100%; height: 100%;"></canvas>
   </div>

--- a/apps/web/src/lib/components/analytics/StoreListingStats.svelte
+++ b/apps/web/src/lib/components/analytics/StoreListingStats.svelte
@@ -74,12 +74,12 @@
   $: conversionRate = totalVisitors > 0 ? ((totalConversions / totalVisitors) * 100).toFixed(1) : '0.0';
 </script>
 
-<div class="bg-white rounded-xl border border-gray-200 p-5">
+<div class="bg-surface rounded-xl border border-border p-5">
   <div class="flex items-center justify-between mb-4">
-    <h3 class="text-sm font-semibold text-gray-700">{$_('googlePlay.metrics.visitors')} vs {$_('googlePlay.metrics.conversion')}</h3>
-    <div class="flex items-center gap-4 text-xs text-gray-500">
-      <span>{$_('googlePlay.metrics.visitors')}: <strong class="text-gray-900">{totalVisitors.toLocaleString()}</strong></span>
-      <span>{$_('googlePlay.metrics.conversion')}: <strong class="text-gray-900">{conversionRate}%</strong></span>
+    <h3 class="text-sm font-semibold text-ink">{$_('googlePlay.metrics.visitors')} vs {$_('googlePlay.metrics.conversion')}</h3>
+    <div class="flex items-center gap-4 text-xs text-ink-muted">
+      <span>{$_('googlePlay.metrics.visitors')}: <strong class="text-ink">{totalVisitors.toLocaleString()}</strong></span>
+      <span>{$_('googlePlay.metrics.conversion')}: <strong class="text-ink">{conversionRate}%</strong></span>
     </div>
   </div>
   <div class="relative" style="height: 288px;">

--- a/apps/web/src/lib/components/campaign-detail/AttachContentModal.svelte
+++ b/apps/web/src/lib/components/campaign-detail/AttachContentModal.svelte
@@ -62,36 +62,36 @@
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => dispatch('close')}>
-  <div class="bg-white rounded-2xl shadow-2xl w-full max-w-lg flex flex-col max-h-[85vh]">
-    <div class="p-5 border-b border-gray-100">
-      <h2 class="text-lg font-semibold text-gray-900 mb-3">{$_('campaigns.detail.attachContent')}</h2>
+  <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-lg flex flex-col max-h-[85vh]">
+    <div class="p-5 border-b border-border">
+      <h2 class="text-lg font-semibold text-ink mb-3">{$_('campaigns.detail.attachContent')}</h2>
       <input
         type="text"
         bind:value={search}
         on:input={onSearch}
         placeholder={$_('campaigns.detail.searchPlaceholder')}
-        class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+        class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
       />
     </div>
     <div class="flex-1 overflow-y-auto p-5">
       {#if loading}
-        <div class="text-center py-6 text-sm text-gray-500">…</div>
+        <div class="text-center py-6 text-sm text-ink-muted">…</div>
       {:else if candidates.length === 0}
-        <p class="text-sm text-gray-500 text-center py-6">{$_('campaigns.detail.noCandidates')}</p>
+        <p class="text-sm text-ink-muted text-center py-6">{$_('campaigns.detail.noCandidates')}</p>
       {:else}
         <ul class="space-y-1">
           {#each candidates as item}
             <li>
-              <label class="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50 cursor-pointer">
+              <label class="flex items-center gap-3 p-2 rounded-lg hover:bg-surface-2 cursor-pointer">
                 <input
                   type="checkbox"
                   checked={selected.has(item.id)}
                   on:change={() => toggle(item.id)}
-                  class="w-4 h-4 text-primary-600 rounded border-gray-300"
+                  class="w-4 h-4 text-brand rounded border-border"
                 />
                 <div class="flex-1 min-w-0">
-                  <div class="text-sm text-gray-900 truncate">{item.title}</div>
-                  <div class="text-xs text-gray-500">
+                  <div class="text-sm text-ink truncate">{item.title}</div>
+                  <div class="text-xs text-ink-muted">
                     {item.type || ''}{item.language ? ' · ' + item.language.toUpperCase() : ''} · {item.status}
                   </div>
                 </div>
@@ -101,17 +101,17 @@
         </ul>
       {/if}
     </div>
-    <div class="p-5 border-t border-gray-100 flex gap-3">
+    <div class="p-5 border-t border-border flex gap-3">
       <button
         on:click={attach}
         disabled={attaching || selected.size === 0}
-        class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 disabled:opacity-50 text-sm cursor-pointer"
+        class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 disabled:opacity-50 text-sm cursor-pointer"
       >
         {$_('campaigns.detail.attachCount', { values: { count: selected.size } })}
       </button>
       <button
         on:click={() => dispatch('close')}
-        class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm cursor-pointer"
+        class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 text-sm cursor-pointer"
       >
         {$_('common.cancel')}
       </button>

--- a/apps/web/src/lib/components/campaign-detail/AttachDocumentsModal.svelte
+++ b/apps/web/src/lib/components/campaign-detail/AttachDocumentsModal.svelte
@@ -69,46 +69,46 @@
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => dispatch('close')}>
-  <div class="bg-white rounded-2xl shadow-2xl w-full max-w-lg flex flex-col max-h-[85vh]">
-    <div class="p-5 border-b border-gray-100">
-      <h2 class="text-lg font-semibold text-gray-900 mb-3">{$_('campaigns.detail.attachDocuments')}</h2>
+  <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-lg flex flex-col max-h-[85vh]">
+    <div class="p-5 border-b border-border">
+      <h2 class="text-lg font-semibold text-ink mb-3">{$_('campaigns.detail.attachDocuments')}</h2>
       <input
         type="text"
         bind:value={search}
         on:input={onSearch}
         placeholder={$_('campaigns.detail.searchPlaceholder')}
-        class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+        class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
       />
     </div>
     <div class="flex-1 overflow-y-auto p-5">
       {#if loading}
-        <div class="text-center py-6 text-sm text-gray-500">…</div>
+        <div class="text-center py-6 text-sm text-ink-muted">…</div>
       {:else if candidates.length === 0}
-        <p class="text-sm text-gray-500 text-center py-6">{$_('campaigns.detail.noDocumentCandidates')}</p>
+        <p class="text-sm text-ink-muted text-center py-6">{$_('campaigns.detail.noDocumentCandidates')}</p>
       {:else}
         <ul class="space-y-1">
           {#each candidates as item}
             <li>
-              <label class="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50 cursor-pointer">
+              <label class="flex items-center gap-3 p-2 rounded-lg hover:bg-surface-2 cursor-pointer">
                 <input
                   type="checkbox"
                   checked={selected.has(item.id)}
                   on:change={() => toggle(item.id)}
-                  class="w-4 h-4 text-primary-600 rounded border-gray-300"
+                  class="w-4 h-4 text-brand rounded border-border"
                 />
                 <div class="flex-1 min-w-0">
-                  <div class="text-sm text-gray-900 truncate">{item.title}</div>
-                  <div class="text-xs text-gray-500 flex items-center gap-1.5 flex-wrap">
+                  <div class="text-sm text-ink truncate">{item.title}</div>
+                  <div class="text-xs text-ink-muted flex items-center gap-1.5 flex-wrap">
                     <span>{item.type || ''}</span>
                     {#if item.fileUrl}
-                      <span class="text-gray-300">·</span>
+                      <span class="text-ink-subtle">·</span>
                       <span>{item.fileName || ''}</span>
                       {#if item.fileSize}
-                        <span class="text-gray-300">·</span>
+                        <span class="text-ink-subtle">·</span>
                         <span>{formatFileSize(item.fileSize)}</span>
                       {/if}
                     {:else if item.generatedByAi}
-                      <span class="text-gray-300">·</span>
+                      <span class="text-ink-subtle">·</span>
                       <span class="text-purple-600">AI</span>
                     {/if}
                   </div>
@@ -119,17 +119,17 @@
         </ul>
       {/if}
     </div>
-    <div class="p-5 border-t border-gray-100 flex gap-3">
+    <div class="p-5 border-t border-border flex gap-3">
       <button
         on:click={attach}
         disabled={attaching || selected.size === 0}
-        class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 disabled:opacity-50 text-sm cursor-pointer"
+        class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 disabled:opacity-50 text-sm cursor-pointer"
       >
         {$_('campaigns.detail.attachDocumentsCount', { values: { count: selected.size } })}
       </button>
       <button
         on:click={() => dispatch('close')}
-        class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm cursor-pointer"
+        class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 text-sm cursor-pointer"
       >
         {$_('common.cancel')}
       </button>

--- a/apps/web/src/lib/components/campaign-detail/AttachEmailModal.svelte
+++ b/apps/web/src/lib/components/campaign-detail/AttachEmailModal.svelte
@@ -62,36 +62,36 @@
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => dispatch('close')}>
-  <div class="bg-white rounded-2xl shadow-2xl w-full max-w-lg flex flex-col max-h-[85vh]">
-    <div class="p-5 border-b border-gray-100">
-      <h2 class="text-lg font-semibold text-gray-900 mb-3">{$_('campaigns.detail.attachEmail')}</h2>
+  <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-lg flex flex-col max-h-[85vh]">
+    <div class="p-5 border-b border-border">
+      <h2 class="text-lg font-semibold text-ink mb-3">{$_('campaigns.detail.attachEmail')}</h2>
       <input
         type="text"
         bind:value={search}
         on:input={onSearch}
         placeholder={$_('campaigns.detail.searchPlaceholder')}
-        class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+        class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
       />
     </div>
     <div class="flex-1 overflow-y-auto p-5">
       {#if loading}
-        <div class="text-center py-6 text-sm text-gray-500">…</div>
+        <div class="text-center py-6 text-sm text-ink-muted">…</div>
       {:else if candidates.length === 0}
-        <p class="text-sm text-gray-500 text-center py-6">{$_('campaigns.detail.noCandidates')}</p>
+        <p class="text-sm text-ink-muted text-center py-6">{$_('campaigns.detail.noCandidates')}</p>
       {:else}
         <ul class="space-y-1">
           {#each candidates as item}
             <li>
-              <label class="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-50 cursor-pointer">
+              <label class="flex items-center gap-3 p-2 rounded-lg hover:bg-surface-2 cursor-pointer">
                 <input
                   type="checkbox"
                   checked={selected.has(item.id)}
                   on:change={() => toggle(item.id)}
-                  class="w-4 h-4 text-primary-600 rounded border-gray-300"
+                  class="w-4 h-4 text-brand rounded border-border"
                 />
                 <div class="flex-1 min-w-0">
-                  <div class="text-sm text-gray-900 truncate">{item.subject}</div>
-                  <div class="text-xs text-gray-500">
+                  <div class="text-sm text-ink truncate">{item.subject}</div>
+                  <div class="text-xs text-ink-muted">
                     {item.list?.name || ''} · {item.emailAccount?.email || ''} · {item.status}
                   </div>
                 </div>
@@ -101,17 +101,17 @@
         </ul>
       {/if}
     </div>
-    <div class="p-5 border-t border-gray-100 flex gap-3">
+    <div class="p-5 border-t border-border flex gap-3">
       <button
         on:click={attach}
         disabled={attaching || selected.size === 0}
-        class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 disabled:opacity-50 text-sm cursor-pointer"
+        class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 disabled:opacity-50 text-sm cursor-pointer"
       >
         {$_('campaigns.detail.attachCount', { values: { count: selected.size } })}
       </button>
       <button
         on:click={() => dispatch('close')}
-        class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm cursor-pointer"
+        class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 text-sm cursor-pointer"
       >
         {$_('common.cancel')}
       </button>

--- a/apps/web/src/lib/components/campaign-detail/CampaignDetail.svelte
+++ b/apps/web/src/lib/components/campaign-detail/CampaignDetail.svelte
@@ -111,15 +111,15 @@
 </script>
 
 <div class="p-4 sm:p-6 max-w-5xl mx-auto">
-  <a href={backHref} class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-4">
+  <a href={backHref} class="inline-flex items-center gap-1 text-sm text-ink-muted hover:text-gray-700 mb-4">
     ← {$_('common.back')}
   </a>
 
   {#if loading}
     <div class="space-y-3">
-      <div class="animate-pulse bg-white border rounded-xl h-28"></div>
-      <div class="animate-pulse bg-white border rounded-xl h-20"></div>
-      <div class="animate-pulse bg-white border rounded-xl h-40"></div>
+      <div class="animate-pulse bg-surface border rounded-xl h-28"></div>
+      <div class="animate-pulse bg-surface border rounded-xl h-20"></div>
+      <div class="animate-pulse bg-surface border rounded-xl h-40"></div>
     </div>
   {:else if error}
     <p class="text-red-500">{error}</p>
@@ -139,27 +139,27 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => (editing = null)}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-lg">
-      <div class="p-6 border-b border-gray-100">
-        <h2 class="text-lg font-semibold text-gray-900">{$_('campaigns.editCampaign')}</h2>
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-lg">
+      <div class="p-6 border-b border-border">
+        <h2 class="text-lg font-semibold text-ink">{$_('campaigns.editCampaign')}</h2>
       </div>
       <div class="p-6 space-y-4">
         <div>
-          <label for="ed-name" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.name')} *</label>
-          <input id="ed-name" type="text" bind:value={editForm.name} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+          <label for="ed-name" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.name')} *</label>
+          <input id="ed-name" type="text" bind:value={editForm.name} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>
-            <label for="ed-type" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.type')}</label>
-            <select id="ed-type" bind:value={editForm.type} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500">
+            <label for="ed-type" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.type')}</label>
+            <select id="ed-type" bind:value={editForm.type} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500">
               {#each CAMPAIGN_TYPES as t}
                 <option value={t}>{$_(typeLabel[t])}</option>
               {/each}
             </select>
           </div>
           <div>
-            <label for="ed-status" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.status')}</label>
-            <select id="ed-status" bind:value={editForm.status} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500">
+            <label for="ed-status" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.status')}</label>
+            <select id="ed-status" bind:value={editForm.status} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500">
               {#each CAMPAIGN_STATUSES as s}
                 <option value={s}>{$_(statusLabel[s])}</option>
               {/each}
@@ -168,32 +168,32 @@
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>
-            <label for="ed-start" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.startDate')}</label>
-            <input id="ed-start" type="date" bind:value={editForm.startDate} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+            <label for="ed-start" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.startDate')}</label>
+            <input id="ed-start" type="date" bind:value={editForm.startDate} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
           </div>
           <div>
-            <label for="ed-end" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.endDate')}</label>
-            <input id="ed-end" type="date" bind:value={editForm.endDate} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+            <label for="ed-end" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.endDate')}</label>
+            <input id="ed-end" type="date" bind:value={editForm.endDate} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
           </div>
         </div>
         <div>
-          <label for="ed-budget" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.budget')}</label>
-          <input id="ed-budget" type="number" step="0.01" min="0" bind:value={editForm.budget} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+          <label for="ed-budget" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.budget')}</label>
+          <input id="ed-budget" type="number" step="0.01" min="0" bind:value={editForm.budget} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
         </div>
         <div>
-          <label for="ed-goals" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.goals')}</label>
-          <textarea id="ed-goals" bind:value={editForm.goals} rows="3" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 resize-none"></textarea>
+          <label for="ed-goals" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.goals')}</label>
+          <textarea id="ed-goals" bind:value={editForm.goals} rows="3" class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 resize-none"></textarea>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={saveEdit}
           disabled={editSaving}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 disabled:opacity-50 text-sm cursor-pointer"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 disabled:opacity-50 text-sm cursor-pointer"
         >
           {editSaving ? $_('campaigns.saving') : $_('common.save')}
         </button>
-        <button on:click={() => (editing = null)} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm cursor-pointer">
+        <button on:click={() => (editing = null)} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>
@@ -205,20 +205,20 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => (deletingId = null)}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm">
       <div class="p-6">
         <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-4">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900 mb-2">{$_('campaigns.deleteCampaign')}</h2>
-        <p class="text-sm text-gray-500 mb-6">{$_('campaigns.confirmDelete')}</p>
+        <h2 class="text-lg font-semibold text-ink mb-2">{$_('campaigns.deleteCampaign')}</h2>
+        <p class="text-sm text-ink-muted mb-6">{$_('campaigns.confirmDelete')}</p>
         <div class="flex gap-3">
           <button on:click={confirmDelete} class="flex-1 bg-red-600 text-white py-2.5 rounded-lg font-medium hover:bg-red-700 text-sm cursor-pointer">
             {$_('common.delete')}
           </button>
-          <button on:click={() => (deletingId = null)} class="flex-1 px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm cursor-pointer">
+          <button on:click={() => (deletingId = null)} class="flex-1 px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 text-sm cursor-pointer">
             {$_('common.cancel')}
           </button>
         </div>

--- a/apps/web/src/lib/components/campaign-detail/CampaignHeader.svelte
+++ b/apps/web/src/lib/components/campaign-detail/CampaignHeader.svelte
@@ -7,7 +7,7 @@
   const dispatch = createEventDispatcher<{ edit: any; delete: string }>();
 
   const statusBadge: Record<string, string> = {
-    DRAFT: 'bg-gray-100 text-gray-600',
+    DRAFT: 'bg-surface-2 text-ink-muted',
     SCHEDULED: 'bg-yellow-100 text-yellow-700',
     ACTIVE: 'bg-green-100 text-green-700',
     PAUSED: 'bg-orange-100 text-orange-700',
@@ -43,20 +43,20 @@
   $: hasMeta = campaign?.budget != null || (campaign?.goals && campaign.goals.trim() !== '');
 </script>
 
-<div class="bg-white rounded-xl border border-gray-200 p-5">
+<div class="bg-surface rounded-xl border border-border p-5">
   <div class="flex flex-col sm:flex-row items-start justify-between gap-3">
     <div class="flex-1 min-w-0">
       <div class="flex flex-wrap items-center gap-1.5 mb-2">
-        <span class="text-xs px-2 py-0.5 rounded font-medium {typeBadge[campaign.type] || 'bg-gray-100 text-gray-600'}">
+        <span class="text-xs px-2 py-0.5 rounded font-medium {typeBadge[campaign.type] || 'bg-surface-2 text-ink-muted'}">
           {$_(typeLabel[campaign.type] || 'campaigns.email')}
         </span>
-        <span class="text-xs px-2 py-0.5 rounded {statusBadge[campaign.status] || 'bg-gray-100 text-gray-600'}">
+        <span class="text-xs px-2 py-0.5 rounded {statusBadge[campaign.status] || 'bg-surface-2 text-ink-muted'}">
           {$_(statusLabel[campaign.status] || 'campaigns.draft')}
         </span>
       </div>
-      <h1 class="text-xl font-semibold text-gray-900 truncate">{campaign.name}</h1>
+      <h1 class="text-xl font-semibold text-ink truncate">{campaign.name}</h1>
       {#if hasMeta}
-        <div class="flex flex-wrap items-center gap-3 mt-2 text-sm text-gray-500">
+        <div class="flex flex-wrap items-center gap-3 mt-2 text-sm text-ink-muted">
           {#if campaign.budget != null}
             <span class="inline-flex items-center gap-1">
               <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -74,7 +74,7 @@
     <div class="flex items-center gap-2 flex-shrink-0">
       <button
         on:click={() => dispatch('edit', campaign)}
-        class="text-xs px-3 py-1.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
+        class="text-xs px-3 py-1.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
       >
         {$_('common.edit')}
       </button>

--- a/apps/web/src/lib/components/campaign-detail/ContentSection.svelte
+++ b/apps/web/src/lib/components/campaign-detail/ContentSection.svelte
@@ -12,10 +12,10 @@
   let detaching: string | null = null;
 
   const statusBadge: Record<string, string> = {
-    DRAFT: 'bg-gray-100 text-gray-600',
+    DRAFT: 'bg-surface-2 text-ink-muted',
     APPROVED: 'bg-yellow-100 text-yellow-700',
     PUBLISHED: 'bg-green-100 text-green-700',
-    ARCHIVED: 'bg-gray-50 text-gray-400',
+    ARCHIVED: 'bg-surface-2 text-ink-subtle',
   };
 
   const statusLabel: Record<string, string> = {
@@ -55,45 +55,45 @@
   }
 </script>
 
-<div class="bg-white rounded-xl border border-gray-200 p-5">
+<div class="bg-surface rounded-xl border border-border p-5">
   <div class="flex items-center justify-between mb-4">
-    <h2 class="text-base font-semibold text-gray-900">
+    <h2 class="text-base font-semibold text-ink">
       {$_('campaigns.detail.contentSection')}
-      <span class="ml-1 text-sm font-normal text-gray-500">({campaign.content?.length ?? 0})</span>
+      <span class="ml-1 text-sm font-normal text-ink-muted">({campaign.content?.length ?? 0})</span>
     </h2>
     <button
       on:click={() => (showAttach = true)}
-      class="text-xs px-3 py-1.5 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors cursor-pointer"
+      class="text-xs px-3 py-1.5 bg-brand text-white rounded-lg hover:brightness-110 transition-colors cursor-pointer"
     >
       + {$_('campaigns.detail.attachContent')}
     </button>
   </div>
 
   {#if !campaign.content || campaign.content.length === 0}
-    <p class="text-sm text-gray-500 py-6 text-center">{$_('campaigns.detail.emptyContent')}</p>
+    <p class="text-sm text-ink-muted py-6 text-center">{$_('campaigns.detail.emptyContent')}</p>
   {:else}
-    <ul class="divide-y divide-gray-100">
+    <ul class="divide-y divide-border">
       {#each campaign.content as item}
         <li class="py-3 flex items-center justify-between gap-3">
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-2 mb-0.5">
-              <span class="text-xs px-2 py-0.5 rounded {statusBadge[item.status] || 'bg-gray-100 text-gray-600'}">
+              <span class="text-xs px-2 py-0.5 rounded {statusBadge[item.status] || 'bg-surface-2 text-ink-muted'}">
                 {$_(statusLabel[item.status] || 'campaigns.detail.statusDraft')}
               </span>
               {#if item.language}
                 <span class="text-xs px-1.5 py-0.5 bg-indigo-50 text-indigo-700 rounded">{item.language.toUpperCase()}</span>
               {/if}
-              <span class="text-xs text-gray-400">{item.type}</span>
-              <span class="text-xs text-gray-400">· {formatDate(item.updatedAt)}</span>
+              <span class="text-xs text-ink-subtle">{item.type}</span>
+              <span class="text-xs text-ink-subtle">· {formatDate(item.updatedAt)}</span>
             </div>
-            <a href={contentHref(item)} class="text-sm text-gray-900 hover:text-primary-600 truncate block">
+            <a href={contentHref(item)} class="text-sm text-ink hover:text-primary-600 truncate block">
               {item.title}
             </a>
           </div>
           <div class="flex items-center gap-1 flex-shrink-0">
             <a
               href={contentHref(item)}
-              class="text-xs px-2 py-1 text-gray-500 hover:text-gray-700 hover:bg-gray-50 rounded cursor-pointer"
+              class="text-xs px-2 py-1 text-ink-muted hover:text-gray-700 hover:bg-surface-2 rounded cursor-pointer"
             >
               {$_('campaigns.detail.open')}
             </a>

--- a/apps/web/src/lib/components/campaign-detail/DateTimeline.svelte
+++ b/apps/web/src/lib/components/campaign-detail/DateTimeline.svelte
@@ -34,11 +34,11 @@
 </script>
 
 {#if visible}
-  <div class="bg-white rounded-xl border border-gray-200 p-5">
-    <div class="flex items-center justify-between text-xs text-gray-500 mb-2">
+  <div class="bg-surface rounded-xl border border-border p-5">
+    <div class="flex items-center justify-between text-xs text-ink-muted mb-2">
       <span>{startDate ? formatDate(startDate) : '—'}</span>
       {#if state === 'notStarted'}
-        <span class="font-medium text-gray-600">{$_('campaigns.detail.notStarted')}</span>
+        <span class="font-medium text-ink-muted">{$_('campaigns.detail.notStarted')}</span>
       {:else if state === 'completed'}
         <span class="font-medium text-blue-600">{$_('campaigns.detail.completed')}</span>
       {:else if state === 'inRange'}
@@ -49,14 +49,14 @@
       {/if}
       <span>{endDate ? formatDate(endDate) : '—'}</span>
     </div>
-    <div class="relative h-2 bg-gray-100 rounded-full overflow-hidden">
+    <div class="relative h-2 bg-surface-2 rounded-full overflow-hidden">
       <div
         class="absolute inset-y-0 left-0 bg-indigo-500 transition-all"
         style="width: {percent}%"
       ></div>
       {#if state === 'inRange'}
         <div
-          class="absolute top-1/2 w-3 h-3 -mt-1.5 -ml-1.5 rounded-full bg-white border-2 border-indigo-600 shadow"
+          class="absolute top-1/2 w-3 h-3 -mt-1.5 -ml-1.5 rounded-full bg-surface border-2 border-indigo-600 shadow"
           style="left: {percent}%"
         ></div>
       {/if}

--- a/apps/web/src/lib/components/campaign-detail/DocumentsSection.svelte
+++ b/apps/web/src/lib/components/campaign-detail/DocumentsSection.svelte
@@ -50,42 +50,42 @@
   }
 </script>
 
-<div class="bg-white rounded-xl border border-gray-200 p-5">
+<div class="bg-surface rounded-xl border border-border p-5">
   <div class="flex items-center justify-between mb-4">
-    <h2 class="text-base font-semibold text-gray-900">
+    <h2 class="text-base font-semibold text-ink">
       {$_('campaigns.detail.documentsSection')}
-      <span class="ml-1 text-sm font-normal text-gray-500">({campaign.documents?.length ?? 0})</span>
+      <span class="ml-1 text-sm font-normal text-ink-muted">({campaign.documents?.length ?? 0})</span>
     </h2>
     <button
       on:click={() => (showAttach = true)}
-      class="text-xs px-3 py-1.5 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors cursor-pointer"
+      class="text-xs px-3 py-1.5 bg-brand text-white rounded-lg hover:brightness-110 transition-colors cursor-pointer"
     >
       + {$_('campaigns.detail.attachDocuments')}
     </button>
   </div>
 
   {#if !campaign.documents || campaign.documents.length === 0}
-    <p class="text-sm text-gray-500 py-6 text-center">{$_('campaigns.detail.emptyDocuments')}</p>
+    <p class="text-sm text-ink-muted py-6 text-center">{$_('campaigns.detail.emptyDocuments')}</p>
   {:else}
-    <ul class="divide-y divide-gray-100">
+    <ul class="divide-y divide-border">
       {#each campaign.documents as item}
         <li class="py-3 flex items-center justify-between gap-3">
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-2 mb-0.5">
-              <span class="text-xs px-2 py-0.5 rounded bg-gray-100 text-gray-600 font-medium">
+              <span class="text-xs px-2 py-0.5 rounded bg-surface-2 text-ink-muted font-medium">
                 {item.type || ''}
               </span>
               {#if item.generatedByAi}
                 <span class="text-xs px-1.5 py-0.5 bg-purple-50 text-purple-600 rounded">AI</span>
               {/if}
               {#if item.fileUrl}
-                <span class="text-xs text-gray-400">{item.fileName || ''}</span>
+                <span class="text-xs text-ink-subtle">{item.fileName || ''}</span>
                 {#if item.fileSize}
-                  <span class="text-xs text-gray-400">· {formatFileSize(item.fileSize)}</span>
+                  <span class="text-xs text-ink-subtle">· {formatFileSize(item.fileSize)}</span>
                 {/if}
               {/if}
             </div>
-            <a href={documentHref(item)} class="text-sm text-gray-900 hover:text-primary-600 truncate block">
+            <a href={documentHref(item)} class="text-sm text-ink hover:text-primary-600 truncate block">
               {item.title}
             </a>
           </div>
@@ -94,14 +94,14 @@
               <a
                 href={downloadUrl(item)}
                 download={item.fileName || item.title}
-                class="text-xs px-2 py-1 text-gray-500 hover:text-gray-700 hover:bg-gray-50 rounded cursor-pointer"
+                class="text-xs px-2 py-1 text-ink-muted hover:text-gray-700 hover:bg-surface-2 rounded cursor-pointer"
               >
                 {$_('documents.download')}
               </a>
             {/if}
             <a
               href={documentHref(item)}
-              class="text-xs px-2 py-1 text-gray-500 hover:text-gray-700 hover:bg-gray-50 rounded cursor-pointer"
+              class="text-xs px-2 py-1 text-ink-muted hover:text-gray-700 hover:bg-surface-2 rounded cursor-pointer"
             >
               {$_('campaigns.detail.open')}
             </a>

--- a/apps/web/src/lib/components/campaign-detail/EmailsSection.svelte
+++ b/apps/web/src/lib/components/campaign-detail/EmailsSection.svelte
@@ -12,7 +12,7 @@
   let detaching: string | null = null;
 
   const statusBadge: Record<string, string> = {
-    draft: 'bg-gray-100 text-gray-600',
+    draft: 'bg-surface-2 text-ink-muted',
     scheduled: 'bg-yellow-100 text-yellow-700',
     sending: 'bg-blue-100 text-blue-700',
     sent: 'bg-green-100 text-green-700',
@@ -52,44 +52,44 @@
   }
 </script>
 
-<div class="bg-white rounded-xl border border-gray-200 p-5">
+<div class="bg-surface rounded-xl border border-border p-5">
   <div class="flex items-center justify-between mb-4">
-    <h2 class="text-base font-semibold text-gray-900">
+    <h2 class="text-base font-semibold text-ink">
       {$_('campaigns.detail.emailsSection')}
-      <span class="ml-1 text-sm font-normal text-gray-500">({campaign.emailCampaigns?.length ?? 0})</span>
+      <span class="ml-1 text-sm font-normal text-ink-muted">({campaign.emailCampaigns?.length ?? 0})</span>
     </h2>
     <button
       on:click={() => (showAttach = true)}
-      class="text-xs px-3 py-1.5 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors cursor-pointer"
+      class="text-xs px-3 py-1.5 bg-brand text-white rounded-lg hover:brightness-110 transition-colors cursor-pointer"
     >
       + {$_('campaigns.detail.attachEmail')}
     </button>
   </div>
 
   {#if !campaign.emailCampaigns || campaign.emailCampaigns.length === 0}
-    <p class="text-sm text-gray-500 py-6 text-center">{$_('campaigns.detail.emptyEmails')}</p>
+    <p class="text-sm text-ink-muted py-6 text-center">{$_('campaigns.detail.emptyEmails')}</p>
   {:else}
-    <ul class="divide-y divide-gray-100">
+    <ul class="divide-y divide-border">
       {#each campaign.emailCampaigns as item}
         <li class="py-3 flex items-center justify-between gap-3">
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-2 mb-0.5">
-              <span class="text-xs px-2 py-0.5 rounded {statusBadge[item.status] || 'bg-gray-100 text-gray-600'}">
+              <span class="text-xs px-2 py-0.5 rounded {statusBadge[item.status] || 'bg-surface-2 text-ink-muted'}">
                 {$_(statusLabel[item.status] || 'campaigns.detail.statusDraft')}
               </span>
-              <span class="text-xs text-gray-400">{item.list?.name || ''}</span>
+              <span class="text-xs text-ink-subtle">{item.list?.name || ''}</span>
               {#if item.sentAt}
-                <span class="text-xs text-gray-400">· {formatDate(item.sentAt)}</span>
+                <span class="text-xs text-ink-subtle">· {formatDate(item.sentAt)}</span>
               {/if}
             </div>
-            <a href={emailHref(item)} class="text-sm text-gray-900 hover:text-primary-600 truncate block">
+            <a href={emailHref(item)} class="text-sm text-ink hover:text-primary-600 truncate block">
               {item.subject}
             </a>
           </div>
           <div class="flex items-center gap-1 flex-shrink-0">
             <a
               href={emailHref(item)}
-              class="text-xs px-2 py-1 text-gray-500 hover:text-gray-700 hover:bg-gray-50 rounded cursor-pointer"
+              class="text-xs px-2 py-1 text-ink-muted hover:text-gray-700 hover:bg-surface-2 rounded cursor-pointer"
             >
               {$_('campaigns.detail.open')}
             </a>

--- a/apps/web/src/lib/components/campaign-detail/ProgressSummary.svelte
+++ b/apps/web/src/lib/components/campaign-detail/ProgressSummary.svelte
@@ -25,16 +25,16 @@
   $: emailSent = progress.email.byStatus['sent'] ?? 0;
 </script>
 
-<div class="bg-white rounded-xl border border-gray-200 p-5 space-y-4">
+<div class="bg-surface rounded-xl border border-border p-5 space-y-4">
   <div>
     <div class="flex items-center justify-between text-sm mb-1.5">
-      <span class="font-medium text-gray-700">{$_('campaigns.detail.contentProgress')}</span>
-      <span class="text-xs text-gray-500">
+      <span class="font-medium text-ink">{$_('campaigns.detail.contentProgress')}</span>
+      <span class="text-xs text-ink-muted">
         {$_('campaigns.detail.publishedOfTotal', { values: { published: contentPublished, total: progress.content.total } })}
       </span>
     </div>
     {#if progress.content.total > 0}
-      <div class="flex h-2 rounded-full overflow-hidden bg-gray-100">
+      <div class="flex h-2 rounded-full overflow-hidden bg-surface-2">
         {#each contentStatuses as s}
           {@const count = progress.content.byStatus[s] ?? 0}
           {#if count > 0}
@@ -47,9 +47,9 @@
         {/each}
       </div>
     {:else}
-      <div class="h-2 rounded-full bg-gray-100"></div>
+      <div class="h-2 rounded-full bg-surface-2"></div>
     {/if}
-    <div class="flex flex-wrap gap-3 mt-2 text-xs text-gray-500">
+    <div class="flex flex-wrap gap-3 mt-2 text-xs text-ink-muted">
       {#each contentStatuses as s}
         <span class="inline-flex items-center gap-1">
           <span class="w-2 h-2 rounded-sm {contentColors[s]}"></span>
@@ -62,12 +62,12 @@
   {#if progress.email.total > 0}
     <div>
       <div class="flex items-center justify-between text-sm mb-1.5">
-        <span class="font-medium text-gray-700">{$_('campaigns.detail.emailProgress')}</span>
-        <span class="text-xs text-gray-500">
+        <span class="font-medium text-ink">{$_('campaigns.detail.emailProgress')}</span>
+        <span class="text-xs text-ink-muted">
           {$_('campaigns.detail.sentOfTotal', { values: { sent: emailSent, total: progress.email.total } })}
         </span>
       </div>
-      <div class="flex h-2 rounded-full overflow-hidden bg-gray-100">
+      <div class="flex h-2 rounded-full overflow-hidden bg-surface-2">
         {#each emailStatuses as s}
           {@const count = progress.email.byStatus[s] ?? 0}
           {#if count > 0}
@@ -79,7 +79,7 @@
           {/if}
         {/each}
       </div>
-      <div class="flex flex-wrap gap-3 mt-2 text-xs text-gray-500">
+      <div class="flex flex-wrap gap-3 mt-2 text-xs text-ink-muted">
         {#each emailStatuses as s}
           <span class="inline-flex items-center gap-1">
             <span class="w-2 h-2 rounded-sm {emailColors[s]}"></span>

--- a/apps/web/src/lib/components/entity-links/LinkBadge.svelte
+++ b/apps/web/src/lib/components/entity-links/LinkBadge.svelte
@@ -6,7 +6,7 @@
 </script>
 
 <span class="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded-full
-  {linkType === 'LINK' ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300' : 'bg-gray-100 text-gray-600 dark:bg-gray-700 dark:text-gray-400'}"
+  {linkType === 'LINK' ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-300' : 'bg-surface-2 text-ink-muted'}"
   title={linkType === 'LINK' ? $_('entityLinks.linkedTooltip') : $_('entityLinks.copiedTooltip')}>
   {#if linkType === 'LINK'}
     <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">

--- a/apps/web/src/lib/components/entity-links/PromoteDemoteModal.svelte
+++ b/apps/web/src/lib/components/entity-links/PromoteDemoteModal.svelte
@@ -38,8 +38,8 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50" on:click|self={() => show = false}>
-    <div class="bg-white dark:bg-gray-800 rounded-xl shadow-xl p-6 w-full max-w-md">
-      <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">
+    <div class="bg-surface rounded-xl shadow-xl p-6 w-full max-w-md">
+      <h2 class="text-lg font-semibold text-ink mb-4">
         {mode === 'promote' ? $_('entityLinks.promoteTitle') : $_('entityLinks.demoteTitle')}
       </h2>
 
@@ -48,21 +48,21 @@
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <label class="flex items-start gap-3 p-3 rounded-lg border cursor-pointer
-          {linkType === 'COPY' ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20' : 'border-gray-200 dark:border-gray-700'}">
+          {linkType === 'COPY' ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20' : 'border-border'}">
           <input type="radio" bind:group={linkType} value="COPY" class="mt-0.5" />
           <div>
-            <p class="font-medium text-gray-900 dark:text-white">{$_('entityLinks.copy')}</p>
-            <p class="text-sm text-gray-500 dark:text-gray-400">{$_('entityLinks.copyDescription')}</p>
+            <p class="font-medium text-ink">{$_('entityLinks.copy')}</p>
+            <p class="text-sm text-ink-muted">{$_('entityLinks.copyDescription')}</p>
           </div>
         </label>
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <label class="flex items-start gap-3 p-3 rounded-lg border cursor-pointer
-          {linkType === 'LINK' ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20' : 'border-gray-200 dark:border-gray-700'}">
+          {linkType === 'LINK' ? 'border-indigo-500 bg-indigo-50 dark:bg-indigo-900/20' : 'border-border'}">
           <input type="radio" bind:group={linkType} value="LINK" class="mt-0.5" />
           <div>
-            <p class="font-medium text-gray-900 dark:text-white">{$_('entityLinks.link')}</p>
-            <p class="text-sm text-gray-500 dark:text-gray-400">{$_('entityLinks.linkDescription')}</p>
+            <p class="font-medium text-ink">{$_('entityLinks.link')}</p>
+            <p class="text-sm text-ink-muted">{$_('entityLinks.linkDescription')}</p>
           </div>
         </label>
       </div>
@@ -70,8 +70,8 @@
       <!-- Project Selector (demote only) -->
       {#if mode === 'demote'}
         <div class="mb-4">
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">{$_('entityLinks.selectProject')}</label>
-          <select bind:value={selectedProjectId} class="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-3 py-2 text-sm">
+          <label class="block text-sm font-medium text-ink mb-1">{$_('entityLinks.selectProject')}</label>
+          <select bind:value={selectedProjectId} class="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm">
             <option value="">{$_('entityLinks.choosePlaceholder')}</option>
             {#each projects as p}
               <option value={p.id}>{p.name}</option>
@@ -81,7 +81,7 @@
       {/if}
 
       <div class="flex justify-end gap-3">
-        <button on:click={() => show = false} class="px-4 py-2 text-sm text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 rounded-lg">
+        <button on:click={() => show = false} class="px-4 py-2 text-sm text-ink hover:bg-surface-2 rounded-lg">
           {$_('common.cancel')}
         </button>
         <button on:click={submit} disabled={loading || (mode === 'demote' && !selectedProjectId)}

--- a/apps/web/src/lib/components/layout/Header.svelte
+++ b/apps/web/src/lib/components/layout/Header.svelte
@@ -20,10 +20,10 @@
   ];
 </script>
 
-<header class="h-14 bg-white border-b border-gray-200 flex items-center justify-between px-4 flex-shrink-0">
+<header class="h-14 bg-surface border-b border-border flex items-center justify-between px-4 flex-shrink-0">
   <button
     on:click={() => sidebarOpen = !sidebarOpen}
-    class="p-2 rounded-lg text-gray-400 hover:text-gray-700 hover:bg-gray-100 transition-colors duration-150 cursor-pointer"
+    class="p-2 rounded-lg text-ink-subtle hover:text-gray-700 hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
     title="Toggle sidebar"
     aria-label="Toggle sidebar"
   >
@@ -36,12 +36,12 @@
 
   <div class="flex items-center gap-3">
     <!-- Language switcher -->
-    <div class="flex items-center bg-gray-100 rounded-lg p-0.5">
+    <div class="flex items-center bg-surface-2 rounded-lg p-0.5">
       {#each locales as loc}
         <button
           on:click={() => setLocale(loc.code)}
           class="px-2.5 py-1 text-xs rounded-md font-medium transition-all duration-150 cursor-pointer
-            {$locale?.startsWith(loc.code) ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'}"
+            {$locale?.startsWith(loc.code) ? 'bg-surface text-ink shadow-sm' : 'text-ink-muted hover:text-gray-700'}"
         >
           {loc.label}
         </button>
@@ -50,16 +50,16 @@
 
     <!-- User section — hidden on mobile; sidebar has its own user block with logout -->
     {#if $currentUser}
-      <div class="hidden md:flex items-center gap-2.5 pl-3 border-l border-gray-200">
+      <div class="hidden md:flex items-center gap-2.5 pl-3 border-l border-border">
         <!-- Gradient avatar matching project card avatars -->
         <div class="w-7 h-7 bg-gradient-to-br from-primary-400 to-primary-600 rounded-full flex items-center justify-center text-white font-semibold text-xs flex-shrink-0 select-none">
           {$currentUser.name?.charAt(0).toUpperCase() || 'U'}
         </div>
-        <span class="text-sm text-gray-700 font-medium hidden sm:block max-w-[8rem] truncate">{$currentUser.name}</span>
+        <span class="text-sm text-ink font-medium hidden sm:block max-w-[8rem] truncate">{$currentUser.name}</span>
         <!-- Logout — red hover signals destructive action -->
         <button
           on:click={logout}
-          class="p-1.5 rounded-lg text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors duration-150 cursor-pointer"
+          class="p-1.5 rounded-lg text-ink-subtle hover:text-red-500 hover:bg-red-50 transition-colors duration-150 cursor-pointer"
           title={$_('auth.logout')}
           aria-label={$_('auth.logout')}
         >

--- a/apps/web/src/lib/components/layout/Header.svelte
+++ b/apps/web/src/lib/components/layout/Header.svelte
@@ -23,7 +23,7 @@
 <header class="h-14 bg-surface border-b border-border flex items-center justify-between px-4 flex-shrink-0">
   <button
     on:click={() => sidebarOpen = !sidebarOpen}
-    class="p-2 rounded-lg text-ink-subtle hover:text-gray-700 hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
+    class="p-2 rounded-lg text-ink-subtle hover:text-ink hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
     title="Toggle sidebar"
     aria-label="Toggle sidebar"
   >
@@ -41,7 +41,7 @@
         <button
           on:click={() => setLocale(loc.code)}
           class="px-2.5 py-1 text-xs rounded-md font-medium transition-all duration-150 cursor-pointer
-            {$locale?.startsWith(loc.code) ? 'bg-surface text-ink shadow-sm' : 'text-ink-muted hover:text-gray-700'}"
+            {$locale?.startsWith(loc.code) ? 'bg-surface text-brand shadow-sm' : 'text-ink-muted hover:text-ink'}"
         >
           {loc.label}
         </button>
@@ -52,7 +52,7 @@
     {#if $currentUser}
       <div class="hidden md:flex items-center gap-2.5 pl-3 border-l border-border">
         <!-- Gradient avatar matching project card avatars -->
-        <div class="w-7 h-7 bg-gradient-to-br from-primary-400 to-primary-600 rounded-full flex items-center justify-center text-white font-semibold text-xs flex-shrink-0 select-none">
+        <div class="w-7 h-7 bg-gradient-to-br from-iris-400 to-iris-600 rounded-full flex items-center justify-center text-white font-semibold text-xs flex-shrink-0 select-none">
           {$currentUser.name?.charAt(0).toUpperCase() || 'U'}
         </div>
         <span class="text-sm text-ink font-medium hidden sm:block max-w-[8rem] truncate">{$currentUser.name}</span>

--- a/apps/web/src/lib/components/layout/InvitationsBanner.svelte
+++ b/apps/web/src/lib/components/layout/InvitationsBanner.svelte
@@ -86,14 +86,14 @@
             <button
               on:click={() => accept(inv)}
               disabled={processing[inv.id]}
-              class="inline-flex items-center bg-primary-600 text-white text-xs font-medium px-3 py-1.5 rounded-lg hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 cursor-pointer"
+              class="inline-flex items-center bg-brand text-white text-xs font-medium px-3 py-1.5 rounded-lg hover:brightness-110 transition-colors duration-150 disabled:opacity-50 cursor-pointer"
             >
               {$_('invitations.accept')}
             </button>
             <button
               on:click={() => decline(inv)}
               disabled={processing[inv.id]}
-              class="inline-flex items-center border border-gray-300 text-gray-700 text-xs font-medium px-3 py-1.5 rounded-lg hover:bg-gray-100 transition-colors duration-150 disabled:opacity-50 cursor-pointer"
+              class="inline-flex items-center border border-border text-ink text-xs font-medium px-3 py-1.5 rounded-lg hover:bg-surface-2 transition-colors duration-150 disabled:opacity-50 cursor-pointer"
             >
               {$_('invitations.decline')}
             </button>

--- a/apps/web/src/lib/components/layout/ProjectPicker.svelte
+++ b/apps/web/src/lib/components/layout/ProjectPicker.svelte
@@ -68,14 +68,14 @@
     on:click|stopPropagation={() => open = !open}
     disabled={!loaded}
     class="flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors duration-150 cursor-pointer max-w-[220px]
-      {!loaded ? 'bg-gray-100 text-gray-400 animate-pulse' :
+      {!loaded ? 'bg-surface-2 text-ink-subtle animate-pulse' :
        current
         ? 'bg-indigo-50 text-indigo-700 hover:bg-indigo-100'
-        : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}"
+        : 'bg-surface-2 text-ink-muted hover:bg-gray-200'}"
     title={$_('header.switchContext')}
   >
     {#if !loaded}
-      <div class="w-4 h-4 rounded-full border-2 border-gray-300 border-t-transparent animate-spin"></div>
+      <div class="w-4 h-4 rounded-full border-2 border-border border-t-transparent animate-spin"></div>
       <span class="truncate">...</span>
     {:else if current}
       <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75">
@@ -94,13 +94,13 @@
   </button>
 
   {#if open}
-    <div class="absolute left-0 top-full mt-1 w-64 bg-white rounded-lg shadow-lg border border-gray-200 z-50 py-1 max-h-80 overflow-y-auto">
+    <div class="absolute left-0 top-full mt-1 w-64 bg-surface rounded-lg shadow-lg border border-border z-50 py-1 max-h-80 overflow-y-auto">
       <button
         on:click|stopPropagation={selectOrg}
         class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left transition-colors cursor-pointer
-          {!current ? 'bg-gray-50 text-gray-900 font-medium' : 'text-gray-600 hover:bg-gray-50'}"
+          {!current ? 'bg-surface-2 text-ink font-medium' : 'text-ink-muted hover:bg-surface-2'}"
       >
-        <svg class="w-4 h-4 flex-shrink-0 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75">
+        <svg class="w-4 h-4 flex-shrink-0 text-ink-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21" />
         </svg>
         <span>{currentOrg?.name || $_('header.orgContext')}</span>
@@ -111,12 +111,12 @@
         {/if}
       </button>
 
-      <div class="border-t border-gray-100 my-1"></div>
+      <div class="border-t border-border my-1"></div>
 
       {#if projects.length === 0}
         <a
           href="/dashboard"
-          class="block px-3 py-2 text-sm text-gray-400 hover:text-indigo-600 transition-colors"
+          class="block px-3 py-2 text-sm text-ink-subtle hover:text-indigo-600 transition-colors"
           on:click={() => open = false}
         >
           {$_('header.noProjects')}
@@ -126,9 +126,9 @@
           <button
             on:click|stopPropagation={() => selectProject(project)}
             class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left transition-colors cursor-pointer
-              {current?.id === project.id ? 'bg-indigo-50 text-indigo-700 font-medium' : 'text-gray-600 hover:bg-gray-50'}"
+              {current?.id === project.id ? 'bg-indigo-50 text-indigo-700 font-medium' : 'text-ink-muted hover:bg-surface-2'}"
           >
-            <svg class="w-4 h-4 flex-shrink-0 {current?.id === project.id ? 'text-indigo-500' : 'text-gray-400'}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75">
+            <svg class="w-4 h-4 flex-shrink-0 {current?.id === project.id ? 'text-indigo-500' : 'text-ink-subtle'}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75">
               <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
             </svg>
             <span class="truncate">{project.name}</span>

--- a/apps/web/src/lib/components/layout/ProjectPicker.svelte
+++ b/apps/web/src/lib/components/layout/ProjectPicker.svelte
@@ -70,8 +70,8 @@
     class="flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors duration-150 cursor-pointer max-w-[220px]
       {!loaded ? 'bg-surface-2 text-ink-subtle animate-pulse' :
        current
-        ? 'bg-indigo-50 text-indigo-700 hover:bg-indigo-100'
-        : 'bg-surface-2 text-ink-muted hover:bg-gray-200'}"
+        ? 'bg-brand-subtle/15 text-brand-subtle-fg hover:bg-brand-subtle/25'
+        : 'bg-surface-2 text-ink-muted hover:bg-surface-2'}"
     title={$_('header.switchContext')}
   >
     {#if !loaded}
@@ -105,7 +105,7 @@
         </svg>
         <span>{currentOrg?.name || $_('header.orgContext')}</span>
         {#if !current}
-          <svg class="w-4 h-4 ml-auto text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <svg class="w-4 h-4 ml-auto text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
           </svg>
         {/if}
@@ -116,7 +116,7 @@
       {#if projects.length === 0}
         <a
           href="/dashboard"
-          class="block px-3 py-2 text-sm text-ink-subtle hover:text-indigo-600 transition-colors"
+          class="block px-3 py-2 text-sm text-ink-subtle hover:text-brand transition-colors"
           on:click={() => open = false}
         >
           {$_('header.noProjects')}
@@ -126,14 +126,14 @@
           <button
             on:click|stopPropagation={() => selectProject(project)}
             class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left transition-colors cursor-pointer
-              {current?.id === project.id ? 'bg-indigo-50 text-indigo-700 font-medium' : 'text-ink-muted hover:bg-surface-2'}"
+              {current?.id === project.id ? 'bg-brand-subtle/15 text-brand-subtle-fg font-medium' : 'text-ink-muted hover:bg-surface-2'}"
           >
-            <svg class="w-4 h-4 flex-shrink-0 {current?.id === project.id ? 'text-indigo-500' : 'text-ink-subtle'}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75">
+            <svg class="w-4 h-4 flex-shrink-0 {current?.id === project.id ? 'text-brand' : 'text-ink-subtle'}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75">
               <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
             </svg>
             <span class="truncate">{project.name}</span>
             {#if current?.id === project.id}
-              <svg class="w-4 h-4 ml-auto text-indigo-500 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <svg class="w-4 h-4 ml-auto text-brand flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
               </svg>
             {/if}

--- a/apps/web/src/lib/components/layout/Sidebar.svelte
+++ b/apps/web/src/lib/components/layout/Sidebar.svelte
@@ -177,7 +177,7 @@
 
 <!-- Sidebar: uses inline style width transition for smooth slide animation -->
 <aside
-  class="bg-white border-r border-gray-200 flex flex-col h-full overflow-hidden flex-shrink-0 transition-[width,transform] duration-200 ease-in-out
+  class="bg-surface border-r border-border flex flex-col h-full overflow-hidden flex-shrink-0 transition-[width,transform] duration-200 ease-in-out
     {isMobile ? 'fixed inset-y-0 left-0 z-40 w-64' : ''}"
   style={isMobile ? `transform: translateX(${open ? '0' : '-100%'});` : `width: ${open ? '16rem' : '0'};`}
   aria-hidden={!open}
@@ -185,7 +185,7 @@
   <!-- Inner wrapper prevents content from reflowing during width transition -->
   <div class="w-64 flex flex-col h-full overflow-y-auto custom-scroll">
     <!-- Logo -->
-    <div class="p-5 border-b border-gray-100 flex-shrink-0">
+    <div class="p-5 border-b border-border flex-shrink-0">
       <a href="/dashboard" class="flex items-center gap-2.5 group cursor-pointer">
         <!-- SparklesIcon badge — more distinctive than plain "M" letter -->
         <div class="w-8 h-8 bg-gradient-to-br from-primary-500 to-primary-700 rounded-lg flex items-center justify-center flex-shrink-0 shadow-sm group-hover:shadow-primary-200 transition-shadow duration-200">
@@ -194,44 +194,44 @@
           </svg>
         </div>
         <div>
-          <div class="font-bold text-gray-900 text-sm leading-none" style="font-family: 'Space Grotesk', sans-serif;">Marketing AI</div>
-          <div class="text-xs text-gray-400 mt-0.5">Assistant</div>
+          <div class="font-bold text-ink text-sm leading-none" style="font-family: 'Space Grotesk', sans-serif;">Marketing AI</div>
+          <div class="text-xs text-ink-subtle mt-0.5">Assistant</div>
         </div>
       </a>
     </div>
 
     <!-- Organization switcher -->
     {#if hasMultipleOrgs}
-      <div class="px-4 py-3 border-b border-gray-100 relative">
+      <div class="px-4 py-3 border-b border-border relative">
         <button
           on:click|stopPropagation={() => (showOrgDropdown = !showOrgDropdown)}
-          class="w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded-lg hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
+          class="w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded-lg hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
         >
           <div class="flex items-center gap-2 min-w-0">
-            <div class="w-6 h-6 rounded bg-primary-100 flex items-center justify-center text-primary-700 text-xs font-bold flex-shrink-0">
+            <div class="w-6 h-6 rounded bg-primary-100 flex items-center justify-center text-brand text-xs font-bold flex-shrink-0">
               {(currentOrg?.name || '?').charAt(0).toUpperCase()}
             </div>
-            <span class="text-sm font-medium text-gray-700 truncate">{currentOrg?.name || ''}</span>
+            <span class="text-sm font-medium text-ink truncate">{currentOrg?.name || ''}</span>
           </div>
-          <svg class="w-4 h-4 text-gray-400 flex-shrink-0 transition-transform duration-150 {showOrgDropdown ? 'rotate-180' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <svg class="w-4 h-4 text-ink-subtle flex-shrink-0 transition-transform duration-150 {showOrgDropdown ? 'rotate-180' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
           </svg>
         </button>
         {#if showOrgDropdown}
-          <div class="absolute left-3 right-3 mt-1 bg-white border border-gray-200 rounded-lg shadow-lg z-50 py-1">
+          <div class="absolute left-3 right-3 mt-1 bg-surface border border-border rounded-lg shadow-lg z-50 py-1">
             {#each memberships as m}
-              <div class="flex items-center hover:bg-gray-50 transition-colors duration-150">
+              <div class="flex items-center hover:bg-surface-2 transition-colors duration-150">
                 <button
                   on:click={() => switchOrg(m.organization.id)}
                   class="flex-1 text-left px-3 py-2 text-sm flex items-center gap-2 cursor-pointer
-                    {m.organization.id === $organizationIdStore ? 'text-primary-700 font-medium' : 'text-gray-600'}"
+                    {m.organization.id === $organizationIdStore ? 'text-brand font-medium' : 'text-ink-muted'}"
                 >
-                  <div class="w-5 h-5 rounded bg-primary-100 flex items-center justify-center text-primary-700 text-[10px] font-bold flex-shrink-0">
+                  <div class="w-5 h-5 rounded bg-primary-100 flex items-center justify-center text-brand text-[10px] font-bold flex-shrink-0">
                     {(m.organization.name || '?').charAt(0).toUpperCase()}
                   </div>
                   <span class="truncate">{m.organization.name}</span>
                   {#if m.organization.id === $organizationIdStore}
-                    <svg class="w-4 h-4 text-primary-600 ml-auto flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <svg class="w-4 h-4 text-brand ml-auto flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
                     </svg>
                   {/if}
@@ -257,7 +257,7 @@
     <nav class="p-3 flex-1 space-y-6">
       <!-- Main navigation -->
       <div>
-        <p class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest px-3 mb-2">Navigation</p>
+        <p class="text-[10px] font-semibold text-ink-subtle uppercase tracking-widest px-3 mb-2">Navigation</p>
         <ul class="space-y-0.5">
           {#each mainLinks as link}
             <li>
@@ -265,8 +265,8 @@
                 href={link.href}
                 class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors duration-150 cursor-pointer
                   {isActive(link.href, currentPath)
-                    ? 'bg-primary-50 text-primary-700 border-l-2 border-primary-600'
-                    : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900 border-l-2 border-transparent'}"
+                    ? 'bg-brand-subtle/10 text-brand border-l-2 border-primary-600'
+                    : 'text-ink-muted hover:bg-surface-2 hover:text-gray-900 border-l-2 border-transparent'}"
               >
                 {@html icons[link.iconKey]}
                 <span>{$_(link.labelKey)}</span>
@@ -278,7 +278,7 @@
 
       <!-- Marketing -->
       <div>
-        <p class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest px-3 mb-2">{$_('nav.marketing')}</p>
+        <p class="text-[10px] font-semibold text-ink-subtle uppercase tracking-widest px-3 mb-2">{$_('nav.marketing')}</p>
         <ul class="space-y-0.5">
           <!-- Overview — only when project selected -->
           {#if $currentProjectStore}
@@ -288,8 +288,8 @@
                 href={overviewHref}
                 class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors duration-150 cursor-pointer
                   {currentPath === overviewHref || currentPath.startsWith(overviewHref)
-                    ? 'bg-primary-50 text-primary-700 border-l-2 border-primary-600'
-                    : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900 border-l-2 border-transparent'}"
+                    ? 'bg-brand-subtle/10 text-brand border-l-2 border-primary-600'
+                    : 'text-ink-muted hover:bg-surface-2 hover:text-gray-900 border-l-2 border-transparent'}"
               >
                 {@html icons['chartbar']}
                 <span>{$_('projects.overview')}</span>
@@ -303,8 +303,8 @@
                 href={link.href}
                 class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors duration-150 cursor-pointer
                   {isActive(link.href, currentPath)
-                    ? 'bg-primary-50 text-primary-700 border-l-2 border-primary-600'
-                    : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900 border-l-2 border-transparent'}"
+                    ? 'bg-brand-subtle/10 text-brand border-l-2 border-primary-600'
+                    : 'text-ink-muted hover:bg-surface-2 hover:text-gray-900 border-l-2 border-transparent'}"
               >
                 {@html icons[link.iconKey]}
                 <span>{$_(link.labelKey)}</span>
@@ -316,7 +316,7 @@
           <li>
             <button
               on:click={toggleAdvanced}
-              class="w-full flex items-center justify-between px-3 py-2 text-xs font-medium text-gray-400 hover:text-gray-600 cursor-pointer transition-colors duration-150 mt-1"
+              class="w-full flex items-center justify-between px-3 py-2 text-xs font-medium text-ink-subtle hover:text-gray-600 cursor-pointer transition-colors duration-150 mt-1"
             >
               <span>{showAdvanced ? $_('nav.hideAdvanced') : $_('nav.showAdvanced')}</span>
               <svg
@@ -335,8 +335,8 @@
                   href={link.href}
                   class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors duration-150 cursor-pointer
                     {isActive(link.href, currentPath)
-                      ? 'bg-primary-50 text-primary-700 border-l-2 border-primary-600'
-                      : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900 border-l-2 border-transparent'}"
+                      ? 'bg-brand-subtle/10 text-brand border-l-2 border-primary-600'
+                      : 'text-ink-muted hover:bg-surface-2 hover:text-gray-900 border-l-2 border-transparent'}"
                 >
                   {@html icons[link.iconKey]}
                   <span>{$_(link.labelKey)}</span>
@@ -349,7 +349,7 @@
 
       <!-- Settings -->
       <div>
-        <p class="text-[10px] font-semibold text-gray-400 uppercase tracking-widest px-3 mb-2">{$_('common.settings')}</p>
+        <p class="text-[10px] font-semibold text-ink-subtle uppercase tracking-widest px-3 mb-2">{$_('common.settings')}</p>
         <ul class="space-y-0.5">
           {#each settingsLinks as link}
             <li>
@@ -357,8 +357,8 @@
                 href={link.href}
                 class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors duration-150 cursor-pointer
                   {isActive(link.href, currentPath)
-                    ? 'bg-primary-50 text-primary-700 border-l-2 border-primary-600'
-                    : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900 border-l-2 border-transparent'}"
+                    ? 'bg-brand-subtle/10 text-brand border-l-2 border-primary-600'
+                    : 'text-ink-muted hover:bg-surface-2 hover:text-gray-900 border-l-2 border-transparent'}"
               >
                 {@html icons[link.iconKey]}
                 <span>{$_(link.labelKey)}</span>
@@ -370,20 +370,20 @@
 
       <!-- User profile + logout -->
       {#if $currentUser}
-        <div class="px-3 py-2 border-t border-gray-200 dark:border-gray-700">
+        <div class="px-3 py-2 border-t border-border">
           <div class="flex items-center gap-2.5 px-3 py-2">
             <div class="w-8 h-8 bg-gradient-to-br from-primary-400 to-primary-600 rounded-full flex items-center justify-center text-white font-semibold text-xs flex-shrink-0 select-none">
               {$currentUser.name?.charAt(0).toUpperCase() || 'U'}
             </div>
             <div class="flex-1 min-w-0">
-              <div class="text-sm font-medium text-gray-900 truncate">{$currentUser.name}</div>
+              <div class="text-sm font-medium text-ink truncate">{$currentUser.name}</div>
               {#if $currentUser.email}
-                <div class="text-xs text-gray-400 truncate">{$currentUser.email}</div>
+                <div class="text-xs text-ink-subtle truncate">{$currentUser.email}</div>
               {/if}
             </div>
             <button
               on:click={logout}
-              class="p-1.5 rounded-lg text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors duration-150 cursor-pointer flex-shrink-0"
+              class="p-1.5 rounded-lg text-ink-subtle hover:text-red-500 hover:bg-red-50 transition-colors duration-150 cursor-pointer flex-shrink-0"
               title={$_('auth.logout')}
               aria-label={$_('auth.logout')}
             >
@@ -396,10 +396,10 @@
       {/if}
 
       <!-- Theme Toggle + Help -->
-      <div class="px-3 py-2 border-t border-gray-200 dark:border-gray-700">
+      <div class="px-3 py-2 border-t border-border">
         <button
           on:click={toggleTheme}
-          class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-colors duration-150 w-full text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white cursor-pointer"
+          class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-colors duration-150 w-full text-ink-muted hover:bg-surface-2 hover:text-gray-900 cursor-pointer"
         >
           {#if isDark}
             <svg class="w-[18px] h-[18px] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" /></svg>
@@ -411,7 +411,7 @@
         </button>
         <a href="/help"
           class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-colors duration-150
-            {$page.url.pathname.startsWith('/help') ? 'bg-primary-50 text-primary-700 font-medium' : 'text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 hover:text-gray-900 dark:hover:text-white'}">
+            {$page.url.pathname.startsWith('/help') ? 'bg-brand-subtle/10 text-brand font-medium' : 'text-ink-muted hover:bg-surface-2 hover:text-gray-900'}">
           {@html icons.questionmark}
           <span>{$_('nav.help')}</span>
         </a>
@@ -425,15 +425,15 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => (leavingOrg = null)}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm p-6">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm p-6">
       <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-4">
         <svg class="w-6 h-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" />
         </svg>
       </div>
-      <h2 class="text-lg font-semibold text-gray-900 mb-1">{$_('settings.leaveTeamConfirm')}</h2>
-      <p class="text-sm text-gray-500 mb-1 font-medium">{leavingOrg.organization?.name}</p>
-      <p class="text-sm text-gray-500 mb-6">{$_('settings.leaveTeamDesc')}</p>
+      <h2 class="text-lg font-semibold text-ink mb-1">{$_('settings.leaveTeamConfirm')}</h2>
+      <p class="text-sm text-ink-muted mb-1 font-medium">{leavingOrg.organization?.name}</p>
+      <p class="text-sm text-ink-muted mb-6">{$_('settings.leaveTeamDesc')}</p>
       <div class="flex gap-3">
         <button
           on:click={leaveOrg}
@@ -443,7 +443,7 @@
         </button>
         <button
           on:click={() => (leavingOrg = null)}
-          class="flex-1 border border-gray-300 rounded-lg text-sm py-2.5 font-medium hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
+          class="flex-1 border border-border rounded-lg text-sm py-2.5 font-medium hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
         >
           {$_('common.cancel')}
         </button>

--- a/apps/web/src/lib/components/layout/Sidebar.svelte
+++ b/apps/web/src/lib/components/layout/Sidebar.svelte
@@ -2,7 +2,7 @@
   import { page } from '$app/stores';
   import { _ } from 'svelte-i18n';
   import { goto } from '$app/navigation';
-  import { currentProjectStore, organizationIdStore } from '$lib/stores/projects';
+  import { currentProjectStore, organizationIdStore, projectsStore } from '$lib/stores/projects';
   import { authStore, currentUser } from '$lib/stores/auth';
   import { api } from '$lib/api/client';
   import { browser } from '$app/environment';
@@ -30,12 +30,47 @@
   $: currentOrg = memberships.find((m: any) => m.organization?.id === $organizationIdStore)?.organization;
   $: hasMultipleOrgs = memberships.length > 1;
   let showOrgDropdown = false;
+  let showProjectDropdown = false;
+
+  // ── Context: organization mode vs project mode ──
+  $: inProject = !!$currentProjectStore;
+  $: projectId = $currentProjectStore?.id;
+
+  const orgSections = ['content', 'checklists', 'documents', 'campaigns', 'email', 'analytics', 'finances', 'seo', 'competitors', 'experiments', 'sequences', 'calendar'];
 
   function switchOrg(orgId: string) {
     organizationIdStore.set(orgId);
     showOrgDropdown = false;
     currentProjectStore.set(null);
     window.location.href = '/dashboard';
+  }
+
+  // Return to organization mode, preserving the section when possible (mirrors ProjectPicker).
+  function backToOrg() {
+    showProjectDropdown = false;
+    const path = $page.url.pathname;
+    if (path.startsWith('/projects/')) {
+      const m = path.match(/^\/projects\/[^/]+\/(.+)/);
+      const section = m?.[1]?.split('/')[0];
+      const target = section && orgSections.includes(section) ? `/${section}` : '/dashboard';
+      goto(target).then(() => currentProjectStore.set(null));
+    } else {
+      currentProjectStore.set(null);
+    }
+  }
+
+  // Quick-switch to another project, keeping the current section.
+  function selectProjectFromSidebar(project: any) {
+    const prevId = $currentProjectStore?.id;
+    currentProjectStore.set(project);
+    if (project.organizationId && project.organizationId !== $organizationIdStore) {
+      organizationIdStore.set(project.organizationId);
+    }
+    showProjectDropdown = false;
+    const path = $page.url.pathname;
+    if (path.startsWith('/projects/') && prevId !== project.id) {
+      goto(path.replace(/\/projects\/[^/]+/, `/projects/${project.id}`));
+    }
   }
 
   let leavingOrg: any = null;
@@ -54,12 +89,12 @@
     }
   }
 
-  function handleClickOutside(event: MouseEvent) {
+  function handleClickOutside() {
     if (showOrgDropdown) showOrgDropdown = false;
+    if (showProjectDropdown) showProjectDropdown = false;
   }
 
   // Heroicons outline 24px — stored as SVG strings for {@html} rendering
-  // Consistent with existing {@html action.icon} pattern in overview/+page.svelte
   const icons: Record<string, string> = {
     home: `<svg xmlns="http://www.w3.org/2000/svg" class="w-[18px] h-[18px] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75"><path stroke-linecap="round" stroke-linejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" /></svg>`,
     folder: `<svg xmlns="http://www.w3.org/2000/svg" class="w-[18px] h-[18px] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" /></svg>`,
@@ -75,7 +110,7 @@
     megaphone: `<svg xmlns="http://www.w3.org/2000/svg" class="w-[18px] h-[18px] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75"><path stroke-linecap="round" stroke-linejoin="round" d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 1 8.835-2.535m0 0A23.74 23.74 0 0 1 18.795 3c1.168 0 2.316.08 3.443.238.562.085.99.566.99 1.14V19.5c0 .564-.427 1.044-.989 1.129a23.95 23.95 0 0 1-3.444.238 23.844 23.844 0 0 1-1.02-.04m0-17.38V3m0 0h-3.614" /></svg>`,
     pencil: `<svg xmlns="http://www.w3.org/2000/svg" class="w-[18px] h-[18px] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75"><path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" /></svg>`,
     checkcircle: `<svg xmlns="http://www.w3.org/2000/svg" class="w-[18px] h-[18px] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" /></svg>`,
-    document: `<svg xmlns="http://www.w3.org/2000/svg" class="w-[18px] h-[18px] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" /></svg>`,
+    document: `<svg xmlns="http://www.w3.org/2000/svg" class="w-[18px] h-[18px] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" /></svg>`,
     presentation: `<svg xmlns="http://www.w3.org/2000/svg" class="w-[18px] h-[18px] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0 1 18 16.5h-2.25m-7.5 0h7.5m-7.5 0-1 3m8.5-3 1 3m0 0 .5 1.5m-.5-1.5h-9.5m0 0-.5 1.5m.75-9 3-3 2.148 2.148A12.061 12.061 0 0 1 16.5 7.605" /></svg>`,
     calendar: `<svg xmlns="http://www.w3.org/2000/svg" class="w-[18px] h-[18px] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75"><path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" /></svg>`,
     globe: `<svg xmlns="http://www.w3.org/2000/svg" class="w-[18px] h-[18px] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75"><path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5a17.92 17.92 0 0 1-8.716-2.247m0 0A9.015 9.015 0 0 1 3 12c0-1.605.42-3.113 1.157-4.418" /></svg>`,
@@ -86,32 +121,43 @@
     questionmark: `<svg xmlns="http://www.w3.org/2000/svg" class="w-[18px] h-[18px] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75"><path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-9 5.25h.008v.008H12v-.008Z" /></svg>`,
   };
 
-  const mainLinks = [
-    { href: '/dashboard', iconKey: 'home', labelKey: 'nav.dashboard' },
+  // ── Org-mode menus ──
+  const workspaceLinks = [
+    { href: '/dashboard', iconKey: 'home', labelKey: 'nav.dashboard', hint: true },
     { href: '/projects', iconKey: 'folder', labelKey: 'nav.projects' },
     { href: '/ai-chat', iconKey: 'sparkles', labelKey: 'nav.aiChat' },
     { href: '/templates', iconKey: 'clipboard', labelKey: 'nav.templates' },
   ];
-
-  const marketingLinks = [
-    { href: '/content',     iconKey: 'pencil',       labelKey: 'nav.orgContent' },
-    { href: '/checklists',  iconKey: 'checkcircle',  labelKey: 'nav.orgChecklists' },
-    { href: '/documents',   iconKey: 'document',     labelKey: 'nav.orgDocuments' },
-    { href: '/campaigns',   iconKey: 'megaphone',    labelKey: 'nav.orgCampaigns' },
-    { href: '/email',       iconKey: 'envelope',     labelKey: 'nav.orgEmail' },
-    { href: '/analytics',   iconKey: 'presentation', labelKey: 'nav.orgAnalytics' },
-    { href: '/finances',    iconKey: 'banknotes',    labelKey: 'nav.orgFinances' },
+  const rollupLinks = [
+    { href: '/analytics', iconKey: 'presentation', labelKey: 'nav.orgAnalytics' },
+    { href: '/finances', iconKey: 'banknotes', labelKey: 'nav.orgFinances' },
   ];
 
-  const advancedMarketingLinks = [
-    { href: '/seo',         iconKey: 'globe',         labelKey: 'nav.orgSeo' },
-    { href: '/competitors', iconKey: 'eye',           labelKey: 'nav.orgCompetitors' },
-    { href: '/experiments', iconKey: 'beaker',        labelKey: 'nav.orgExperiments' },
-    { href: '/sequences',   iconKey: 'mailstack',     labelKey: 'nav.orgSequences' },
-    { href: '/calendar',    iconKey: 'calendar',      labelKey: 'nav.orgCalendar' },
+  // ── Project-mode menus (seg is appended to /projects/:id) ──
+  const projectLinks = [
+    { seg: 'overview',   iconKey: 'chartbar',     labelKey: 'projects.overview' },
+    { seg: 'content',    iconKey: 'pencil',       labelKey: 'nav.orgContent' },
+    { seg: 'checklists', iconKey: 'checkcircle',  labelKey: 'nav.orgChecklists' },
+    { seg: 'documents',  iconKey: 'document',     labelKey: 'nav.orgDocuments' },
+    { seg: 'campaigns',  iconKey: 'megaphone',    labelKey: 'nav.orgCampaigns' },
+    { seg: 'email',      iconKey: 'envelope',     labelKey: 'nav.orgEmail' },
+    { seg: 'analytics',  iconKey: 'presentation', labelKey: 'nav.orgAnalytics' },
+    { seg: 'finances',   iconKey: 'banknotes',    labelKey: 'nav.orgFinances' },
+  ];
+  // AI Chat + Templates surfaced inside a project (carry project context — Task 9).
+  const projectToolLinks = [
+    { href: '/ai-chat',   iconKey: 'sparkles',  labelKey: 'nav.aiChat' },
+    { href: '/templates', iconKey: 'clipboard', labelKey: 'nav.templates' },
+  ];
+  const projectAdvanced = [
+    { seg: 'seo',         iconKey: 'globe',     labelKey: 'nav.orgSeo' },
+    { seg: 'competitors', iconKey: 'eye',       labelKey: 'nav.orgCompetitors' },
+    { seg: 'experiments', iconKey: 'beaker',    labelKey: 'nav.orgExperiments' },
+    { seg: 'sequences',   iconKey: 'mailstack', labelKey: 'nav.orgSequences' },
+    { seg: 'calendar',    iconKey: 'calendar',  labelKey: 'nav.orgCalendar' },
   ];
 
-  const settingsLinks = [
+  const orgSettingsLinks = [
     { href: '/settings/organization', iconKey: 'building', labelKey: 'nav.settings' },
     { href: '/settings/billing', iconKey: 'creditcard', labelKey: 'nav.billing' },
     { href: '/settings/team', iconKey: 'users', labelKey: 'nav.team' },
@@ -120,9 +166,7 @@
     { href: '/settings/webhooks', iconKey: 'webhook', labelKey: 'nav.webhooks' },
   ];
 
-
   let showAdvanced = browser ? localStorage.getItem('sidebarAdvanced') === 'true' : false;
-
   function toggleAdvanced() {
     showAdvanced = !showAdvanced;
     if (browser) localStorage.setItem('sidebarAdvanced', String(showAdvanced));
@@ -130,43 +174,25 @@
 
   $: currentPath = $page.url.pathname;
 
-  const marketingPathSegments = ['content', 'checklists', 'documents', 'campaigns', 'email', 'analytics', 'finances', 'seo', 'competitors', 'experiments', 'sequences', 'calendar'];
-
-  // Extracts the marketing section for both org-level (/content) and project-level (/projects/:id/content) URLs.
-  function getMarketingSegment(p: string): string | null {
-    const projectMatch = p.match(/^\/projects\/[^/]+\/([^/]+)/);
-    if (projectMatch && marketingPathSegments.includes(projectMatch[1])) {
-      return projectMatch[1];
-    }
-    const firstSeg = p.replace(/^\//, '').split('/')[0];
-    if (firstSeg && marketingPathSegments.includes(firstSeg)) {
-      return firstSeg;
-    }
-    return null;
+  // Active when path equals href or is a sub-path. For org rollups (/analytics,
+  // /finances) we require we're NOT inside a project route.
+  function isActiveOrg(href: string): boolean {
+    return currentPath === href || currentPath.startsWith(href + '/');
+  }
+  function isActiveSeg(seg: string): boolean {
+    if (!projectId) return false;
+    const base = `/projects/${projectId}/${seg}`;
+    return currentPath === base || currentPath.startsWith(base + '/');
   }
 
-  function isActive(href: string, path: string = currentPath): boolean {
-    if (path === href || path.startsWith(href + '/')) return true;
-    const hrefSeg = getMarketingSegment(href);
-    const pathSeg = getMarketingSegment(path);
-    return hrefSeg !== null && hrefSeg === pathSeg;
-  }
-
-  // When a project is selected, marketing links navigate directly to the project-scoped page
-  // (avoids the org-level hub that then forwards you into the project anyway). Computed as a
-  // reactive statement so Svelte tracks the $currentProjectStore dependency and re-renders
-  // sidebar links when the selection changes.
-  $: projectPrefix = $currentProjectStore ? `/projects/${$currentProjectStore.id}` : '';
-  $: resolvedMarketingLinks = marketingLinks.map(l => ({ ...l, href: projectPrefix + l.href }));
-  $: resolvedAdvancedLinks = advancedMarketingLinks.map(l => ({ ...l, href: projectPrefix + l.href }));
-
-  // Auto-expand advanced section when navigating to an advanced route
+  // Auto-expand advanced when navigating to an advanced project route
   $: {
-    const advancedHrefs = advancedMarketingLinks.map(l => l.href);
-    const isOnAdvanced = advancedHrefs.some(h => isActive(h, currentPath));
-    if (isOnAdvanced && !showAdvanced) {
-      showAdvanced = true;
-      if (browser) localStorage.setItem('sidebarAdvanced', 'true');
+    if (projectId) {
+      const onAdvanced = projectAdvanced.some((l) => isActiveSeg(l.seg));
+      if (onAdvanced && !showAdvanced) {
+        showAdvanced = true;
+        if (browser) localStorage.setItem('sidebarAdvanced', 'true');
+      }
     }
   }
 </script>
@@ -182,41 +208,84 @@
   style={isMobile ? `transform: translateX(${open ? '0' : '-100%'});` : `width: ${open ? '16rem' : '0'};`}
   aria-hidden={!open}
 >
-  <!-- Inner wrapper prevents content from reflowing during width transition -->
   <div class="w-64 flex flex-col h-full overflow-y-auto custom-scroll">
     <!-- Logo -->
-    <div class="p-5 border-b border-border flex-shrink-0">
+    <div class="p-4 border-b border-border flex-shrink-0">
       <a href="/dashboard" class="flex items-center gap-2.5 group cursor-pointer">
-        <!-- SparklesIcon badge — more distinctive than plain "M" letter -->
-        <div class="w-8 h-8 bg-gradient-to-br from-primary-500 to-primary-700 rounded-lg flex items-center justify-center flex-shrink-0 shadow-sm group-hover:shadow-primary-200 transition-shadow duration-200">
+        <div class="w-8 h-8 bg-gradient-to-br from-iris-500 to-iris-700 rounded-lg flex items-center justify-center flex-shrink-0 glow-brand transition-shadow duration-200">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" />
           </svg>
         </div>
         <div>
-          <div class="font-bold text-ink text-sm leading-none" style="font-family: 'Space Grotesk', sans-serif;">Marketing AI</div>
+          <div class="font-bold text-ink text-sm leading-none font-display">Marketing AI</div>
           <div class="text-xs text-ink-subtle mt-0.5">Assistant</div>
         </div>
       </a>
     </div>
 
-    <!-- Organization switcher -->
-    {#if hasMultipleOrgs}
-      <div class="px-4 py-3 border-b border-border relative">
+    <!-- ── Context switcher ── -->
+    <div class="px-3 pt-3 relative">
+      {#if inProject}
+        <!-- Back to organization -->
         <button
-          on:click|stopPropagation={() => (showOrgDropdown = !showOrgDropdown)}
-          class="w-full flex items-center justify-between gap-2 px-2 py-1.5 rounded-lg hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
+          on:click={backToOrg}
+          class="w-full flex items-center gap-2 px-2 py-1.5 mb-2 rounded-lg text-xs font-semibold text-ink-muted hover:bg-surface-2 hover:text-ink transition-colors duration-150 cursor-pointer"
         >
-          <div class="flex items-center gap-2 min-w-0">
-            <div class="w-6 h-6 rounded bg-primary-100 flex items-center justify-center text-brand text-xs font-bold flex-shrink-0">
-              {(currentOrg?.name || '?').charAt(0).toUpperCase()}
-            </div>
-            <span class="text-sm font-medium text-ink truncate">{currentOrg?.name || ''}</span>
-          </div>
-          <svg class="w-4 h-4 text-ink-subtle flex-shrink-0 transition-transform duration-150 {showOrgDropdown ? 'rotate-180' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
-          </svg>
+          <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" /></svg>
+          {$_('nav.allProjects')}
         </button>
+
+        <!-- Project chip -->
+        <button
+          on:click|stopPropagation={() => (showProjectDropdown = !showProjectDropdown)}
+          class="w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg border border-brand/30 bg-brand-subtle/10 hover:bg-brand-subtle/15 transition-colors duration-150 cursor-pointer"
+        >
+          <div class="w-7 h-7 rounded-lg bg-gradient-to-br from-iris-400 to-iris-700 flex items-center justify-center text-white text-xs font-bold flex-shrink-0">
+            {($currentProjectStore?.name || '?').charAt(0).toUpperCase()}
+          </div>
+          <div class="min-w-0 flex-1 text-left">
+            <div class="text-[9px] font-bold uppercase tracking-wider text-brand-subtle-fg leading-none">{$_('nav.project')}</div>
+            <div class="text-sm font-semibold text-ink truncate leading-tight mt-0.5">{$currentProjectStore?.name}</div>
+          </div>
+          <svg class="w-4 h-4 text-ink-subtle flex-shrink-0 transition-transform duration-150 {showProjectDropdown ? 'rotate-180' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 9l4-4 4 4M8 15l4 4 4-4" /></svg>
+        </button>
+
+        {#if showProjectDropdown}
+          <div class="absolute left-3 right-3 mt-1 bg-surface border border-border rounded-lg shadow-lg z-50 py-1 max-h-72 overflow-y-auto custom-scroll">
+            {#each $projectsStore as project}
+              <button
+                on:click|stopPropagation={() => selectProjectFromSidebar(project)}
+                class="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-left transition-colors duration-150 cursor-pointer
+                  {$currentProjectStore?.id === project.id ? 'bg-brand-subtle/15 text-brand-subtle-fg font-medium' : 'text-ink-muted hover:bg-surface-2'}"
+              >
+                <span class="w-5 h-5 rounded bg-gradient-to-br from-iris-400 to-iris-700 flex items-center justify-center text-white text-[10px] font-bold flex-shrink-0">{(project.name || '?').charAt(0).toUpperCase()}</span>
+                <span class="truncate">{project.name}</span>
+                {#if $currentProjectStore?.id === project.id}
+                  <svg class="w-4 h-4 ml-auto text-brand flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" /></svg>
+                {/if}
+              </button>
+            {/each}
+          </div>
+        {/if}
+      {:else}
+        <!-- Organization chip -->
+        <button
+          on:click|stopPropagation={() => hasMultipleOrgs && (showOrgDropdown = !showOrgDropdown)}
+          class="w-full flex items-center gap-2.5 px-2.5 py-2 rounded-lg border border-warn/25 bg-warn/5 transition-colors duration-150 {hasMultipleOrgs ? 'hover:bg-warn/10 cursor-pointer' : 'cursor-default'}"
+        >
+          <div class="w-7 h-7 rounded-lg bg-gradient-to-br from-amber-400 to-amber-600 flex items-center justify-center text-white text-xs font-bold flex-shrink-0">
+            {(currentOrg?.name || '?').charAt(0).toUpperCase()}
+          </div>
+          <div class="min-w-0 flex-1 text-left">
+            <div class="text-[9px] font-bold uppercase tracking-wider text-warn leading-none">{$_('nav.organization')}</div>
+            <div class="text-sm font-semibold text-ink truncate leading-tight mt-0.5">{currentOrg?.name || ''}</div>
+          </div>
+          {#if hasMultipleOrgs}
+            <svg class="w-4 h-4 text-ink-subtle flex-shrink-0 transition-transform duration-150 {showOrgDropdown ? 'rotate-180' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M8 9l4-4 4 4M8 15l4 4 4-4" /></svg>
+          {/if}
+        </button>
+
         {#if showOrgDropdown}
           <div class="absolute left-3 right-3 mt-1 bg-surface border border-border rounded-lg shadow-lg z-50 py-1">
             {#each memberships as m}
@@ -226,153 +295,137 @@
                   class="flex-1 text-left px-3 py-2 text-sm flex items-center gap-2 cursor-pointer
                     {m.organization.id === $organizationIdStore ? 'text-brand font-medium' : 'text-ink-muted'}"
                 >
-                  <div class="w-5 h-5 rounded bg-primary-100 flex items-center justify-center text-brand text-[10px] font-bold flex-shrink-0">
+                  <div class="w-5 h-5 rounded bg-warn/15 flex items-center justify-center text-warn text-[10px] font-bold flex-shrink-0">
                     {(m.organization.name || '?').charAt(0).toUpperCase()}
                   </div>
                   <span class="truncate">{m.organization.name}</span>
                   {#if m.organization.id === $organizationIdStore}
-                    <svg class="w-4 h-4 text-brand ml-auto flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
-                    </svg>
+                    <svg class="w-4 h-4 text-brand ml-auto flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" /></svg>
                   {/if}
                 </button>
                 {#if m.role !== 'OWNER'}
                   <button
                     on:click|stopPropagation={() => (leavingOrg = m)}
-                    class="px-2 py-1 mr-2 text-red-400 hover:text-red-600 cursor-pointer flex-shrink-0"
+                    class="px-2 py-1 mr-2 text-bad/70 hover:text-bad cursor-pointer flex-shrink-0"
                     title={$_('settings.leaveTeam')}
                   >
-                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" />
-                    </svg>
+                    <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" /></svg>
                   </button>
                 {/if}
               </div>
             {/each}
           </div>
         {/if}
-      </div>
-    {/if}
+      {/if}
+    </div>
 
     <nav class="p-3 flex-1 space-y-6">
-      <!-- Main navigation -->
-      <div>
-        <p class="text-[10px] font-semibold text-ink-subtle uppercase tracking-widest px-3 mb-2">Navigation</p>
-        <ul class="space-y-0.5">
-          {#each mainLinks as link}
-            <li>
-              <a
-                href={link.href}
-                class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors duration-150 cursor-pointer
-                  {isActive(link.href, currentPath)
-                    ? 'bg-brand-subtle/10 text-brand border-l-2 border-primary-600'
-                    : 'text-ink-muted hover:bg-surface-2 hover:text-gray-900 border-l-2 border-transparent'}"
-              >
-                {@html icons[link.iconKey]}
-                <span>{$_(link.labelKey)}</span>
-              </a>
-            </li>
-          {/each}
-        </ul>
-      </div>
-
-      <!-- Marketing -->
-      <div>
-        <p class="text-[10px] font-semibold text-ink-subtle uppercase tracking-widest px-3 mb-2">{$_('nav.marketing')}</p>
-        <ul class="space-y-0.5">
-          <!-- Overview — only when project selected -->
-          {#if $currentProjectStore}
-            {@const overviewHref = `/projects/${$currentProjectStore.id}/overview`}
-            <li>
-              <a
-                href={overviewHref}
-                class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors duration-150 cursor-pointer
-                  {currentPath === overviewHref || currentPath.startsWith(overviewHref)
-                    ? 'bg-brand-subtle/10 text-brand border-l-2 border-primary-600'
-                    : 'text-ink-muted hover:bg-surface-2 hover:text-gray-900 border-l-2 border-transparent'}"
-              >
-                {@html icons['chartbar']}
-                <span>{$_('projects.overview')}</span>
-              </a>
-            </li>
-          {/if}
-
-          {#each resolvedMarketingLinks as link}
-            <li>
-              <a
-                href={link.href}
-                class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors duration-150 cursor-pointer
-                  {isActive(link.href, currentPath)
-                    ? 'bg-brand-subtle/10 text-brand border-l-2 border-primary-600'
-                    : 'text-ink-muted hover:bg-surface-2 hover:text-gray-900 border-l-2 border-transparent'}"
-              >
-                {@html icons[link.iconKey]}
-                <span>{$_(link.labelKey)}</span>
-              </a>
-            </li>
-          {/each}
-
-          <!-- Advanced toggle -->
-          <li>
-            <button
-              on:click={toggleAdvanced}
-              class="w-full flex items-center justify-between px-3 py-2 text-xs font-medium text-ink-subtle hover:text-gray-600 cursor-pointer transition-colors duration-150 mt-1"
-            >
-              <span>{showAdvanced ? $_('nav.hideAdvanced') : $_('nav.showAdvanced')}</span>
-              <svg
-                class="w-3.5 h-3.5 transition-transform duration-200 {showAdvanced ? 'rotate-180' : ''}"
-                fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"
-              >
-                <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
-              </svg>
-            </button>
-          </li>
-
-          {#if showAdvanced}
-            {#each resolvedAdvancedLinks as link}
+      {#if inProject}
+        <!-- ═══ PROJECT MODE ═══ -->
+        <div>
+          <p class="text-[10px] font-semibold text-ink-subtle uppercase tracking-widest px-3 mb-2">{$_('nav.thisProject')}</p>
+          <ul class="space-y-0.5">
+            {#each projectLinks as link}
               <li>
-                <a
-                  href={link.href}
-                  class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors duration-150 cursor-pointer
-                    {isActive(link.href, currentPath)
-                      ? 'bg-brand-subtle/10 text-brand border-l-2 border-primary-600'
-                      : 'text-ink-muted hover:bg-surface-2 hover:text-gray-900 border-l-2 border-transparent'}"
-                >
+                <a href={`/projects/${projectId}/${link.seg}`} class="nav-item" class:is-active={isActiveSeg(link.seg)}>
                   {@html icons[link.iconKey]}
                   <span>{$_(link.labelKey)}</span>
                 </a>
               </li>
             {/each}
-          {/if}
-        </ul>
-      </div>
+            {#each projectToolLinks as link}
+              <li>
+                <!-- AI Chat / Templates: currentProjectStore is already set, so these pages open pre-scoped to this project -->
+                <a href={link.href} class="nav-item" class:is-active={isActiveOrg(link.href)}>
+                  {@html icons[link.iconKey]}
+                  <span>{$_(link.labelKey)}</span>
+                </a>
+              </li>
+            {/each}
 
-      <!-- Settings -->
-      <div>
-        <p class="text-[10px] font-semibold text-ink-subtle uppercase tracking-widest px-3 mb-2">{$_('common.settings')}</p>
-        <ul class="space-y-0.5">
-          {#each settingsLinks as link}
             <li>
-              <a
-                href={link.href}
-                class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors duration-150 cursor-pointer
-                  {isActive(link.href, currentPath)
-                    ? 'bg-brand-subtle/10 text-brand border-l-2 border-primary-600'
-                    : 'text-ink-muted hover:bg-surface-2 hover:text-gray-900 border-l-2 border-transparent'}"
-              >
-                {@html icons[link.iconKey]}
-                <span>{$_(link.labelKey)}</span>
+              <button on:click={toggleAdvanced} class="w-full flex items-center justify-between px-3 py-2 text-xs font-medium text-ink-subtle hover:text-ink-muted cursor-pointer transition-colors duration-150 mt-1">
+                <span>{showAdvanced ? $_('nav.hideAdvanced') : $_('nav.showAdvanced')}</span>
+                <svg class="w-3.5 h-3.5 transition-transform duration-200 {showAdvanced ? 'rotate-180' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" /></svg>
+              </button>
+            </li>
+            {#if showAdvanced}
+              {#each projectAdvanced as link}
+                <li>
+                  <a href={`/projects/${projectId}/${link.seg}`} class="nav-item" class:is-active={isActiveSeg(link.seg)}>
+                    {@html icons[link.iconKey]}
+                    <span>{$_(link.labelKey)}</span>
+                  </a>
+                </li>
+              {/each}
+            {/if}
+          </ul>
+        </div>
+
+        <div>
+          <p class="text-[10px] font-semibold text-ink-subtle uppercase tracking-widest px-3 mb-2">{$_('common.settings')}</p>
+          <ul class="space-y-0.5">
+            <li>
+              <a href={`/projects/${projectId}/settings`} class="nav-item" class:is-active={isActiveSeg('settings')}>
+                {@html icons['building']}
+                <span>{$_('nav.settings')}</span>
               </a>
             </li>
-          {/each}
-        </ul>
-      </div>
+          </ul>
+        </div>
+      {:else}
+        <!-- ═══ ORGANIZATION MODE ═══ -->
+        <div>
+          <p class="text-[10px] font-semibold text-ink-subtle uppercase tracking-widest px-3 mb-2">{$_('nav.workspace')}</p>
+          <ul class="space-y-0.5">
+            {#each workspaceLinks as link}
+              <li>
+                <a href={link.href} class="nav-item" class:is-active={isActiveOrg(link.href)}>
+                  {@html icons[link.iconKey]}
+                  <span>{$_(link.labelKey)}</span>
+                  {#if link.hint}
+                    <span class="ml-auto text-[9px] font-medium text-ink-subtle">{$_('nav.allProjects').toLowerCase()}</span>
+                  {/if}
+                </a>
+              </li>
+            {/each}
+          </ul>
+        </div>
+
+        <div>
+          <p class="text-[10px] font-semibold text-ink-subtle uppercase tracking-widest px-3 mb-2">{$_('nav.rollups')}</p>
+          <ul class="space-y-0.5">
+            {#each rollupLinks as link}
+              <li>
+                <a href={link.href} class="nav-item" class:is-active={isActiveOrg(link.href)}>
+                  {@html icons[link.iconKey]}
+                  <span>{$_(link.labelKey)}</span>
+                </a>
+              </li>
+            {/each}
+          </ul>
+        </div>
+
+        <div>
+          <p class="text-[10px] font-semibold text-ink-subtle uppercase tracking-widest px-3 mb-2">{$_('common.settings')}</p>
+          <ul class="space-y-0.5">
+            {#each orgSettingsLinks as link}
+              <li>
+                <a href={link.href} class="nav-item" class:is-active={isActiveOrg(link.href)}>
+                  {@html icons[link.iconKey]}
+                  <span>{$_(link.labelKey)}</span>
+                </a>
+              </li>
+            {/each}
+          </ul>
+        </div>
+      {/if}
 
       <!-- User profile + logout -->
       {#if $currentUser}
         <div class="px-3 py-2 border-t border-border">
           <div class="flex items-center gap-2.5 px-3 py-2">
-            <div class="w-8 h-8 bg-gradient-to-br from-primary-400 to-primary-600 rounded-full flex items-center justify-center text-white font-semibold text-xs flex-shrink-0 select-none">
+            <div class="w-8 h-8 bg-gradient-to-br from-iris-400 to-iris-600 rounded-full flex items-center justify-center text-white font-semibold text-xs flex-shrink-0 select-none">
               {$currentUser.name?.charAt(0).toUpperCase() || 'U'}
             </div>
             <div class="flex-1 min-w-0">
@@ -383,13 +436,11 @@
             </div>
             <button
               on:click={logout}
-              class="p-1.5 rounded-lg text-ink-subtle hover:text-red-500 hover:bg-red-50 transition-colors duration-150 cursor-pointer flex-shrink-0"
+              class="p-1.5 rounded-lg text-ink-subtle hover:text-bad hover:bg-bad/10 transition-colors duration-150 cursor-pointer flex-shrink-0"
               title={$_('auth.logout')}
               aria-label={$_('auth.logout')}
             >
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" />
-              </svg>
+              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1" /></svg>
             </button>
           </div>
         </div>
@@ -397,10 +448,7 @@
 
       <!-- Theme Toggle + Help -->
       <div class="px-3 py-2 border-t border-border">
-        <button
-          on:click={toggleTheme}
-          class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-colors duration-150 w-full text-ink-muted hover:bg-surface-2 hover:text-gray-900 cursor-pointer"
-        >
+        <button on:click={toggleTheme} class="nav-item w-full">
           {#if isDark}
             <svg class="w-[18px] h-[18px] flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.75"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3v2.25m6.364.386-1.591 1.591M21 12h-2.25m-.386 6.364-1.591-1.591M12 18.75V21m-4.773-4.227-1.591 1.591M5.25 12H3m4.227-4.773L5.636 5.636M15.75 12a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0Z" /></svg>
             <span>{$_('nav.lightMode') || 'Light Mode'}</span>
@@ -409,9 +457,7 @@
             <span>{$_('nav.darkMode') || 'Dark Mode'}</span>
           {/if}
         </button>
-        <a href="/help"
-          class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm transition-colors duration-150
-            {$page.url.pathname.startsWith('/help') ? 'bg-brand-subtle/10 text-brand font-medium' : 'text-ink-muted hover:bg-surface-2 hover:text-gray-900'}">
+        <a href="/help" class="nav-item" class:is-active={currentPath.startsWith('/help')}>
           {@html icons.questionmark}
           <span>{$_('nav.help')}</span>
         </a>
@@ -424,29 +470,17 @@
 {#if leavingOrg}
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
-  <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => (leavingOrg = null)}>
-    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm p-6">
-      <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-4">
-        <svg class="w-6 h-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" />
-        </svg>
+  <div class="modal-overlay" on:click|self={() => (leavingOrg = null)}>
+    <div class="modal-panel max-w-sm p-6">
+      <div class="w-12 h-12 bg-bad/10 rounded-xl flex items-center justify-center mb-4">
+        <svg class="w-6 h-6 text-bad" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" /></svg>
       </div>
       <h2 class="text-lg font-semibold text-ink mb-1">{$_('settings.leaveTeamConfirm')}</h2>
       <p class="text-sm text-ink-muted mb-1 font-medium">{leavingOrg.organization?.name}</p>
       <p class="text-sm text-ink-muted mb-6">{$_('settings.leaveTeamDesc')}</p>
       <div class="flex gap-3">
-        <button
-          on:click={leaveOrg}
-          class="flex-1 bg-red-600 text-white py-2.5 rounded-lg font-medium text-sm hover:bg-red-700 transition-colors duration-150 cursor-pointer"
-        >
-          {$_('settings.leaveTeam')}
-        </button>
-        <button
-          on:click={() => (leavingOrg = null)}
-          class="flex-1 border border-border rounded-lg text-sm py-2.5 font-medium hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
-        >
-          {$_('common.cancel')}
-        </button>
+        <button on:click={leaveOrg} class="btn btn-danger flex-1">{$_('settings.leaveTeam')}</button>
+        <button on:click={() => (leavingOrg = null)} class="btn btn-secondary flex-1">{$_('common.cancel')}</button>
       </div>
     </div>
   </div>

--- a/apps/web/src/lib/components/seo/GscFilters.svelte
+++ b/apps/web/src/lib/components/seo/GscFilters.svelte
@@ -75,19 +75,19 @@
   $: parseFiltersToLocal(), filters;
 </script>
 
-<div class="bg-white rounded-xl border border-gray-200 p-4 mb-5 space-y-4">
+<div class="bg-surface rounded-xl border border-border p-4 mb-5 space-y-4">
   <!-- Row 1: Period + Compare + Search type -->
   <div class="flex flex-wrap items-center gap-4">
     <!-- Period selector -->
-    <div class="flex items-center gap-1 bg-gray-100 rounded-lg p-1">
+    <div class="flex items-center gap-1 bg-surface-2 rounded-lg p-1">
       {#each [7, 28, 90] as d}
         <button
           type="button"
           on:click={() => onDaysChange(d)}
           class="px-3 py-1.5 text-sm font-medium rounded-md transition-colors duration-150
             {days === d
-              ? 'bg-white text-gray-900 shadow-sm'
-              : 'text-gray-500 hover:text-gray-700'}">
+              ? 'bg-surface text-ink shadow-sm'
+              : 'text-ink-muted hover:text-gray-700'}">
           {d}d
         </button>
       {/each}
@@ -99,16 +99,16 @@
         type="checkbox"
         checked={compare}
         on:change={onCompareChange}
-        class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500" />
-      <span class="text-sm text-gray-700">{$_('gscDetail.compare')}</span>
+        class="h-4 w-4 rounded border-border text-brand focus:ring-primary-500" />
+      <span class="text-sm text-ink">{$_('gscDetail.compare')}</span>
     </label>
 
     <!-- Search type -->
     <div class="flex items-center gap-2">
-      <label class="text-sm text-gray-600 whitespace-nowrap">{$_('gscDetail.searchType')}:</label>
+      <label class="text-sm text-ink-muted whitespace-nowrap">{$_('gscDetail.searchType')}:</label>
       <select
         bind:value={searchType}
-        class="text-sm border border-gray-300 rounded-lg px-2.5 py-1.5 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+        class="text-sm border border-border rounded-lg px-2.5 py-1.5 bg-surface text-ink focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
         <option value="web">Web</option>
         <option value="image">Image</option>
         <option value="video">Video</option>
@@ -119,36 +119,36 @@
   </div>
 
   <!-- Row 2: Filter inputs -->
-  <div class="border-t border-gray-100 pt-3">
-    <span class="text-xs font-semibold text-gray-500 uppercase tracking-wide mb-2 block">{$_('gscDetail.filters')}</span>
+  <div class="border-t border-border pt-3">
+    <span class="text-xs font-semibold text-ink-muted uppercase tracking-wide mb-2 block">{$_('gscDetail.filters')}</span>
     <div class="flex flex-wrap items-end gap-3">
       <!-- Query contains -->
       <div class="flex flex-col gap-1 min-w-[160px]">
-        <label class="text-xs text-gray-500">{$_('gscDetail.queryContains')}</label>
+        <label class="text-xs text-ink-muted">{$_('gscDetail.queryContains')}</label>
         <input
           type="text"
           bind:value={queryContains}
           placeholder="e.g. marketing"
-          class="text-sm border border-gray-300 rounded-lg px-3 py-1.5 bg-white text-gray-700 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
+          class="text-sm border border-border rounded-lg px-3 py-1.5 bg-surface text-ink placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
       </div>
 
       <!-- Country -->
       <div class="flex flex-col gap-1 min-w-[120px]">
-        <label class="text-xs text-gray-500">{$_('gscDetail.country')}</label>
+        <label class="text-xs text-ink-muted">{$_('gscDetail.country')}</label>
         <input
           type="text"
           bind:value={country}
           placeholder="usa"
           maxlength={3}
-          class="text-sm border border-gray-300 rounded-lg px-3 py-1.5 bg-white text-gray-700 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent uppercase" />
+          class="text-sm border border-border rounded-lg px-3 py-1.5 bg-surface text-ink placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent uppercase" />
       </div>
 
       <!-- Device -->
       <div class="flex flex-col gap-1">
-        <label class="text-xs text-gray-500">{$_('gscDetail.device')}</label>
+        <label class="text-xs text-ink-muted">{$_('gscDetail.device')}</label>
         <select
           bind:value={device}
-          class="text-sm border border-gray-300 rounded-lg px-2.5 py-1.5 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+          class="text-sm border border-border rounded-lg px-2.5 py-1.5 bg-surface text-ink focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
           <option value="ALL">All devices</option>
           <option value="DESKTOP">Desktop</option>
           <option value="MOBILE">Mobile</option>
@@ -158,10 +158,10 @@
 
       <!-- Brand mode -->
       <div class="flex flex-col gap-1">
-        <label class="text-xs text-gray-500">{$_('gscDetail.filters')}</label>
+        <label class="text-xs text-ink-muted">{$_('gscDetail.filters')}</label>
         <select
           bind:value={brandMode}
-          class="text-sm border border-gray-300 rounded-lg px-2.5 py-1.5 bg-white text-gray-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+          class="text-sm border border-border rounded-lg px-2.5 py-1.5 bg-surface text-ink focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
           <option value="none">All queries</option>
           <option value="brand">{$_('gscDetail.brandOnly')}</option>
           <option value="nonbrand">{$_('gscDetail.nonBrandOnly')}</option>
@@ -171,12 +171,12 @@
       <!-- Brand term (shown when brand/nonbrand selected) -->
       {#if brandMode !== 'none'}
         <div class="flex flex-col gap-1 min-w-[140px]">
-          <label class="text-xs text-gray-500">{$_('gscDetail.brandTerm')}</label>
+          <label class="text-xs text-ink-muted">{$_('gscDetail.brandTerm')}</label>
           <input
             type="text"
             bind:value={brandTerm}
             placeholder="your brand"
-            class="text-sm border border-gray-300 rounded-lg px-3 py-1.5 bg-white text-gray-700 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
+            class="text-sm border border-border rounded-lg px-3 py-1.5 bg-surface text-ink placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
         </div>
       {/if}
 
@@ -184,7 +184,7 @@
       <button
         type="button"
         on:click={applyFilters}
-        class="px-4 py-1.5 text-sm font-medium bg-primary-600 hover:bg-primary-700 text-white rounded-lg transition-colors self-end">
+        class="px-4 py-1.5 text-sm font-medium bg-brand hover:brightness-110 text-white rounded-lg transition-colors self-end">
         Apply
       </button>
     </div>

--- a/apps/web/src/lib/components/seo/GscInsights.svelte
+++ b/apps/web/src/lib/components/seo/GscInsights.svelte
@@ -121,12 +121,12 @@
 
   /** deltaPosition negative = improved (lower rank number = higher position) → green */
   function positionDeltaClass(delta: number): string {
-    if (Math.abs(delta) < 0.0001) return 'text-gray-400';
+    if (Math.abs(delta) < 0.0001) return 'text-ink-subtle';
     return delta < 0 ? 'text-green-600' : 'text-red-500';
   }
 
   function clicksDeltaClass(delta: number): string {
-    if (Math.abs(delta) < 0.0001) return 'text-gray-400';
+    if (Math.abs(delta) < 0.0001) return 'text-ink-subtle';
     return delta > 0 ? 'text-green-600' : 'text-red-500';
   }
 
@@ -144,27 +144,27 @@
 {#if loading}
   <div class="space-y-4 animate-pulse mt-6">
     {#each Array(4) as _}
-      <div class="bg-white rounded-xl border border-gray-200 p-5">
-        <div class="h-4 bg-gray-100 rounded w-1/3 mb-2"></div>
-        <div class="h-3 bg-gray-100 rounded w-2/3 mb-4"></div>
+      <div class="bg-surface rounded-xl border border-border p-5">
+        <div class="h-4 bg-surface-2 rounded w-1/3 mb-2"></div>
+        <div class="h-3 bg-surface-2 rounded w-2/3 mb-4"></div>
         {#each Array(3) as _}
-          <div class="h-9 bg-gray-100 rounded mb-1.5"></div>
+          <div class="h-9 bg-surface-2 rounded mb-1.5"></div>
         {/each}
       </div>
     {/each}
   </div>
 
 {:else if error}
-  <div class="mt-6 bg-white rounded-xl border border-gray-200 flex flex-col items-center justify-center py-10 px-5 text-center">
+  <div class="mt-6 bg-surface rounded-xl border border-border flex flex-col items-center justify-center py-10 px-5 text-center">
     <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-3">
       <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
       </svg>
     </div>
-    <p class="text-sm text-gray-700 mb-3">{error}</p>
+    <p class="text-sm text-ink mb-3">{error}</p>
     <button
       on:click={fetchInsights}
-      class="px-4 py-1.5 text-sm font-medium bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg transition-colors">
+      class="px-4 py-1.5 text-sm font-medium bg-surface-2 hover:bg-gray-200 text-ink rounded-lg transition-colors">
       {$_('seo.searchConsolePanel.retry')}
     </button>
   </div>
@@ -173,38 +173,38 @@
   <div class="mt-8 space-y-6">
 
     <!-- 1. Striking distance -->
-    <div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
-      <div class="px-5 py-4 border-b border-gray-100">
-        <h3 class="text-sm font-semibold text-gray-900">{$_('gscDetail.strikingDistance')}</h3>
-        <p class="text-xs text-gray-500 mt-0.5">{$_('gscDetail.strikingDistanceDesc')}</p>
+    <div class="bg-surface rounded-xl border border-border overflow-hidden">
+      <div class="px-5 py-4 border-b border-border">
+        <h3 class="text-sm font-semibold text-ink">{$_('gscDetail.strikingDistance')}</h3>
+        <p class="text-xs text-ink-muted mt-0.5">{$_('gscDetail.strikingDistanceDesc')}</p>
       </div>
 
       {#if data.strikingDistance.length === 0}
-        <div class="text-sm text-gray-400 py-8 text-center">{$_('gscDetail.noData')}</div>
+        <div class="text-sm text-ink-subtle py-8 text-center">{$_('gscDetail.noData')}</div>
       {:else}
         <div class="overflow-x-auto">
           <table class="w-full text-sm min-w-[400px]">
             <thead>
-              <tr class="bg-gray-50 border-b border-gray-200">
-                <th class="text-left px-4 py-2.5 text-xs font-semibold text-gray-500">
+              <tr class="bg-surface-2 border-b border-border">
+                <th class="text-left px-4 py-2.5 text-xs font-semibold text-ink-muted">
                   {$_('seo.searchConsolePanel.query')}
                 </th>
-                <th class="text-right px-4 py-2.5 text-xs font-semibold text-gray-500 whitespace-nowrap">
+                <th class="text-right px-4 py-2.5 text-xs font-semibold text-ink-muted whitespace-nowrap">
                   {$_('seo.searchConsolePanel.position')}
                 </th>
-                <th class="text-right px-4 py-2.5 text-xs font-semibold text-gray-500 whitespace-nowrap">
+                <th class="text-right px-4 py-2.5 text-xs font-semibold text-ink-muted whitespace-nowrap">
                   {$_('seo.searchConsolePanel.impressions')}
                 </th>
               </tr>
             </thead>
             <tbody>
               {#each data.strikingDistance as row (row.key)}
-                <tr class="border-b border-gray-100 last:border-0 hover:bg-gray-50 transition-colors">
+                <tr class="border-b border-border last:border-0 hover:bg-surface-2 transition-colors">
                   <td class="px-4 py-2.5 max-w-[300px]">
-                    <span class="text-gray-800 truncate block" title={row.key}>{row.key}</span>
+                    <span class="text-ink truncate block" title={row.key}>{row.key}</span>
                   </td>
-                  <td class="px-4 py-2.5 text-right text-gray-600">{formatPosition(row.position)}</td>
-                  <td class="px-4 py-2.5 text-right text-gray-600">{formatNumber(row.impressions)}</td>
+                  <td class="px-4 py-2.5 text-right text-ink-muted">{formatPosition(row.position)}</td>
+                  <td class="px-4 py-2.5 text-right text-ink-muted">{formatNumber(row.impressions)}</td>
                 </tr>
               {/each}
             </tbody>
@@ -214,41 +214,41 @@
     </div>
 
     <!-- 2. Low CTR -->
-    <div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
-      <div class="px-5 py-4 border-b border-gray-100">
-        <h3 class="text-sm font-semibold text-gray-900">{$_('gscDetail.lowCtr')}</h3>
-        <p class="text-xs text-gray-500 mt-0.5">{$_('gscDetail.lowCtrDesc')}</p>
+    <div class="bg-surface rounded-xl border border-border overflow-hidden">
+      <div class="px-5 py-4 border-b border-border">
+        <h3 class="text-sm font-semibold text-ink">{$_('gscDetail.lowCtr')}</h3>
+        <p class="text-xs text-ink-muted mt-0.5">{$_('gscDetail.lowCtrDesc')}</p>
       </div>
 
       {#if data.lowCtr.length === 0}
-        <div class="text-sm text-gray-400 py-8 text-center">{$_('gscDetail.noData')}</div>
+        <div class="text-sm text-ink-subtle py-8 text-center">{$_('gscDetail.noData')}</div>
       {:else}
         <div class="overflow-x-auto">
           <table class="w-full text-sm min-w-[480px]">
             <thead>
-              <tr class="bg-gray-50 border-b border-gray-200">
-                <th class="text-left px-4 py-2.5 text-xs font-semibold text-gray-500">
+              <tr class="bg-surface-2 border-b border-border">
+                <th class="text-left px-4 py-2.5 text-xs font-semibold text-ink-muted">
                   {$_('seo.searchConsolePanel.query')}
                 </th>
-                <th class="text-right px-4 py-2.5 text-xs font-semibold text-gray-500 whitespace-nowrap">
+                <th class="text-right px-4 py-2.5 text-xs font-semibold text-ink-muted whitespace-nowrap">
                   {$_('seo.searchConsolePanel.position')}
                 </th>
-                <th class="text-right px-4 py-2.5 text-xs font-semibold text-gray-500 whitespace-nowrap">
+                <th class="text-right px-4 py-2.5 text-xs font-semibold text-ink-muted whitespace-nowrap">
                   {$_('seo.searchConsolePanel.ctr')}
                 </th>
-                <th class="text-right px-4 py-2.5 text-xs font-semibold text-gray-500 whitespace-nowrap">
+                <th class="text-right px-4 py-2.5 text-xs font-semibold text-ink-muted whitespace-nowrap">
                   {$_('gscDetail.missedClicks')}
                 </th>
               </tr>
             </thead>
             <tbody>
               {#each data.lowCtr as row (row.key)}
-                <tr class="border-b border-gray-100 last:border-0 hover:bg-gray-50 transition-colors">
+                <tr class="border-b border-border last:border-0 hover:bg-surface-2 transition-colors">
                   <td class="px-4 py-2.5 max-w-[280px]">
-                    <span class="text-gray-800 truncate block" title={row.key}>{row.key}</span>
+                    <span class="text-ink truncate block" title={row.key}>{row.key}</span>
                   </td>
-                  <td class="px-4 py-2.5 text-right text-gray-600">{formatPosition(row.position)}</td>
-                  <td class="px-4 py-2.5 text-right text-gray-600">{formatCtr(row.ctr)}</td>
+                  <td class="px-4 py-2.5 text-right text-ink-muted">{formatPosition(row.position)}</td>
+                  <td class="px-4 py-2.5 text-right text-ink-muted">{formatCtr(row.ctr)}</td>
                   <td class="px-4 py-2.5 text-right text-amber-600 font-medium">{formatNumber(row.missedClicks)}</td>
                 </tr>
               {/each}
@@ -259,27 +259,27 @@
     </div>
 
     <!-- 3. Cannibalization -->
-    <div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
-      <div class="px-5 py-4 border-b border-gray-100">
-        <h3 class="text-sm font-semibold text-gray-900">{$_('gscDetail.cannibalization')}</h3>
-        <p class="text-xs text-gray-500 mt-0.5">{$_('gscDetail.cannibalizationDesc')}</p>
+    <div class="bg-surface rounded-xl border border-border overflow-hidden">
+      <div class="px-5 py-4 border-b border-border">
+        <h3 class="text-sm font-semibold text-ink">{$_('gscDetail.cannibalization')}</h3>
+        <p class="text-xs text-ink-muted mt-0.5">{$_('gscDetail.cannibalizationDesc')}</p>
       </div>
 
       {#if data.cannibalization.length === 0}
-        <div class="text-sm text-gray-400 py-8 text-center">{$_('gscDetail.noData')}</div>
+        <div class="text-sm text-ink-subtle py-8 text-center">{$_('gscDetail.noData')}</div>
       {:else}
-        <div class="divide-y divide-gray-100">
+        <div class="divide-y divide-border">
           {#each data.cannibalization as item (item.query)}
             <div class="px-5 py-4">
               <div class="flex items-center gap-2 mb-2">
-                <span class="text-sm font-medium text-gray-800 truncate">{item.query}</span>
-                <span class="text-xs text-gray-400 whitespace-nowrap">
+                <span class="text-sm font-medium text-ink truncate">{item.query}</span>
+                <span class="text-xs text-ink-subtle whitespace-nowrap">
                   {formatNumber(item.totalImpressions)} {$_('seo.searchConsolePanel.impressions').toLowerCase()}
                 </span>
               </div>
-              <div class="space-y-1 pl-3 border-l-2 border-gray-200">
+              <div class="space-y-1 pl-3 border-l-2 border-border">
                 {#each item.pages as pg (pg.page)}
-                  <div class="flex items-center justify-between gap-4 text-xs text-gray-600">
+                  <div class="flex items-center justify-between gap-4 text-xs text-ink-muted">
                     <span class="truncate text-blue-600" title={pg.page}>{getPath(pg.page)}</span>
                     <span class="whitespace-nowrap shrink-0">
                       pos {formatPosition(pg.position)}
@@ -296,47 +296,47 @@
     </div>
 
     <!-- 4. Movers (gainers / losers from moversQueries) -->
-    <div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
-      <div class="px-5 py-4 border-b border-gray-100">
-        <h3 class="text-sm font-semibold text-gray-900">{$_('gscDetail.movers')}</h3>
-        <p class="text-xs text-gray-500 mt-0.5">{$_('gscDetail.moversDesc')}</p>
+    <div class="bg-surface rounded-xl border border-border overflow-hidden">
+      <div class="px-5 py-4 border-b border-border">
+        <h3 class="text-sm font-semibold text-ink">{$_('gscDetail.movers')}</h3>
+        <p class="text-xs text-ink-muted mt-0.5">{$_('gscDetail.moversDesc')}</p>
       </div>
 
       {#if data.moversQueries.gainers.length === 0 && data.moversQueries.losers.length === 0}
-        <div class="text-sm text-gray-400 py-8 text-center">{$_('gscDetail.noData')}</div>
+        <div class="text-sm text-ink-subtle py-8 text-center">{$_('gscDetail.noData')}</div>
       {:else}
-        <div class="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-gray-100">
+        <div class="grid grid-cols-1 md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-border">
 
           <!-- Gainers -->
           <div>
-            <div class="px-4 py-3 bg-green-50 border-b border-gray-100">
+            <div class="px-4 py-3 bg-green-50 border-b border-border">
               <span class="text-xs font-semibold text-green-700 uppercase tracking-wide">{$_('gscDetail.gainers')}</span>
             </div>
             {#if data.moversQueries.gainers.length === 0}
-              <div class="text-xs text-gray-400 py-6 text-center">{$_('gscDetail.noData')}</div>
+              <div class="text-xs text-ink-subtle py-6 text-center">{$_('gscDetail.noData')}</div>
             {:else}
               <table class="w-full text-xs">
                 <thead>
-                  <tr class="bg-gray-50 border-b border-gray-100">
-                    <th class="text-left px-4 py-2 font-semibold text-gray-500">{$_('seo.searchConsolePanel.query')}</th>
-                    <th class="text-right px-3 py-2 font-semibold text-gray-500 whitespace-nowrap">{$_('seo.searchConsolePanel.clicks')}</th>
-                    <th class="text-right px-3 py-2 font-semibold text-gray-500 whitespace-nowrap">{$_('seo.searchConsolePanel.position')}</th>
+                  <tr class="bg-surface-2 border-b border-border">
+                    <th class="text-left px-4 py-2 font-semibold text-ink-muted">{$_('seo.searchConsolePanel.query')}</th>
+                    <th class="text-right px-3 py-2 font-semibold text-ink-muted whitespace-nowrap">{$_('seo.searchConsolePanel.clicks')}</th>
+                    <th class="text-right px-3 py-2 font-semibold text-ink-muted whitespace-nowrap">{$_('seo.searchConsolePanel.position')}</th>
                   </tr>
                 </thead>
                 <tbody>
                   {#each data.moversQueries.gainers as row (row.key)}
-                    <tr class="border-b border-gray-100 last:border-0 hover:bg-gray-50 transition-colors">
+                    <tr class="border-b border-border last:border-0 hover:bg-surface-2 transition-colors">
                       <td class="px-4 py-2 max-w-[160px]">
-                        <span class="text-gray-800 truncate block" title={row.key}>{row.key}</span>
+                        <span class="text-ink truncate block" title={row.key}>{row.key}</span>
                       </td>
                       <td class="px-3 py-2 text-right">
-                        <span class="text-gray-700 font-medium">{formatNumber(row.clicks)}</span>
+                        <span class="text-ink font-medium">{formatNumber(row.clicks)}</span>
                         {#if row.deltaClicks !== 0}
                           <br /><span class="text-xs {clicksDeltaClass(row.deltaClicks)}">{fmtIntDelta(row.deltaClicks)}</span>
                         {/if}
                       </td>
                       <td class="px-3 py-2 text-right">
-                        <span class="text-gray-600">{formatPosition(row.position)}</span>
+                        <span class="text-ink-muted">{formatPosition(row.position)}</span>
                         {#if Math.abs(row.deltaPosition) >= 0.0001}
                           <br /><span class="text-xs {positionDeltaClass(row.deltaPosition)}">{fmtPosDelta(row.deltaPosition)}</span>
                         {/if}
@@ -350,34 +350,34 @@
 
           <!-- Losers -->
           <div>
-            <div class="px-4 py-3 bg-red-50 border-b border-gray-100">
+            <div class="px-4 py-3 bg-red-50 border-b border-border">
               <span class="text-xs font-semibold text-red-700 uppercase tracking-wide">{$_('gscDetail.losers')}</span>
             </div>
             {#if data.moversQueries.losers.length === 0}
-              <div class="text-xs text-gray-400 py-6 text-center">{$_('gscDetail.noData')}</div>
+              <div class="text-xs text-ink-subtle py-6 text-center">{$_('gscDetail.noData')}</div>
             {:else}
               <table class="w-full text-xs">
                 <thead>
-                  <tr class="bg-gray-50 border-b border-gray-100">
-                    <th class="text-left px-4 py-2 font-semibold text-gray-500">{$_('seo.searchConsolePanel.query')}</th>
-                    <th class="text-right px-3 py-2 font-semibold text-gray-500 whitespace-nowrap">{$_('seo.searchConsolePanel.clicks')}</th>
-                    <th class="text-right px-3 py-2 font-semibold text-gray-500 whitespace-nowrap">{$_('seo.searchConsolePanel.position')}</th>
+                  <tr class="bg-surface-2 border-b border-border">
+                    <th class="text-left px-4 py-2 font-semibold text-ink-muted">{$_('seo.searchConsolePanel.query')}</th>
+                    <th class="text-right px-3 py-2 font-semibold text-ink-muted whitespace-nowrap">{$_('seo.searchConsolePanel.clicks')}</th>
+                    <th class="text-right px-3 py-2 font-semibold text-ink-muted whitespace-nowrap">{$_('seo.searchConsolePanel.position')}</th>
                   </tr>
                 </thead>
                 <tbody>
                   {#each data.moversQueries.losers as row (row.key)}
-                    <tr class="border-b border-gray-100 last:border-0 hover:bg-gray-50 transition-colors">
+                    <tr class="border-b border-border last:border-0 hover:bg-surface-2 transition-colors">
                       <td class="px-4 py-2 max-w-[160px]">
-                        <span class="text-gray-800 truncate block" title={row.key}>{row.key}</span>
+                        <span class="text-ink truncate block" title={row.key}>{row.key}</span>
                       </td>
                       <td class="px-3 py-2 text-right">
-                        <span class="text-gray-700 font-medium">{formatNumber(row.clicks)}</span>
+                        <span class="text-ink font-medium">{formatNumber(row.clicks)}</span>
                         {#if row.deltaClicks !== 0}
                           <br /><span class="text-xs {clicksDeltaClass(row.deltaClicks)}">{fmtIntDelta(row.deltaClicks)}</span>
                         {/if}
                       </td>
                       <td class="px-3 py-2 text-right">
-                        <span class="text-gray-600">{formatPosition(row.position)}</span>
+                        <span class="text-ink-muted">{formatPosition(row.position)}</span>
                         {#if Math.abs(row.deltaPosition) >= 0.0001}
                           <br /><span class="text-xs {positionDeltaClass(row.deltaPosition)}">{fmtPosDelta(row.deltaPosition)}</span>
                         {/if}

--- a/apps/web/src/lib/components/seo/GscOverview.svelte
+++ b/apps/web/src/lib/components/seo/GscOverview.svelte
@@ -124,7 +124,7 @@
   // Delta badge: positive delta is green (good), negative is red (bad).
   // For position, the sign is inverted: lower position = better.
   function deltaClass(delta: number, invertGood = false): string {
-    if (delta === 0) return 'bg-gray-100 text-gray-500';
+    if (delta === 0) return 'bg-surface-2 text-ink-muted';
     const good = invertGood ? delta < 0 : delta > 0;
     return good ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700';
   }
@@ -141,9 +141,9 @@
   <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
 
     <!-- Clicks -->
-    <div class="bg-white border border-gray-200 rounded-xl p-4 border-t-4 border-t-blue-400">
-      <div class="text-xs text-gray-500 mb-1">{$_('seo.searchConsolePanel.totalClicks')}</div>
-      <div class="text-2xl font-bold text-gray-900">{totals ? formatNumber(totals.clicks ?? 0) : '—'}</div>
+    <div class="bg-surface border border-border rounded-xl p-4 border-t-4 border-t-blue-400">
+      <div class="text-xs text-ink-muted mb-1">{$_('seo.searchConsolePanel.totalClicks')}</div>
+      <div class="text-2xl font-bold text-ink">{totals ? formatNumber(totals.clicks ?? 0) : '—'}</div>
       {#if clicksDelta !== null}
         <span class="inline-block mt-1 text-xs font-medium px-1.5 py-0.5 rounded {deltaClass(clicksDelta)}">
           {formatDelta(clicksDelta)}
@@ -152,9 +152,9 @@
     </div>
 
     <!-- Impressions -->
-    <div class="bg-white border border-gray-200 rounded-xl p-4 border-t-4 border-t-purple-400">
-      <div class="text-xs text-gray-500 mb-1">{$_('seo.searchConsolePanel.totalImpressions')}</div>
-      <div class="text-2xl font-bold text-gray-900">{totals ? formatNumber(totals.impressions ?? 0) : '—'}</div>
+    <div class="bg-surface border border-border rounded-xl p-4 border-t-4 border-t-purple-400">
+      <div class="text-xs text-ink-muted mb-1">{$_('seo.searchConsolePanel.totalImpressions')}</div>
+      <div class="text-2xl font-bold text-ink">{totals ? formatNumber(totals.impressions ?? 0) : '—'}</div>
       {#if impressionsDelta !== null}
         <span class="inline-block mt-1 text-xs font-medium px-1.5 py-0.5 rounded {deltaClass(impressionsDelta)}">
           {formatDelta(impressionsDelta)}
@@ -163,9 +163,9 @@
     </div>
 
     <!-- CTR -->
-    <div class="bg-white border border-gray-200 rounded-xl p-4 border-t-4 border-t-green-400">
-      <div class="text-xs text-gray-500 mb-1">{$_('seo.searchConsolePanel.avgCtr')}</div>
-      <div class="text-2xl font-bold text-gray-900">{totals ? formatCtr(totals.ctr ?? 0) : '—'}</div>
+    <div class="bg-surface border border-border rounded-xl p-4 border-t-4 border-t-green-400">
+      <div class="text-xs text-ink-muted mb-1">{$_('seo.searchConsolePanel.avgCtr')}</div>
+      <div class="text-2xl font-bold text-ink">{totals ? formatCtr(totals.ctr ?? 0) : '—'}</div>
       {#if ctrDelta !== null}
         <span class="inline-block mt-1 text-xs font-medium px-1.5 py-0.5 rounded {deltaClass(ctrDelta)}">
           {formatDelta(ctrDelta * 100)}%
@@ -174,9 +174,9 @@
     </div>
 
     <!-- Average position (lower = better → invert delta color) -->
-    <div class="bg-white border border-gray-200 rounded-xl p-4 border-t-4 border-t-amber-400">
-      <div class="text-xs text-gray-500 mb-1">{$_('seo.searchConsolePanel.avgPosition')}</div>
-      <div class="text-2xl font-bold text-gray-900">{totals ? formatPosition(totals.position ?? 0) : '—'}</div>
+    <div class="bg-surface border border-border rounded-xl p-4 border-t-4 border-t-amber-400">
+      <div class="text-xs text-ink-muted mb-1">{$_('seo.searchConsolePanel.avgPosition')}</div>
+      <div class="text-2xl font-bold text-ink">{totals ? formatPosition(totals.position ?? 0) : '—'}</div>
       {#if positionDelta !== null}
         <span class="inline-block mt-1 text-xs font-medium px-1.5 py-0.5 rounded {deltaClass(positionDelta, true)}">
           {formatDelta(positionDelta)}
@@ -187,8 +187,8 @@
 
   <!-- Clicks + Impressions line chart -->
   {#if byDate.length > 0}
-    <div class="bg-white border border-gray-200 rounded-xl p-5">
-      <h3 class="text-sm font-semibold text-gray-700 mb-4">{$_('seo.searchConsolePanel.clicks')} &amp; {$_('seo.searchConsolePanel.impressions')}</h3>
+    <div class="bg-surface border border-border rounded-xl p-5">
+      <h3 class="text-sm font-semibold text-ink mb-4">{$_('seo.searchConsolePanel.clicks')} &amp; {$_('seo.searchConsolePanel.impressions')}</h3>
       <div class="relative" style="height: 220px;">
         <canvas bind:this={lineCanvas} style="width: 100%; height: 100%;"></canvas>
       </div>

--- a/apps/web/src/lib/components/seo/GscPerformanceTable.svelte
+++ b/apps/web/src/lib/components/seo/GscPerformanceTable.svelte
@@ -193,7 +193,7 @@
 
   /** Returns Tailwind colour class for a delta. lowerIsBetter inverts green/red. */
   function deltaClass(delta: number, lowerIsBetter = false): string {
-    if (Math.abs(delta) < 0.0001) return 'text-gray-400';
+    if (Math.abs(delta) < 0.0001) return 'text-ink-subtle';
     const positive = lowerIsBetter ? delta < 0 : delta > 0;
     return positive ? 'text-green-600' : 'text-red-500';
   }
@@ -215,13 +215,13 @@
   }
 </script>
 
-<div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
+<div class="bg-surface rounded-xl border border-border overflow-hidden">
   {#if loading}
     <!-- Skeleton loader -->
     <div class="p-5 space-y-2 animate-pulse">
-      <div class="h-9 bg-gray-100 rounded-lg mb-3"></div>
+      <div class="h-9 bg-surface-2 rounded-lg mb-3"></div>
       {#each Array(5) as _}
-        <div class="h-11 bg-gray-100 rounded-lg"></div>
+        <div class="h-11 bg-surface-2 rounded-lg"></div>
       {/each}
     </div>
 
@@ -232,24 +232,24 @@
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
         </svg>
       </div>
-      <p class="text-sm text-gray-700 mb-3">{error}</p>
+      <p class="text-sm text-ink mb-3">{error}</p>
       <button
         on:click={fetchRows}
-        class="px-4 py-1.5 text-sm font-medium bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg transition-colors">
+        class="px-4 py-1.5 text-sm font-medium bg-surface-2 hover:bg-gray-200 text-ink rounded-lg transition-colors">
         {$_('seo.searchConsolePanel.retry')}
       </button>
     </div>
 
   {:else if rows.length === 0}
-    <div class="text-sm text-gray-400 py-10 text-center">{$_('gscDetail.noData')}</div>
+    <div class="text-sm text-ink-subtle py-10 text-center">{$_('gscDetail.noData')}</div>
 
   {:else}
     <div class="overflow-x-auto">
       <table class="w-full text-sm min-w-[520px]">
         <thead>
-          <tr class="bg-gray-50 border-b border-gray-200">
+          <tr class="bg-surface-2 border-b border-border">
             <th
-              class="text-left px-3 py-2.5 text-xs font-semibold text-gray-500 cursor-pointer hover:text-gray-700 select-none"
+              class="text-left px-3 py-2.5 text-xs font-semibold text-ink-muted cursor-pointer hover:text-gray-700 select-none"
               on:click={() => toggleSort('value')}>
               {dimension === 'query'
                 ? $_('seo.searchConsolePanel.query')
@@ -257,22 +257,22 @@
               {sortIcon('value')}
             </th>
             <th
-              class="text-right px-3 py-2.5 text-xs font-semibold text-gray-500 cursor-pointer hover:text-gray-700 whitespace-nowrap select-none"
+              class="text-right px-3 py-2.5 text-xs font-semibold text-ink-muted cursor-pointer hover:text-gray-700 whitespace-nowrap select-none"
               on:click={() => toggleSort('clicks')}>
               {$_('seo.searchConsolePanel.clicks')} {sortIcon('clicks')}
             </th>
             <th
-              class="text-right px-3 py-2.5 text-xs font-semibold text-gray-500 cursor-pointer hover:text-gray-700 whitespace-nowrap select-none"
+              class="text-right px-3 py-2.5 text-xs font-semibold text-ink-muted cursor-pointer hover:text-gray-700 whitespace-nowrap select-none"
               on:click={() => toggleSort('impressions')}>
               {$_('seo.searchConsolePanel.impressions')} {sortIcon('impressions')}
             </th>
             <th
-              class="text-right px-3 py-2.5 text-xs font-semibold text-gray-500 cursor-pointer hover:text-gray-700 whitespace-nowrap select-none"
+              class="text-right px-3 py-2.5 text-xs font-semibold text-ink-muted cursor-pointer hover:text-gray-700 whitespace-nowrap select-none"
               on:click={() => toggleSort('ctr')}>
               {$_('seo.searchConsolePanel.ctr')} {sortIcon('ctr')}
             </th>
             <th
-              class="text-right px-3 py-2.5 text-xs font-semibold text-gray-500 cursor-pointer hover:text-gray-700 whitespace-nowrap select-none"
+              class="text-right px-3 py-2.5 text-xs font-semibold text-ink-muted cursor-pointer hover:text-gray-700 whitespace-nowrap select-none"
               on:click={() => toggleSort('position')}>
               {$_('seo.searchConsolePanel.position')} {sortIcon('position')}
             </th>
@@ -284,18 +284,18 @@
             {@const isExpanded = !!expanded[rowKey]}
             <!-- Main row — click to drill down -->
             <tr
-              class="border-b border-gray-100 hover:bg-blue-50 cursor-pointer transition-colors"
+              class="border-b border-border hover:bg-blue-50 cursor-pointer transition-colors"
               class:bg-blue-50={isExpanded}
               on:click={() => toggleDrillDown(rowKey)}>
               <td class="px-3 py-2 max-w-[200px]">
-                <span class="text-gray-800 truncate block" title={rowKey}>
+                <span class="text-ink truncate block" title={rowKey}>
                   {formatDimValue(rowKey, dimension)}
                 </span>
               </td>
 
               <!-- Clicks -->
               <td class="px-3 py-2 text-right">
-                <span class="text-gray-700 font-medium">{formatNumber(row.clicks)}</span>
+                <span class="text-ink font-medium">{formatNumber(row.clicks)}</span>
                 {#if compare && row.prevClicks != null}
                   {@const d = row.clicks - row.prevClicks}
                   <br /><span class="text-xs {deltaClass(d)}">{fmtIntDelta(d)}</span>
@@ -304,7 +304,7 @@
 
               <!-- Impressions -->
               <td class="px-3 py-2 text-right">
-                <span class="text-gray-600">{formatNumber(row.impressions)}</span>
+                <span class="text-ink-muted">{formatNumber(row.impressions)}</span>
                 {#if compare && row.prevImpressions != null}
                   {@const d = row.impressions - row.prevImpressions}
                   <br /><span class="text-xs {deltaClass(d)}">{fmtIntDelta(d)}</span>
@@ -313,7 +313,7 @@
 
               <!-- CTR -->
               <td class="px-3 py-2 text-right">
-                <span class="text-gray-600">{formatCtr(row.ctr)}</span>
+                <span class="text-ink-muted">{formatCtr(row.ctr)}</span>
                 {#if compare && row.prevCtr != null}
                   {@const d = row.ctr - row.prevCtr}
                   <br /><span class="text-xs {deltaClass(d)}">{fmtCtrDelta(d)}</span>
@@ -322,7 +322,7 @@
 
               <!-- Position (lower = better) -->
               <td class="px-3 py-2 text-right">
-                <span class="text-gray-600">{formatPosition(row.position)}</span>
+                <span class="text-ink-muted">{formatPosition(row.position)}</span>
                 {#if compare && row.prevPosition != null}
                   {@const d = row.position - row.prevPosition}
                   <br /><span class="text-xs {deltaClass(d, true)}">{fmtPosDelta(d)}</span>
@@ -333,7 +333,7 @@
             <!-- Drill-down sub-row -->
             {#if isExpanded}
               {@const drill = expanded[rowKey]}
-              <tr class="border-b border-gray-100">
+              <tr class="border-b border-border">
                 <td colspan="5" class="p-0 bg-blue-50">
                   <div class="px-6 py-3 border-l-4 border-blue-300">
                     <p class="text-xs font-semibold text-blue-700 mb-2 uppercase tracking-wide">
@@ -354,27 +354,27 @@
                       <p class="text-xs text-red-500">{drill.error}</p>
 
                     {:else if drill.rows.length === 0}
-                      <p class="text-xs text-gray-400">{$_('gscDetail.noData')}</p>
+                      <p class="text-xs text-ink-subtle">{$_('gscDetail.noData')}</p>
 
                     {:else}
                       <table class="w-full text-xs min-w-[400px]">
                         <thead>
                           <tr class="border-b border-blue-200">
-                            <th class="text-left py-1.5 pr-3 font-semibold text-gray-500">
+                            <th class="text-left py-1.5 pr-3 font-semibold text-ink-muted">
                               {oppDim(dimension) === 'query'
                                 ? $_('seo.searchConsolePanel.query')
                                 : $_('seo.searchConsolePanel.page')}
                             </th>
-                            <th class="text-right py-1.5 px-2 font-semibold text-gray-500 whitespace-nowrap">
+                            <th class="text-right py-1.5 px-2 font-semibold text-ink-muted whitespace-nowrap">
                               {$_('seo.searchConsolePanel.clicks')}
                             </th>
-                            <th class="text-right py-1.5 px-2 font-semibold text-gray-500 whitespace-nowrap">
+                            <th class="text-right py-1.5 px-2 font-semibold text-ink-muted whitespace-nowrap">
                               {$_('seo.searchConsolePanel.impressions')}
                             </th>
-                            <th class="text-right py-1.5 px-2 font-semibold text-gray-500 whitespace-nowrap">
+                            <th class="text-right py-1.5 px-2 font-semibold text-ink-muted whitespace-nowrap">
                               {$_('seo.searchConsolePanel.ctr')}
                             </th>
-                            <th class="text-right py-1.5 pl-2 font-semibold text-gray-500 whitespace-nowrap">
+                            <th class="text-right py-1.5 pl-2 font-semibold text-ink-muted whitespace-nowrap">
                               {$_('seo.searchConsolePanel.position')}
                             </th>
                           </tr>
@@ -383,14 +383,14 @@
                           {#each drill.rows as dr (dr.keys[0])}
                             <tr class="border-b border-blue-100 last:border-0">
                               <td class="py-1.5 pr-3 max-w-[180px]">
-                                <span class="text-gray-700 truncate block" title={dr.keys[0]}>
+                                <span class="text-ink truncate block" title={dr.keys[0]}>
                                   {formatDimValue(dr.keys[0], oppDim(dimension))}
                                 </span>
                               </td>
-                              <td class="py-1.5 px-2 text-right text-gray-700 font-medium">{formatNumber(dr.clicks)}</td>
-                              <td class="py-1.5 px-2 text-right text-gray-600">{formatNumber(dr.impressions)}</td>
-                              <td class="py-1.5 px-2 text-right text-gray-600">{formatCtr(dr.ctr)}</td>
-                              <td class="py-1.5 pl-2 text-right text-gray-600">{formatPosition(dr.position)}</td>
+                              <td class="py-1.5 px-2 text-right text-ink font-medium">{formatNumber(dr.clicks)}</td>
+                              <td class="py-1.5 px-2 text-right text-ink-muted">{formatNumber(dr.impressions)}</td>
+                              <td class="py-1.5 px-2 text-right text-ink-muted">{formatCtr(dr.ctr)}</td>
+                              <td class="py-1.5 pl-2 text-right text-ink-muted">{formatPosition(dr.position)}</td>
                             </tr>
                           {/each}
                         </tbody>
@@ -406,18 +406,18 @@
     </div>
 
     <!-- Pagination -->
-    <div class="flex items-center justify-between px-4 py-3 border-t border-gray-100">
+    <div class="flex items-center justify-between px-4 py-3 border-t border-border">
       <button
         on:click={goToPrevPage}
         disabled={currentPage === 0 || loading}
         class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg transition-colors
           {currentPage === 0 || loading
-            ? 'text-gray-300 cursor-not-allowed'
-            : 'text-gray-600 hover:bg-gray-100'}">
+            ? 'text-ink-subtle cursor-not-allowed'
+            : 'text-ink-muted hover:bg-surface-2'}">
         ← {$_('common.previous')}
       </button>
 
-      <span class="text-xs text-gray-400">
+      <span class="text-xs text-ink-subtle">
         {currentPage + 1} / {hasMore ? '…' : currentPage + 1}
       </span>
 
@@ -426,8 +426,8 @@
         disabled={!hasMore || loading}
         class="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-lg transition-colors
           {!hasMore || loading
-            ? 'text-gray-300 cursor-not-allowed'
-            : 'text-gray-600 hover:bg-gray-100'}">
+            ? 'text-ink-subtle cursor-not-allowed'
+            : 'text-ink-muted hover:bg-surface-2'}">
         {$_('common.next')} →
       </button>
     </div>

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -114,7 +114,7 @@
 <svelte:window bind:innerWidth />
 
 {#if appReady}
-  <div class="flex h-screen bg-gray-50 overflow-hidden">
+  <div class="flex h-screen bg-surface-2 overflow-hidden">
     <!-- Mobile backdrop overlay -->
     {#if isMobile && sidebarOpen}
       <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -138,7 +138,7 @@
     {#if !isHelpPage}
       <button
         on:click={() => showHelpDrawer = true}
-        class="fixed bottom-6 right-6 z-40 w-10 h-10 bg-primary-600 text-white rounded-full shadow-lg hover:bg-primary-700 hover:shadow-xl transition-all duration-200 flex items-center justify-center cursor-pointer"
+        class="fixed bottom-6 right-6 z-40 w-10 h-10 bg-brand text-white rounded-full shadow-lg hover:brightness-110 hover:shadow-xl transition-all duration-200 flex items-center justify-center cursor-pointer"
         title="Help"
       >
         <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -150,7 +150,7 @@
     <HelpDrawer bind:show={showHelpDrawer} slug={helpSlug} />
   </div>
 {:else}
-  <div class="flex items-center justify-center h-screen bg-gray-50">
+  <div class="flex items-center justify-center h-screen bg-surface-2">
     <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-primary-600"></div>
   </div>
 {/if}

--- a/apps/web/src/routes/(app)/+layout.svelte
+++ b/apps/web/src/routes/(app)/+layout.svelte
@@ -114,7 +114,7 @@
 <svelte:window bind:innerWidth />
 
 {#if appReady}
-  <div class="flex h-screen bg-surface-2 overflow-hidden">
+  <div class="flex h-screen bg-canvas overflow-hidden">
     <!-- Mobile backdrop overlay -->
     {#if isMobile && sidebarOpen}
       <!-- svelte-ignore a11y-click-events-have-key-events -->
@@ -138,7 +138,7 @@
     {#if !isHelpPage}
       <button
         on:click={() => showHelpDrawer = true}
-        class="fixed bottom-6 right-6 z-40 w-10 h-10 bg-brand text-white rounded-full shadow-lg hover:brightness-110 hover:shadow-xl transition-all duration-200 flex items-center justify-center cursor-pointer"
+        class="fixed bottom-6 right-6 z-40 w-10 h-10 bg-brand text-brand-fg rounded-full glow-brand hover:brightness-110 transition-all duration-200 flex items-center justify-center cursor-pointer"
         title="Help"
       >
         <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -150,7 +150,7 @@
     <HelpDrawer bind:show={showHelpDrawer} slug={helpSlug} />
   </div>
 {:else}
-  <div class="flex items-center justify-center h-screen bg-surface-2">
-    <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-primary-600"></div>
+  <div class="flex items-center justify-center h-screen bg-canvas">
+    <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-brand"></div>
   </div>
 {/if}

--- a/apps/web/src/routes/(app)/ai-chat/+page.svelte
+++ b/apps/web/src/routes/(app)/ai-chat/+page.svelte
@@ -244,10 +244,10 @@
 
 <div class="flex h-full max-h-[calc(100vh-56px)]">
   <!-- Sessions sidebar -->
-  <div class="w-64 border-r border-gray-200 flex flex-col flex-shrink-0 bg-gray-50">
-    <div class="p-3 border-b border-gray-200">
+  <div class="w-64 border-r border-border flex flex-col flex-shrink-0 bg-surface-2">
+    <div class="p-3 border-b border-border">
       <button on:click={startNewChat}
-        class="w-full flex items-center gap-2 px-3 py-2 bg-primary-600 text-white text-sm font-medium rounded-lg hover:bg-primary-700 transition-colors duration-150 cursor-pointer">
+        class="w-full flex items-center gap-2 px-3 py-2 bg-brand text-white text-sm font-medium rounded-lg hover:brightness-110 transition-colors duration-150 cursor-pointer">
         <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" /></svg>
         {$_('aiChat.newChat')}
       </button>
@@ -263,18 +263,18 @@
             <button
               on:click={() => selectSession(session.id)}
               class="flex-1 min-w-0 text-left px-3 py-2 rounded-lg transition-colors duration-150 cursor-pointer
-                {currentSessionId === session.id ? 'bg-primary-50 text-primary-700 font-medium' : 'text-gray-600 hover:bg-gray-100'}"
+                {currentSessionId === session.id ? 'bg-brand-subtle/10 text-brand font-medium' : 'text-ink-muted hover:bg-surface-2'}"
             >
               <span class="block text-sm truncate">{session.title}</span>
               {#if getSessionProjectName(session)}
-                <span class="block text-[10px] text-gray-400 truncate mt-0.5">{getSessionProjectName(session)}</span>
+                <span class="block text-[10px] text-ink-subtle truncate mt-0.5">{getSessionProjectName(session)}</span>
               {:else}
-                <span class="block text-[10px] text-gray-400 italic truncate mt-0.5">{$_('aiChat.orgLevel')}</span>
+                <span class="block text-[10px] text-ink-subtle italic truncate mt-0.5">{$_('aiChat.orgLevel')}</span>
               {/if}
             </button>
             <button
               on:click|stopPropagation={() => confirmDeleteSession(session.id)}
-              class="{currentSessionId === session.id ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'} mt-2 p-1.5 text-gray-400 hover:text-red-500 hover:bg-red-50 rounded-md transition-all duration-150 cursor-pointer flex-shrink-0"
+              class="{currentSessionId === session.id ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'} mt-2 p-1.5 text-ink-subtle hover:text-red-500 hover:bg-red-50 rounded-md transition-all duration-150 cursor-pointer flex-shrink-0"
               title={$_('aiChat.deleteChat.title')}
             >
               <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" /></svg>
@@ -287,30 +287,30 @@
 
   <!-- Chat area -->
   <div class="flex-1 flex flex-col">
-    <div class="px-6 py-4 border-b border-gray-200 flex-shrink-0 flex items-center justify-between">
+    <div class="px-6 py-4 border-b border-border flex-shrink-0 flex items-center justify-between">
       <div>
-        <h1 class="text-xl font-bold text-gray-900">{$_('aiChat.title')}</h1>
-        <div class="flex items-center gap-1.5 mt-0.5 text-xs text-gray-500">
+        <h1 class="text-xl font-bold text-ink">{$_('aiChat.title')}</h1>
+        <div class="flex items-center gap-1.5 mt-0.5 text-xs text-ink-muted">
           {#if currentOrg}
             <span class="inline-flex items-center gap-1">
-              <svg class="w-3 h-3 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21" /></svg>
-              <span class="font-medium text-gray-700">{currentOrg.name}</span>
+              <svg class="w-3 h-3 text-ink-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21" /></svg>
+              <span class="font-medium text-ink">{currentOrg.name}</span>
             </span>
           {/if}
           {#if $currentProjectStore}
-            <svg class="w-3 h-3 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" /></svg>
+            <svg class="w-3 h-3 text-ink-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" /></svg>
             <span class="inline-flex items-center gap-1">
               <svg class="w-3 h-3 text-primary-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" /></svg>
-              <span class="font-medium text-primary-600">{$currentProjectStore.name}</span>
+              <span class="font-medium text-brand">{$currentProjectStore.name}</span>
             </span>
           {:else if currentOrg}
-            <svg class="w-3 h-3 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" /></svg>
-            <span class="text-gray-400 italic">{$_('aiChat.noProject')}</span>
+            <svg class="w-3 h-3 text-ink-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" /></svg>
+            <span class="text-ink-subtle italic">{$_('aiChat.noProject')}</span>
           {/if}
         </div>
       </div>
       {#if messages.length > 0}
-        <button on:click={startNewChat} class="text-xs text-gray-400 hover:text-gray-600 transition-colors duration-150 cursor-pointer">{$_('aiChat.clearHistory')}</button>
+        <button on:click={startNewChat} class="text-xs text-ink-subtle hover:text-gray-600 transition-colors duration-150 cursor-pointer">{$_('aiChat.clearHistory')}</button>
       {/if}
     </div>
 
@@ -319,36 +319,36 @@
         <!-- Scope picker: choose org-level or project -->
         <div class="flex flex-col items-center justify-center h-full text-center py-12">
           <div class="w-16 h-16 bg-primary-100 rounded-2xl flex items-center justify-center mb-4">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456z" />
             </svg>
           </div>
-          <h2 class="text-xl font-semibold text-gray-900 mb-1">{$_('aiChat.newChat')}</h2>
-          <p class="text-gray-500 mb-6 max-w-sm text-sm">{$_('aiChat.scopePicker.subtitle')}</p>
+          <h2 class="text-xl font-semibold text-ink mb-1">{$_('aiChat.newChat')}</h2>
+          <p class="text-ink-muted mb-6 max-w-sm text-sm">{$_('aiChat.scopePicker.subtitle')}</p>
           <div class="flex flex-col gap-2 w-full max-w-sm">
             <!-- Organization-level option -->
             {#if currentOrg}
               <button on:click={() => selectScope(null)}
-                class="flex items-center gap-3 px-4 py-3 bg-white border border-gray-200 rounded-xl hover:border-primary-300 hover:bg-primary-50 transition-colors duration-150 text-left cursor-pointer group">
-                <div class="w-9 h-9 bg-gray-100 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:bg-primary-100">
-                  <svg class="w-5 h-5 text-gray-500 group-hover:text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21" /></svg>
+                class="flex items-center gap-3 px-4 py-3 bg-surface border border-border rounded-xl hover:border-primary-300 hover:bg-brand-subtle/10 transition-colors duration-150 text-left cursor-pointer group">
+                <div class="w-9 h-9 bg-surface-2 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:bg-primary-100">
+                  <svg class="w-5 h-5 text-ink-muted group-hover:text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21" /></svg>
                 </div>
                 <div>
-                  <p class="text-sm font-medium text-gray-900">{currentOrg.name}</p>
-                  <p class="text-xs text-gray-400">{$_('aiChat.scopePicker.orgHint')}</p>
+                  <p class="text-sm font-medium text-ink">{currentOrg.name}</p>
+                  <p class="text-xs text-ink-subtle">{$_('aiChat.scopePicker.orgHint')}</p>
                 </div>
               </button>
             {/if}
             <!-- Project options -->
             {#each $projectsStore as project}
               <button on:click={() => selectScope(project.id)}
-                class="flex items-center gap-3 px-4 py-3 bg-white border border-gray-200 rounded-xl hover:border-primary-300 hover:bg-primary-50 transition-colors duration-150 text-left cursor-pointer group">
-                <div class="w-9 h-9 bg-gray-100 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:bg-primary-100">
-                  <svg class="w-5 h-5 text-gray-500 group-hover:text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" /></svg>
+                class="flex items-center gap-3 px-4 py-3 bg-surface border border-border rounded-xl hover:border-primary-300 hover:bg-brand-subtle/10 transition-colors duration-150 text-left cursor-pointer group">
+                <div class="w-9 h-9 bg-surface-2 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:bg-primary-100">
+                  <svg class="w-5 h-5 text-ink-muted group-hover:text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" /></svg>
                 </div>
                 <div>
-                  <p class="text-sm font-medium text-gray-900">{project.name}</p>
-                  <p class="text-xs text-gray-400">{project.industry || $_('aiChat.scopePicker.projectHint')}</p>
+                  <p class="text-sm font-medium text-ink">{project.name}</p>
+                  <p class="text-xs text-ink-subtle">{project.industry || $_('aiChat.scopePicker.projectHint')}</p>
                 </div>
               </button>
             {/each}
@@ -357,24 +357,24 @@
       {:else if messages.length === 0}
         <div class="flex flex-col items-center justify-center h-full text-center py-12">
           <div class="w-16 h-16 bg-primary-100 rounded-2xl flex items-center justify-center mb-4">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456z" />
             </svg>
           </div>
-          <h2 class="text-xl font-semibold text-gray-900 mb-1">{$_('aiChat.title')}</h2>
+          <h2 class="text-xl font-semibold text-ink mb-1">{$_('aiChat.title')}</h2>
           {#if $currentProjectStore}
-            <p class="text-gray-500 mb-2 max-w-sm text-sm">{$_('aiChat.chatContext.project', { values: { name: $currentProjectStore.name } })}</p>
+            <p class="text-ink-muted mb-2 max-w-sm text-sm">{$_('aiChat.chatContext.project', { values: { name: $currentProjectStore.name } })}</p>
           {:else if currentOrg}
-            <p class="text-gray-500 mb-2 max-w-sm text-sm">{$_('aiChat.chatContext.orgOnly', { values: { org: currentOrg.name } })}</p>
+            <p class="text-ink-muted mb-2 max-w-sm text-sm">{$_('aiChat.chatContext.orgOnly', { values: { org: currentOrg.name } })}</p>
           {/if}
-          <p class="text-gray-500 mb-8 max-w-sm text-sm">{$_('aiChat.examples.title')}</p>
+          <p class="text-ink-muted mb-8 max-w-sm text-sm">{$_('aiChat.examples.title')}</p>
           <div class="flex flex-col gap-2 w-full max-w-md">
             {#if $currentProjectStore}
-              <p class="text-xs text-gray-400 mb-1 text-left">{$_('aiChat.contextualHint', { values: { name: $currentProjectStore.name } })}</p>
+              <p class="text-xs text-ink-subtle mb-1 text-left">{$_('aiChat.contextualHint', { values: { name: $currentProjectStore.name } })}</p>
             {/if}
             {#each examples as ex}
               <button on:click={() => { input = ex; send(); }}
-                class="text-sm px-4 py-2.5 bg-white border border-gray-200 text-gray-700 rounded-xl hover:border-primary-300 hover:bg-primary-50 hover:text-primary-700 transition-colors duration-150 text-left cursor-pointer">
+                class="text-sm px-4 py-2.5 bg-surface border border-border text-ink rounded-xl hover:border-primary-300 hover:bg-brand-subtle/10 hover:text-primary-700 transition-colors duration-150 text-left cursor-pointer">
                 {ex}
               </button>
             {/each}
@@ -385,15 +385,15 @@
           <div class="group flex {msg.role === 'user' ? 'justify-end' : 'justify-start'} gap-3">
             {#if msg.role === 'assistant'}
               <div class="w-8 h-8 bg-primary-100 rounded-full flex items-center justify-center flex-shrink-0 mt-1">
-                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
                 </svg>
               </div>
             {/if}
             <div class="max-w-2xl">
-              <div class="{msg.role === 'user' ? 'bg-primary-600 text-white rounded-2xl rounded-tr-sm' : 'bg-white border border-gray-200 text-gray-800 rounded-2xl rounded-tl-sm'} px-4 py-3 shadow-sm">
+              <div class="{msg.role === 'user' ? 'bg-brand text-white rounded-2xl rounded-tr-sm' : 'bg-surface border border-border text-ink rounded-2xl rounded-tl-sm'} px-4 py-3 shadow-sm">
                 {#if msg.role === 'assistant'}
-                  <div class="text-sm leading-relaxed prose prose-sm prose-primary max-w-none prose-p:my-1 prose-headings:my-2 prose-ul:my-1 prose-ol:my-1 prose-pre:my-2 prose-code:text-primary-700 prose-code:bg-primary-50 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:before:content-[''] prose-code:after:content-['']">
+                  <div class="text-sm leading-relaxed prose prose-sm prose-primary max-w-none prose-p:my-1 prose-headings:my-2 prose-ul:my-1 prose-ol:my-1 prose-pre:my-2 prose-code:text-primary-700 prose-code:bg-brand-subtle/10 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:before:content-[''] prose-code:after:content-['']">
                     {@html renderMarkdown(msg.content)}
                   </div>
                 {:else}
@@ -401,10 +401,10 @@
                 {/if}
               </div>
               <div class="flex items-center gap-1.5 mt-1 {msg.role === 'user' ? 'justify-end' : ''}">
-                <p class="text-xs text-gray-400">{msg.time}</p>
+                <p class="text-xs text-ink-subtle">{msg.time}</p>
                 <button
                   on:click={() => deleteMessage(msg, i)}
-                  class="hidden group-hover:inline-flex items-center gap-1 px-1.5 py-0.5 text-xs text-gray-400 hover:text-red-500 hover:bg-red-50 rounded transition-all duration-150 cursor-pointer"
+                  class="hidden group-hover:inline-flex items-center gap-1 px-1.5 py-0.5 text-xs text-ink-subtle hover:text-red-500 hover:bg-red-50 rounded transition-all duration-150 cursor-pointer"
                   title={$_('aiChat.deleteMessage')}
                 >
                   <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" /></svg>
@@ -416,11 +416,11 @@
         {#if loading}
           <div class="flex justify-start gap-3">
             <div class="w-8 h-8 bg-primary-100 rounded-full flex items-center justify-center flex-shrink-0">
-              <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09z" />
               </svg>
             </div>
-            <div class="bg-white border border-gray-200 rounded-2xl rounded-tl-sm px-4 py-3 shadow-sm">
+            <div class="bg-surface border border-border rounded-2xl rounded-tl-sm px-4 py-3 shadow-sm">
               <div class="flex gap-1 items-center h-5">
                 <div class="w-2 h-2 bg-primary-300 rounded-full animate-bounce" style="animation-delay:0ms"></div>
                 <div class="w-2 h-2 bg-primary-300 rounded-full animate-bounce" style="animation-delay:150ms"></div>
@@ -432,20 +432,20 @@
       {/if}
     </div>
 
-    <div class="p-4 border-t border-gray-200 flex-shrink-0 bg-white">
+    <div class="p-4 border-t border-border flex-shrink-0 bg-surface">
       <div class="flex gap-3 items-end max-w-4xl mx-auto">
         <textarea
           bind:value={input}
           on:keydown={onKeydown}
           placeholder={$_('aiChat.placeholder')}
           rows="2"
-          class="flex-1 px-4 py-3 border border-gray-300 rounded-xl focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none text-sm"
+          class="flex-1 px-4 py-3 border border-border rounded-xl focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none text-sm"
         ></textarea>
         <button
           on:click={send}
           disabled={loading || !input.trim()}
           aria-label={$_('aiChat.send')}
-          class="bg-primary-600 text-white p-3 rounded-xl hover:bg-primary-700 transition-colors duration-150 disabled:opacity-40 disabled:cursor-not-allowed flex-shrink-0 cursor-pointer"
+          class="bg-brand text-white p-3 rounded-xl hover:brightness-110 transition-colors duration-150 disabled:opacity-40 disabled:cursor-not-allowed flex-shrink-0 cursor-pointer"
         >
           <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
@@ -459,19 +459,19 @@
 <!-- Delete session confirmation modal -->
 {#if deletingSessionId}
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40" on:click|self={() => deletingSessionId = null} on:keydown={(e) => e.key === 'Escape' && (deletingSessionId = null)} role="dialog" tabindex="-1">
-    <div class="bg-white rounded-2xl shadow-xl p-6 max-w-sm w-full mx-4">
+    <div class="bg-surface rounded-2xl shadow-xl p-6 max-w-sm w-full mx-4">
       <div class="flex items-center gap-3 mb-4">
         <div class="w-10 h-10 bg-red-100 rounded-full flex items-center justify-center flex-shrink-0">
           <svg class="w-5 h-5 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" /></svg>
         </div>
         <div>
-          <h3 class="text-base font-semibold text-gray-900">{$_('aiChat.deleteChat.title')}</h3>
-          <p class="text-sm text-gray-500 mt-0.5">{$_('aiChat.deleteChat.message')}</p>
+          <h3 class="text-base font-semibold text-ink">{$_('aiChat.deleteChat.title')}</h3>
+          <p class="text-sm text-ink-muted mt-0.5">{$_('aiChat.deleteChat.message')}</p>
         </div>
       </div>
       <div class="flex justify-end gap-2">
         <button on:click={() => deletingSessionId = null}
-          class="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors cursor-pointer">
+          class="px-4 py-2 text-sm font-medium text-ink bg-surface-2 rounded-lg hover:bg-gray-200 transition-colors cursor-pointer">
           {$_('aiChat.deleteChat.cancel')}
         </button>
         <button on:click={deleteSession}

--- a/apps/web/src/routes/(app)/analytics/+page.svelte
+++ b/apps/web/src/routes/(app)/analytics/+page.svelte
@@ -45,23 +45,23 @@
   {:else if hasProject && projectId}
     <!-- Non-mobile project: link to project analytics -->
     <div class="flex items-center justify-between mb-6">
-      <h1 class="text-2xl font-bold text-gray-900">{$_('nav.orgAnalytics')}</h1>
+      <h1 class="text-2xl font-bold text-ink">{$_('nav.orgAnalytics')}</h1>
     </div>
     <div class="text-center py-12">
-      <a href="/projects/{projectId}/analytics" class="px-5 py-2.5 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors">
+      <a href="/projects/{projectId}/analytics" class="px-5 py-2.5 bg-brand text-white rounded-lg text-sm font-medium hover:brightness-110 transition-colors">
         {$_('nav.orgAnalytics')} → {$currentProjectStore?.name}
       </a>
     </div>
   {:else}
     <!-- Org-level analytics -->
-    <div class="flex items-center gap-1.5 text-sm text-gray-500 mb-1">
+    <div class="flex items-center gap-1.5 text-sm text-ink-muted mb-1">
       <span>{currentOrg?.name || $_('header.orgContext')}</span>
-      <span class="text-gray-300">›</span>
-      <span class="text-gray-700">{$_('nav.orgAnalytics')}</span>
+      <span class="text-ink-subtle">›</span>
+      <span class="text-ink">{$_('nav.orgAnalytics')}</span>
     </div>
 
     <div class="flex items-center justify-between mb-6">
-      <h1 class="text-2xl font-bold text-gray-900">{$_('nav.orgAnalytics')}</h1>
+      <h1 class="text-2xl font-bold text-ink">{$_('nav.orgAnalytics')}</h1>
     </div>
 
     {#if loading}
@@ -69,17 +69,17 @@
         <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500"></div>
       </div>
     {:else if items.length === 0}
-      <div class="text-center py-12 text-gray-500">
+      <div class="text-center py-12 text-ink-muted">
         <p>{$_('common.noData')}</p>
       </div>
     {:else}
       <div class="space-y-3">
         {#each items as item}
-          <a href="/projects/{item.projectId}/analytics" class="block bg-white rounded-lg border border-gray-200 p-4 hover:border-indigo-300 hover:shadow-sm transition-all cursor-pointer">
+          <a href="/projects/{item.projectId}/analytics" class="block bg-surface rounded-lg border border-border p-4 hover:border-indigo-300 hover:shadow-sm transition-all cursor-pointer">
             <div class="flex items-center justify-between">
               <div>
-                <h3 class="font-medium text-gray-900">{item.name || item.title || 'Analytics'}</h3>
-                <p class="text-sm text-gray-500">{item.type || ''}</p>
+                <h3 class="font-medium text-ink">{item.name || item.title || 'Analytics'}</h3>
+                <p class="text-sm text-ink-muted">{item.type || ''}</p>
               </div>
             </div>
           </a>

--- a/apps/web/src/routes/(app)/calendar/+page.svelte
+++ b/apps/web/src/routes/(app)/calendar/+page.svelte
@@ -30,7 +30,7 @@
   const CONTENT_TYPES = ['SOCIAL_POST', 'BLOG_ARTICLE', 'EMAIL', 'NEWSLETTER', 'AD_COPY', 'LANDING_PAGE'];
 
   const statusBadge: Record<string, string> = {
-    DRAFT: 'bg-gray-100 text-gray-600',
+    DRAFT: 'bg-surface-2 text-ink-muted',
     REVIEW: 'bg-yellow-100 text-yellow-700',
     APPROVED: 'bg-green-100 text-green-700',
     PUBLISHED: 'bg-blue-100 text-blue-700',
@@ -211,33 +211,33 @@
 </script>
 
 <div class="p-4 sm:p-6 h-full flex flex-col min-h-0">
-  <div class="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 mb-1">
+  <div class="flex items-center gap-1.5 text-sm text-ink-muted mb-1">
     <span>{currentOrg?.name || $_('header.orgContext')}</span>
     {#if $currentProjectStore}
-      <span class="text-gray-300">›</span>
+      <span class="text-ink-subtle">›</span>
       <span class="text-indigo-600 dark:text-indigo-400">{$currentProjectStore.name}</span>
     {/if}
-    <span class="text-gray-300">›</span>
-    <span class="text-gray-700 dark:text-gray-200">{$_('nav.orgCalendar')}</span>
+    <span class="text-ink-subtle">›</span>
+    <span class="text-ink">{$_('nav.orgCalendar')}</span>
   </div>
 
   <div class="flex items-center justify-between mb-5">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{$_('nav.orgCalendar')}</h1>
+    <h1 class="text-2xl font-bold text-ink">{$_('nav.orgCalendar')}</h1>
     <div class="flex items-center gap-2">
-      <div class="hidden md:flex items-center border border-gray-300 rounded-lg overflow-hidden">
+      <div class="hidden md:flex items-center border border-border rounded-lg overflow-hidden">
         <button on:click={() => viewMode = 'month'}
           class="text-xs px-3 py-1.5 transition-colors duration-150 cursor-pointer
-            {viewMode === 'month' ? 'bg-primary-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}">
+            {viewMode === 'month' ? 'bg-brand text-white' : 'bg-surface text-ink-muted hover:bg-surface-2'}">
           {$_('calendar.monthView')}
         </button>
         <button on:click={() => { viewMode = 'week'; currentWeekStart = getWeekStart(new Date(currentYear, currentMonth, 1)); }}
           class="text-xs px-3 py-1.5 transition-colors duration-150 cursor-pointer
-            {viewMode === 'week' ? 'bg-primary-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}">
+            {viewMode === 'week' ? 'bg-brand text-white' : 'bg-surface text-ink-muted hover:bg-surface-2'}">
           {$_('calendar.weekView')}
         </button>
       </div>
       <button on:click={goToToday}
-        class="text-xs px-3 py-1.5 border border-gray-300 rounded-lg bg-white hover:bg-gray-50 transition-colors duration-150 cursor-pointer font-medium text-gray-700">
+        class="text-xs px-3 py-1.5 border border-border rounded-lg bg-surface hover:bg-surface-2 transition-colors duration-150 cursor-pointer font-medium text-ink">
         {$_('calendar.today')}
       </button>
     </div>
@@ -246,17 +246,17 @@
   <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 mb-4">
     <div class="flex items-center gap-2">
       <button on:click={() => viewMode === 'week' ? prevWeek() : prevMonth()}
-        class="p-1.5 rounded-lg border border-gray-300 hover:bg-gray-50 transition-colors duration-150 cursor-pointer">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        class="p-1.5 rounded-lg border border-border hover:bg-surface-2 transition-colors duration-150 cursor-pointer">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-ink-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
         </svg>
       </button>
-      <h2 class="text-lg font-semibold text-gray-900 min-w-[180px] text-center capitalize">
+      <h2 class="text-lg font-semibold text-ink min-w-[180px] text-center capitalize">
         {formatMonthYear(currentYear, currentMonth)}
       </h2>
       <button on:click={() => viewMode === 'week' ? nextWeek() : nextMonth()}
-        class="p-1.5 rounded-lg border border-gray-300 hover:bg-gray-50 transition-colors duration-150 cursor-pointer">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        class="p-1.5 rounded-lg border border-border hover:bg-surface-2 transition-colors duration-150 cursor-pointer">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-ink-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
         </svg>
       </button>
@@ -264,14 +264,14 @@
 
     <div class="flex items-center gap-2">
       <select bind:value={filterStatus}
-        class="text-xs px-2 py-1.5 border border-gray-300 rounded-lg bg-white cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-500">
+        class="text-xs px-2 py-1.5 border border-border rounded-lg bg-surface cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-500">
         <option value="">{$_('calendar.allStatuses')}</option>
         {#each STATUSES as s}
           <option value={s}>{$_(statusLabel[s])}</option>
         {/each}
       </select>
       <select bind:value={filterType}
-        class="text-xs px-2 py-1.5 border border-gray-300 rounded-lg bg-white cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-500">
+        class="text-xs px-2 py-1.5 border border-border rounded-lg bg-surface cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-500">
         <option value="">{$_('calendar.allTypes')}</option>
         {#each CONTENT_TYPES as t}
           <option value={t}>{$_(typeLabel[t])}</option>
@@ -281,18 +281,18 @@
   </div>
 
   {#if loading}
-    <div class="bg-white rounded-xl border border-gray-200 p-4 flex-1 min-h-0">
+    <div class="bg-surface rounded-xl border border-border p-4 flex-1 min-h-0">
       <div class="grid grid-cols-7 gap-px h-full">
         {#each Array(42) as _}
-          <div class="bg-gray-50 rounded animate-pulse"></div>
+          <div class="bg-surface-2 rounded animate-pulse"></div>
         {/each}
       </div>
     </div>
   {:else if viewMode === 'month'}
-    <div class="bg-white rounded-xl border border-gray-200 overflow-hidden flex-1 min-h-0 flex flex-col">
-      <div class="grid grid-cols-7 border-b border-gray-200 bg-gray-50/50 flex-shrink-0">
+    <div class="bg-surface rounded-xl border border-border overflow-hidden flex-1 min-h-0 flex flex-col">
+      <div class="grid grid-cols-7 border-b border-border bg-surface-2/50 flex-shrink-0">
         {#each ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as dayKey}
-          <div class="py-2.5 text-center text-xs font-medium text-gray-500 uppercase tracking-wide">
+          <div class="py-2.5 text-center text-xs font-medium text-ink-muted uppercase tracking-wide">
             {$_(`calendar.${dayKey}`)}
           </div>
         {/each}
@@ -307,16 +307,16 @@
           {@const dayContents = contentByDate[dateKey] || []}
           {@const todayHighlight = isToday(dayInfo.year, dayInfo.month, dayInfo.day)}
           <div
-            class="min-h-[100px] p-1.5 border-b border-r border-gray-100 flex flex-col overflow-hidden
+            class="min-h-[100px] p-1.5 border-b border-r border-border flex flex-col overflow-hidden
                    {dayInfo.isCurrentMonth ? '' : 'opacity-40'}"
           >
             <div class="flex items-start justify-between mb-1 flex-shrink-0">
               {#if todayHighlight}
-                <span class="bg-primary-600 text-white text-xs font-semibold w-6 h-6 rounded-full flex items-center justify-center">
+                <span class="bg-brand text-white text-xs font-semibold w-6 h-6 rounded-full flex items-center justify-center">
                   {dayInfo.day}
                 </span>
               {:else}
-                <span class="text-xs font-medium text-gray-700 w-6 h-6 flex items-center justify-center">
+                <span class="text-xs font-medium text-ink w-6 h-6 flex items-center justify-center">
                   {dayInfo.day}
                 </span>
               {/if}
@@ -328,7 +328,7 @@
                 <!-- svelte-ignore a11y-no-static-element-interactions -->
                 <div
                   class="flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] leading-tight truncate cursor-pointer hover:opacity-80 transition-opacity duration-100
-                         {statusBadge[content.status] || 'bg-gray-100 text-gray-600'}"
+                         {statusBadge[content.status] || 'bg-surface-2 text-ink-muted'}"
                   on:click|stopPropagation={() => selectedContent = content}
                   title={content.title}
                 >
@@ -349,35 +349,35 @@
         {@const dayContents = contentByDate[dateKey] || []}
         {@const todayHighlight = isSameDay(weekDay, today)}
 
-        <div class="bg-white rounded-xl border border-gray-200 {todayHighlight ? 'border-primary-300 ring-1 ring-primary-100' : ''} p-3">
+        <div class="bg-surface rounded-xl border border-border {todayHighlight ? 'border-primary-300 ring-1 ring-primary-100' : ''} p-3">
           <div class="flex items-center justify-between mb-2">
             <div class="flex items-center gap-2">
-              <span class="text-sm font-semibold {todayHighlight ? 'text-primary-600' : 'text-gray-900'}">
+              <span class="text-sm font-semibold {todayHighlight ? 'text-brand' : 'text-ink'}">
                 {weekDay.toLocaleDateString(undefined, { weekday: 'short', day: 'numeric', month: 'short' })}
               </span>
               {#if todayHighlight}
-                <span class="text-[10px] px-1.5 py-0.5 bg-primary-100 text-primary-700 rounded-full font-medium">{todayLabel}</span>
+                <span class="text-[10px] px-1.5 py-0.5 bg-primary-100 text-brand rounded-full font-medium">{todayLabel}</span>
               {/if}
             </div>
-            <span class="text-xs text-gray-400">{dayContents.length}</span>
+            <span class="text-xs text-ink-subtle">{dayContents.length}</span>
           </div>
 
           {#if dayContents.length === 0}
-            <div class="text-xs text-gray-400 py-2 text-center">—</div>
+            <div class="text-xs text-ink-subtle py-2 text-center">—</div>
           {:else}
             <div class="space-y-1.5">
               {#each dayContents as content (content.id)}
                 <!-- svelte-ignore a11y-click-events-have-key-events -->
                 <!-- svelte-ignore a11y-no-static-element-interactions -->
-                <div class="flex items-center gap-2 p-2 rounded-lg border border-gray-100 cursor-pointer hover:bg-gray-50 transition-colors duration-150"
+                <div class="flex items-center gap-2 p-2 rounded-lg border border-border cursor-pointer hover:bg-surface-2 transition-colors duration-150"
                   on:click={() => selectedContent = content}>
                   <span class="w-2 h-2 rounded-full flex-shrink-0 {statusDot[content.status]}"></span>
                   <div class="flex-1 min-w-0">
-                    <div class="text-sm font-medium text-gray-900 truncate">{content.title}</div>
-                    <div class="text-xs text-gray-500 flex items-center gap-1.5">
+                    <div class="text-sm font-medium text-ink truncate">{content.title}</div>
+                    <div class="text-xs text-ink-muted flex items-center gap-1.5">
                       <span>{content.type.replace('_', ' ')}</span>
                       {#if ctx.type === 'organization' && content.project?.name}
-                        <span class="text-gray-300">·</span>
+                        <span class="text-ink-subtle">·</span>
                         <span>{content.project.name}</span>
                       {/if}
                     </div>
@@ -396,13 +396,13 @@
 
   {#if !loading && contents.length === 0}
     <div class="flex flex-col items-center justify-center py-16 text-center">
-      <div class="w-20 h-20 bg-primary-50 rounded-2xl flex items-center justify-center mb-6">
+      <div class="w-20 h-20 bg-brand-subtle/10 rounded-2xl flex items-center justify-center mb-6">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
         </svg>
       </div>
-      <h2 class="text-xl font-semibold text-gray-900 mb-2">{$_('calendar.noContent')}</h2>
-      <p class="text-gray-500">{$_('calendar.noContentDesc')}</p>
+      <h2 class="text-xl font-semibold text-ink mb-2">{$_('calendar.noContent')}</h2>
+      <p class="text-ink-muted">{$_('calendar.noContentDesc')}</p>
     </div>
   {/if}
 </div>
@@ -411,19 +411,19 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex justify-end z-50" on:click|self={() => selectedContent = null}>
-    <div class="bg-white h-full w-full max-w-md shadow-2xl overflow-y-auto">
-      <div class="p-6 border-b border-gray-100 flex items-center justify-between">
-        <h2 class="text-lg font-semibold text-gray-900">{$_('calendar.contentDetails')}</h2>
+    <div class="bg-surface h-full w-full max-w-md shadow-2xl overflow-y-auto">
+      <div class="p-6 border-b border-border flex items-center justify-between">
+        <h2 class="text-lg font-semibold text-ink">{$_('calendar.contentDetails')}</h2>
         <button on:click={() => selectedContent = null}
-          class="p-1.5 rounded-lg hover:bg-gray-100 transition-colors duration-150 cursor-pointer">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          class="p-1.5 rounded-lg hover:bg-surface-2 transition-colors duration-150 cursor-pointer">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-ink-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
           </svg>
         </button>
       </div>
       <div class="p-6 space-y-5">
         <div class="flex flex-wrap items-center gap-1.5">
-          <span class="text-xs px-2 py-0.5 bg-gray-100 text-gray-600 rounded font-medium">
+          <span class="text-xs px-2 py-0.5 bg-surface-2 text-ink-muted rounded font-medium">
             {selectedContent.type.replace('_', ' ')}
           </span>
           {#if selectedContent.platforms?.length}
@@ -433,7 +433,7 @@
           {:else if selectedContent.platform}
             <span class="text-xs px-2 py-0.5 bg-blue-50 text-blue-600 rounded">{selectedContent.platform}</span>
           {/if}
-          <span class="text-xs px-2 py-0.5 rounded {statusBadge[selectedContent.status] || 'bg-gray-100 text-gray-600'}">
+          <span class="text-xs px-2 py-0.5 rounded {statusBadge[selectedContent.status] || 'bg-surface-2 text-ink-muted'}">
             {$_(statusLabel[selectedContent.status] || 'content.draft')}
           </span>
           {#if selectedContent.project?.name}
@@ -441,18 +441,18 @@
           {/if}
         </div>
 
-        <h3 class="text-xl font-semibold text-gray-900">{selectedContent.title}</h3>
+        <h3 class="text-xl font-semibold text-ink">{selectedContent.title}</h3>
 
-        <div class="text-sm text-gray-600 leading-relaxed whitespace-pre-wrap line-clamp-[10]">
+        <div class="text-sm text-ink-muted leading-relaxed whitespace-pre-wrap line-clamp-[10]">
           {selectedContent.body}
         </div>
 
-        <div class="border-t border-gray-100 pt-4 space-y-2">
+        <div class="border-t border-border pt-4 space-y-2">
           {#if selectedContent.publishedAt}
             <div class="flex items-center gap-2 text-sm">
               <span class="w-2 h-2 rounded-full bg-blue-500"></span>
-              <span class="text-gray-500">{$_('calendar.publishedOn') || 'Published'}:</span>
-              <span class="font-medium text-gray-700">
+              <span class="text-ink-muted">{$_('calendar.publishedOn') || 'Published'}:</span>
+              <span class="font-medium text-ink">
                 {new Date(selectedContent.publishedAt).toLocaleDateString(undefined, { day: 'numeric', month: 'long', year: 'numeric' })}
               </span>
             </div>
@@ -460,26 +460,26 @@
           {#if selectedContent.scheduledAt}
             <div class="flex items-center gap-2 text-sm">
               <span class="w-2 h-2 rounded-full bg-green-500"></span>
-              <span class="text-gray-500">{$_('calendar.scheduledFor', { values: { date: new Date(selectedContent.scheduledAt).toLocaleDateString(undefined, { day: 'numeric', month: 'long', year: 'numeric' }) } })}</span>
+              <span class="text-ink-muted">{$_('calendar.scheduledFor', { values: { date: new Date(selectedContent.scheduledAt).toLocaleDateString(undefined, { day: 'numeric', month: 'long', year: 'numeric' }) } })}</span>
             </div>
           {/if}
           <div class="flex items-center gap-2 text-sm">
             <span class="w-2 h-2 rounded-full bg-gray-400"></span>
-            <span class="text-gray-500">
+            <span class="text-ink-muted">
               {$_('calendar.createdOn', { values: { date: new Date(selectedContent.createdAt).toLocaleDateString(undefined, { day: 'numeric', month: 'long', year: 'numeric' }) } })}
             </span>
           </div>
         </div>
 
-        <div class="border-t border-gray-100 pt-4 flex gap-2">
+        <div class="border-t border-border pt-4 flex gap-2">
           {#if selectedContent.projectId}
             <a href="/projects/{selectedContent.projectId}/content"
-              class="flex-1 text-center bg-primary-600 text-white py-2.5 rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150">
+              class="flex-1 text-center bg-brand text-white py-2.5 rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150">
               {$_('calendar.viewDetails')}
             </a>
           {/if}
           <button on:click={() => selectedContent = null}
-            class="px-5 py-2.5 border border-gray-300 rounded-lg text-sm hover:bg-gray-50 transition-colors duration-150 cursor-pointer">
+            class="px-5 py-2.5 border border-border rounded-lg text-sm hover:bg-surface-2 transition-colors duration-150 cursor-pointer">
             {$_('common.close')}
           </button>
         </div>

--- a/apps/web/src/routes/(app)/campaigns/+page.svelte
+++ b/apps/web/src/routes/(app)/campaigns/+page.svelte
@@ -33,24 +33,24 @@
 </script>
 
 <div class="p-4 sm:p-6">
-  <div class="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 mb-1">
+  <div class="flex items-center gap-1.5 text-sm text-ink-muted mb-1">
     <span>{currentOrg?.name || $_('header.orgContext')}</span>
     {#if $currentProjectStore}
-      <span class="text-gray-300">›</span>
+      <span class="text-ink-subtle">›</span>
       <span class="text-indigo-600 dark:text-indigo-400">{$currentProjectStore.name}</span>
     {/if}
-    <span class="text-gray-300">›</span>
-    <span class="text-gray-700 dark:text-gray-200">{$_('nav.orgCampaigns')}</span>
+    <span class="text-ink-subtle">›</span>
+    <span class="text-ink">{$_('nav.orgCampaigns')}</span>
   </div>
 
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{$_('nav.orgCampaigns')}</h1>
+    <h1 class="text-2xl font-bold text-ink">{$_('nav.orgCampaigns')}</h1>
     {#if $currentProjectStore}
       <a href="/projects/{$currentProjectStore.id}/campaigns" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors">
         + {$_('common.create')}
       </a>
     {:else}
-      <button disabled class="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-400 text-sm font-medium rounded-lg cursor-not-allowed" title={$_('common.selectProjectToCreate')}>
+      <button disabled class="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-ink-subtle text-sm font-medium rounded-lg cursor-not-allowed" title={$_('common.selectProjectToCreate')}>
         + {$_('common.create')}
       </button>
     {/if}
@@ -61,17 +61,17 @@
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500"></div>
     </div>
   {:else if items.length === 0}
-    <div class="text-center py-12 text-gray-500 dark:text-gray-400">
+    <div class="text-center py-12 text-ink-muted">
       <p>{$_('common.noData')}</p>
     </div>
   {:else}
     <div class="space-y-3">
       {#each items as item}
-        <a href="/campaigns/{item.id}" class="block bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
+        <a href="/campaigns/{item.id}" class="block bg-surface rounded-lg border border-border p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
           <div class="flex items-center justify-between">
             <div>
-              <h3 class="font-medium text-gray-900 dark:text-white">{item.name}</h3>
-              <p class="text-sm text-gray-500 dark:text-gray-400">{item.type || ''}{item.status ? ' · ' + item.status : ''}</p>
+              <h3 class="font-medium text-ink">{item.name}</h3>
+              <p class="text-sm text-ink-muted">{item.type || ''}{item.status ? ' · ' + item.status : ''}</p>
             </div>
             {#if ctx.type === 'organization'}
               <span class="text-xs px-2 py-1 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">

--- a/apps/web/src/routes/(app)/checklists/+page.svelte
+++ b/apps/web/src/routes/(app)/checklists/+page.svelte
@@ -225,24 +225,24 @@
 </script>
 
 <div class="p-4 sm:p-6">
-  <div class="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 mb-1">
+  <div class="flex items-center gap-1.5 text-sm text-ink-muted mb-1">
     <span>{currentOrg?.name || $_('header.orgContext')}</span>
     {#if $currentProjectStore}
-      <span class="text-gray-300">›</span>
+      <span class="text-ink-subtle">›</span>
       <span class="text-indigo-600 dark:text-indigo-400">{$currentProjectStore.name}</span>
     {/if}
-    <span class="text-gray-300">›</span>
-    <span class="text-gray-700 dark:text-gray-200">{$_('nav.orgChecklists')}</span>
+    <span class="text-ink-subtle">›</span>
+    <span class="text-ink">{$_('nav.orgChecklists')}</span>
   </div>
 
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{$_('nav.orgChecklists')}</h1>
+    <h1 class="text-2xl font-bold text-ink">{$_('nav.orgChecklists')}</h1>
     <div class="flex items-center gap-2">
-      <button on:click={openImportModal} class="inline-flex items-center gap-2 px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 text-sm font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors cursor-pointer">
+      <button on:click={openImportModal} class="inline-flex items-center gap-2 px-3 py-2 bg-surface border border-border text-ink text-sm font-medium rounded-lg hover:bg-surface-2 transition-colors cursor-pointer">
         <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" /></svg>
         {$_('checklists.importFromMD')}
       </button>
-      <button on:click={openAIModal} class="inline-flex items-center gap-2 px-3 py-2 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 text-sm font-medium rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 transition-colors cursor-pointer">
+      <button on:click={openAIModal} class="inline-flex items-center gap-2 px-3 py-2 bg-surface border border-border text-ink text-sm font-medium rounded-lg hover:bg-surface-2 transition-colors cursor-pointer">
         <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" /></svg>
         {$_('checklists.generateWithAI')}
       </button>
@@ -257,7 +257,7 @@
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500"></div>
     </div>
   {:else if items.length === 0}
-    <div class="text-center py-12 text-gray-500 dark:text-gray-400">
+    <div class="text-center py-12 text-ink-muted">
       <p>{$_('checklists.empty')}</p>
       <p class="text-sm mt-1">{$_('checklists.emptyDesc')}</p>
     </div>
@@ -268,11 +268,11 @@
         <!-- svelte-ignore a11y-no-static-element-interactions -->
         <div
           on:click={() => { if (item.projectId) goto(`/projects/${item.projectId}/checklists`); }}
-          class="block bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
+          class="block bg-surface rounded-lg border border-border p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
           <div class="flex items-center justify-between">
             <div class="min-w-0 flex-1">
-              <h3 class="font-medium text-gray-900 dark:text-white">{item.name}</h3>
-              <p class="text-sm text-gray-500 dark:text-gray-400 truncate">
+              <h3 class="font-medium text-ink">{item.name}</h3>
+              <p class="text-sm text-ink-muted truncate">
                 {$_(checklistTypes.find(t => t.value === item.type)?.labelKey || 'checklists.custom')}
                 {item.description ? ' · ' + item.description.substring(0, 60) : ''}
               </p>
@@ -282,10 +282,10 @@
                 {@const total = item._count?.items || item.items?.length || 0}
                 {@const done = item.items?.filter((i) => i.isCompleted).length || 0}
                 <div class="flex items-center gap-1.5">
-                  <div class="w-16 h-1.5 bg-gray-200 dark:bg-gray-600 rounded-full overflow-hidden">
+                  <div class="w-16 h-1.5 bg-gray-200 rounded-full overflow-hidden">
                     <div class="h-full bg-green-500 rounded-full" style="width: {total > 0 ? Math.round(done / total * 100) : 0}%"></div>
                   </div>
-                  <span class="text-xs text-gray-400 whitespace-nowrap">{done}/{total}</span>
+                  <span class="text-xs text-ink-subtle whitespace-nowrap">{done}/{total}</span>
                 </div>
               {/if}
               <span class="text-xs px-2 py-1 rounded-full whitespace-nowrap {item.scope === 'ORGANIZATION' ? 'bg-purple-100 text-purple-700 dark:bg-purple-900/30 dark:text-purple-300' : 'bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300'}">
@@ -304,31 +304,31 @@
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showCreateModal = false}>
-  <div class="bg-white dark:bg-gray-800 rounded-xl w-full max-w-md p-6 shadow-xl">
-    <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">{$_('checklists.createManual')}</h3>
+  <div class="bg-surface rounded-xl w-full max-w-md p-6 shadow-xl">
+    <h3 class="text-lg font-semibold text-ink mb-4">{$_('checklists.createManual')}</h3>
     <div class="mb-4">
-      <label class="block text-sm text-gray-500 dark:text-gray-400 mb-1">{$_('checklists.scope')}</label>
-      <select bind:value={createForm.projectId} class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-gray-900 dark:text-white">
+      <label class="block text-sm text-ink-muted mb-1">{$_('checklists.scope')}</label>
+      <select bind:value={createForm.projectId} class="w-full bg-surface-2 border border-border rounded-lg px-3 py-2 text-ink">
         <option value="">{currentOrg?.name || $_('header.orgContext')}</option>
         {#each projects as proj}<option value={proj.id}>{proj.name}</option>{/each}
       </select>
     </div>
     <div class="mb-4">
-      <label class="block text-sm text-gray-500 dark:text-gray-400 mb-1">{$_('checklists.name')}</label>
-      <input type="text" bind:value={createForm.name} class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-gray-900 dark:text-white" />
+      <label class="block text-sm text-ink-muted mb-1">{$_('checklists.name')}</label>
+      <input type="text" bind:value={createForm.name} class="w-full bg-surface-2 border border-border rounded-lg px-3 py-2 text-ink" />
     </div>
     <div class="mb-4">
-      <label class="block text-sm text-gray-500 dark:text-gray-400 mb-1">{$_('checklists.type')}</label>
-      <select bind:value={createForm.type} class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-gray-900 dark:text-white">
+      <label class="block text-sm text-ink-muted mb-1">{$_('checklists.type')}</label>
+      <select bind:value={createForm.type} class="w-full bg-surface-2 border border-border rounded-lg px-3 py-2 text-ink">
         {#each checklistTypes as t}<option value={t.value}>{$_(t.labelKey)}</option>{/each}
       </select>
     </div>
     <div class="mb-4">
-      <label class="block text-sm text-gray-500 dark:text-gray-400 mb-1">{$_('checklists.description')}</label>
-      <textarea bind:value={createForm.description} rows="2" class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-gray-900 dark:text-white"></textarea>
+      <label class="block text-sm text-ink-muted mb-1">{$_('checklists.description')}</label>
+      <textarea bind:value={createForm.description} rows="2" class="w-full bg-surface-2 border border-border rounded-lg px-3 py-2 text-ink"></textarea>
     </div>
     <div class="flex gap-3 justify-end">
-      <button on:click={() => showCreateModal = false} class="px-4 py-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-white cursor-pointer">{$_('common.cancel')}</button>
+      <button on:click={() => showCreateModal = false} class="px-4 py-2 text-ink-muted hover:text-gray-700 cursor-pointer">{$_('common.cancel')}</button>
       <button on:click={createChecklist} disabled={creating || !createForm.name.trim()} class="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 cursor-pointer">
         {creating ? $_('common.loading') : $_('common.create')}
       </button>
@@ -342,12 +342,12 @@
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => { if (!aiGenerating) showAIModal = false; }}>
-  <div class="bg-white dark:bg-gray-800 rounded-xl w-full max-w-md p-6 shadow-xl">
-    <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">{$_('checklists.generateWithAI')}</h3>
+  <div class="bg-surface rounded-xl w-full max-w-md p-6 shadow-xl">
+    <h3 class="text-lg font-semibold text-ink mb-4">{$_('checklists.generateWithAI')}</h3>
 
     <div class="mb-4">
-      <label class="block text-sm text-gray-500 dark:text-gray-400 mb-1">{$_('checklists.scope')}</label>
-      <select bind:value={aiForm.projectId} disabled={aiGenerating} class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-gray-900 dark:text-white disabled:opacity-50">
+      <label class="block text-sm text-ink-muted mb-1">{$_('checklists.scope')}</label>
+      <select bind:value={aiForm.projectId} disabled={aiGenerating} class="w-full bg-surface-2 border border-border rounded-lg px-3 py-2 text-ink disabled:opacity-50">
         {#each projects as proj}<option value={proj.id}>{proj.name}</option>{/each}
       </select>
       {#if projects.length === 0}
@@ -356,8 +356,8 @@
     </div>
 
     <div class="mb-4">
-      <label class="block text-sm text-gray-500 dark:text-gray-400 mb-1">{$_('checklists.type')}</label>
-      <select bind:value={aiForm.type} disabled={aiGenerating} class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-gray-900 dark:text-white disabled:opacity-50">
+      <label class="block text-sm text-ink-muted mb-1">{$_('checklists.type')}</label>
+      <select bind:value={aiForm.type} disabled={aiGenerating} class="w-full bg-surface-2 border border-border rounded-lg px-3 py-2 text-ink disabled:opacity-50">
         {#each checklistTypes as t}<option value={t.value}>{$_(t.labelKey)}</option>{/each}
       </select>
     </div>
@@ -376,7 +376,7 @@
     {/if}
 
     <div class="flex gap-3 justify-end">
-      <button on:click={() => showAIModal = false} disabled={aiGenerating} class="px-4 py-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-white cursor-pointer disabled:opacity-50">{$_('common.cancel')}</button>
+      <button on:click={() => showAIModal = false} disabled={aiGenerating} class="px-4 py-2 text-ink-muted hover:text-gray-700 cursor-pointer disabled:opacity-50">{$_('common.cancel')}</button>
       <button on:click={generateWithAI} disabled={aiGenerating || !aiForm.projectId} class="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 cursor-pointer">
         {aiGenerating ? $_('common.loading') : $_('checklists.generateWithAI')}
       </button>
@@ -390,20 +390,20 @@
 <!-- svelte-ignore a11y-click-events-have-key-events -->
 <!-- svelte-ignore a11y-no-static-element-interactions -->
 <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showImportModal = false}>
-  <div class="bg-white dark:bg-gray-800 rounded-xl w-full max-w-md p-6 shadow-xl">
-    <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-2">{$_('checklists.importTitle')}</h3>
-    <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">{$_('checklists.importDesc')}</p>
+  <div class="bg-surface rounded-xl w-full max-w-md p-6 shadow-xl">
+    <h3 class="text-lg font-semibold text-ink mb-2">{$_('checklists.importTitle')}</h3>
+    <p class="text-sm text-ink-muted mb-4">{$_('checklists.importDesc')}</p>
 
     <div class="mb-4">
-      <label class="block text-sm text-gray-500 dark:text-gray-400 mb-1">{$_('checklists.scope')}</label>
-      <select bind:value={importProjectId} class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-gray-900 dark:text-white">
+      <label class="block text-sm text-ink-muted mb-1">{$_('checklists.scope')}</label>
+      <select bind:value={importProjectId} class="w-full bg-surface-2 border border-border rounded-lg px-3 py-2 text-ink">
         <option value="">{currentOrg?.name || $_('header.orgContext')}</option>
         {#each projects as proj}<option value={proj.id}>{proj.name}</option>{/each}
       </select>
     </div>
 
     <div class="mb-4">
-      <input type="file" accept=".md" on:change={handleFileUpload} class="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100 dark:file:bg-indigo-900/30 dark:file:text-indigo-300 cursor-pointer" />
+      <input type="file" accept=".md" on:change={handleFileUpload} class="block w-full text-sm text-ink-muted file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100 dark:file:bg-indigo-900/30 dark:file:text-indigo-300 cursor-pointer" />
     </div>
 
     {#if importError}
@@ -411,14 +411,14 @@
     {/if}
 
     {#if importParsed}
-      <div class="mb-4 p-3 rounded-lg bg-gray-50 dark:bg-gray-700/50 text-sm">
-        <div class="font-medium text-gray-900 dark:text-white">{importParsed.name}</div>
-        <div class="text-gray-500 dark:text-gray-400 mt-1">{$_('checklists.importItems', { values: { count: importParsed.items.length } })}</div>
+      <div class="mb-4 p-3 rounded-lg bg-surface-2 text-sm">
+        <div class="font-medium text-ink">{importParsed.name}</div>
+        <div class="text-ink-muted mt-1">{$_('checklists.importItems', { values: { count: importParsed.items.length } })}</div>
       </div>
     {/if}
 
     <div class="flex gap-3 justify-end">
-      <button on:click={() => showImportModal = false} class="px-4 py-2 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-white cursor-pointer">{$_('common.cancel')}</button>
+      <button on:click={() => showImportModal = false} class="px-4 py-2 text-ink-muted hover:text-gray-700 cursor-pointer">{$_('common.cancel')}</button>
       <button on:click={importChecklist} disabled={importing || !importParsed} class="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 cursor-pointer">
         {importing ? $_('common.loading') : $_('checklists.importConfirm')}
       </button>

--- a/apps/web/src/routes/(app)/competitors/+page.svelte
+++ b/apps/web/src/routes/(app)/competitors/+page.svelte
@@ -33,24 +33,24 @@
 </script>
 
 <div class="p-4 sm:p-6">
-  <div class="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 mb-1">
+  <div class="flex items-center gap-1.5 text-sm text-ink-muted mb-1">
     <span>{currentOrg?.name || $_('header.orgContext')}</span>
     {#if $currentProjectStore}
-      <span class="text-gray-300">›</span>
+      <span class="text-ink-subtle">›</span>
       <span class="text-indigo-600 dark:text-indigo-400">{$currentProjectStore.name}</span>
     {/if}
-    <span class="text-gray-300">›</span>
-    <span class="text-gray-700 dark:text-gray-200">{$_('nav.orgCompetitors')}</span>
+    <span class="text-ink-subtle">›</span>
+    <span class="text-ink">{$_('nav.orgCompetitors')}</span>
   </div>
 
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{$_('nav.orgCompetitors')}</h1>
+    <h1 class="text-2xl font-bold text-ink">{$_('nav.orgCompetitors')}</h1>
     {#if $currentProjectStore}
       <a href="/projects/{$currentProjectStore.id}/competitors" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors">
         + {$_('common.create')}
       </a>
     {:else}
-      <button disabled class="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-400 text-sm font-medium rounded-lg cursor-not-allowed" title={$_('common.selectProjectToCreate')}>
+      <button disabled class="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-ink-subtle text-sm font-medium rounded-lg cursor-not-allowed" title={$_('common.selectProjectToCreate')}>
         + {$_('common.create')}
       </button>
     {/if}
@@ -61,17 +61,17 @@
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500"></div>
     </div>
   {:else if items.length === 0}
-    <div class="text-center py-12 text-gray-500 dark:text-gray-400">
+    <div class="text-center py-12 text-ink-muted">
       <p>{$_('common.noData')}</p>
     </div>
   {:else}
     <div class="space-y-3">
       {#each items as item}
-        <a href="/projects/{item.projectId}/competitors" class="block bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
+        <a href="/projects/{item.projectId}/competitors" class="block bg-surface rounded-lg border border-border p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
           <div class="flex items-center justify-between">
             <div>
-              <h3 class="font-medium text-gray-900 dark:text-white">{item.name || item.title || 'Competitor'}</h3>
-              <p class="text-sm text-gray-500 dark:text-gray-400">{item.type || ''}</p>
+              <h3 class="font-medium text-ink">{item.name || item.title || 'Competitor'}</h3>
+              <p class="text-sm text-ink-muted">{item.type || ''}</p>
             </div>
             {#if ctx.type === 'organization'}
               <span class="text-xs px-2 py-1 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">

--- a/apps/web/src/routes/(app)/content/+page.svelte
+++ b/apps/web/src/routes/(app)/content/+page.svelte
@@ -91,24 +91,24 @@
 </script>
 
 <div class="p-4 sm:p-6">
-  <div class="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 mb-1">
+  <div class="flex items-center gap-1.5 text-sm text-ink-muted mb-1">
     <span>{currentOrg?.name || $_('header.orgContext')}</span>
     {#if $currentProjectStore}
-      <span class="text-gray-300">›</span>
+      <span class="text-ink-subtle">›</span>
       <span class="text-indigo-600 dark:text-indigo-400">{$currentProjectStore.name}</span>
     {/if}
-    <span class="text-gray-300">›</span>
-    <span class="text-gray-700 dark:text-gray-200">{$_('nav.orgContent')}</span>
+    <span class="text-ink-subtle">›</span>
+    <span class="text-ink">{$_('nav.orgContent')}</span>
   </div>
 
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{$_('nav.orgContent')}</h1>
+    <h1 class="text-2xl font-bold text-ink">{$_('nav.orgContent')}</h1>
     {#if $currentProjectStore}
       <a href="/projects/{$currentProjectStore.id}/content" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors">
         + {$_('common.create')}
       </a>
     {:else}
-      <button disabled class="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-400 text-sm font-medium rounded-lg cursor-not-allowed" title={$_('common.selectProjectToCreate')}>
+      <button disabled class="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-ink-subtle text-sm font-medium rounded-lg cursor-not-allowed" title={$_('common.selectProjectToCreate')}>
         + {$_('common.create')}
       </button>
     {/if}
@@ -119,7 +119,7 @@
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500"></div>
     </div>
   {:else if items.length === 0}
-    <div class="text-center py-12 text-gray-500 dark:text-gray-400">
+    <div class="text-center py-12 text-ink-muted">
       <p>{$_('common.noData')}</p>
     </div>
   {:else}
@@ -129,20 +129,20 @@
           <!-- Grouped multilingual content -->
           <!-- svelte-ignore a11y-click-events-have-key-events -->
           <!-- svelte-ignore a11y-no-static-element-interactions -->
-          <div class="bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 overflow-hidden hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all">
+          <div class="bg-surface rounded-lg border border-border overflow-hidden hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all">
             <div class="p-4 cursor-pointer" on:click={() => toggleGroup(group.groupId)}>
               <div class="flex items-center justify-between">
                 <div>
                   <div class="flex items-center gap-1.5 mb-1">
                     {#each group.items as gi}
-                      <span class="text-xs px-1.5 py-0.5 rounded font-medium {langBadge[gi.language] || 'bg-gray-100 text-gray-600'}">{(gi.language || '?').toUpperCase()}</span>
+                      <span class="text-xs px-1.5 py-0.5 rounded font-medium {langBadge[gi.language] || 'bg-surface-2 text-ink-muted'}">{(gi.language || '?').toUpperCase()}</span>
                     {/each}
-                    <span class="text-xs text-gray-400">
+                    <span class="text-xs text-ink-subtle">
                       {group.items[0].type ? (typeLabel[group.items[0].type] ? $_(typeLabel[group.items[0].type]) : group.items[0].type.replace(/_/g, ' ')) : ''}
                       {#if group.items[0].status}· {statusLabel[group.items[0].status] ? $_(statusLabel[group.items[0].status]) : group.items[0].status}{/if}
                     </span>
                   </div>
-                  <h3 class="font-medium text-gray-900 dark:text-white">{group.items[0].title}</h3>
+                  <h3 class="font-medium text-ink">{group.items[0].title}</h3>
                 </div>
                 <div class="flex items-center gap-2">
                   {#if ctx.type === 'organization'}
@@ -150,21 +150,21 @@
                       {group.items[0].projectName || $_('org.scopeProject')}
                     </span>
                   {/if}
-                  <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-400 transition-transform {expandedGroups.has(group.groupId) ? 'rotate-180' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-ink-subtle transition-transform {expandedGroups.has(group.groupId) ? 'rotate-180' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
                   </svg>
                 </div>
               </div>
             </div>
             {#if expandedGroups.has(group.groupId)}
-              <div class="border-t border-gray-200 dark:border-gray-700">
+              <div class="border-t border-border">
                 {#each group.items as item}
-                  <a href="/projects/{item.projectId}/content/{item.id}/edit" class="block p-4 border-b border-gray-100 dark:border-gray-700 last:border-b-0 hover:bg-gray-50 dark:hover:bg-gray-700/50">
+                  <a href="/projects/{item.projectId}/content/{item.id}/edit" class="block p-4 border-b border-border last:border-b-0 hover:bg-surface-2">
                     <div class="flex items-center gap-2">
-                      <span class="text-xs px-1.5 py-0.5 rounded font-bold {langBadge[item.language] || 'bg-gray-100 text-gray-600'}">{(item.language || '?').toUpperCase()}</span>
-                      <h3 class="font-medium text-gray-900 dark:text-white">{item.title}</h3>
+                      <span class="text-xs px-1.5 py-0.5 rounded font-bold {langBadge[item.language] || 'bg-surface-2 text-ink-muted'}">{(item.language || '?').toUpperCase()}</span>
+                      <h3 class="font-medium text-ink">{item.title}</h3>
                     </div>
-                    <p class="text-sm text-gray-500 dark:text-gray-400 mt-1 line-clamp-2">{item.body?.substring(0, 150)}</p>
+                    <p class="text-sm text-ink-muted mt-1 line-clamp-2">{item.body?.substring(0, 150)}</p>
                   </a>
                 {/each}
               </div>
@@ -173,16 +173,16 @@
         {:else}
           <!-- Single content item -->
           {@const item = group.items[0]}
-          <a href="/projects/{item.projectId}/content/{item.id}/edit" class="block bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
+          <a href="/projects/{item.projectId}/content/{item.id}/edit" class="block bg-surface rounded-lg border border-border p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
             <div class="flex items-center justify-between">
               <div>
                 <div class="flex items-center gap-1.5 mb-1">
                   {#if item.language}
-                    <span class="text-xs px-1.5 py-0.5 rounded font-medium {langBadge[item.language] || 'bg-gray-100 text-gray-600'}">{item.language.toUpperCase()}</span>
+                    <span class="text-xs px-1.5 py-0.5 rounded font-medium {langBadge[item.language] || 'bg-surface-2 text-ink-muted'}">{item.language.toUpperCase()}</span>
                   {/if}
                 </div>
-                <h3 class="font-medium text-gray-900 dark:text-white">{item.title}</h3>
-                <p class="text-sm text-gray-500 dark:text-gray-400">
+                <h3 class="font-medium text-ink">{item.title}</h3>
+                <p class="text-sm text-ink-muted">
                   {item.type ? (typeLabel[item.type] ? $_(typeLabel[item.type]) : item.type.replace(/_/g, ' ')) : ''}
                   {#if item.status}· {statusLabel[item.status] ? $_(statusLabel[item.status]) : item.status}{/if}
                 </p>

--- a/apps/web/src/routes/(app)/dashboard/+page.svelte
+++ b/apps/web/src/routes/(app)/dashboard/+page.svelte
@@ -160,17 +160,17 @@
 <div class="p-4 sm:p-6">
   <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 mb-6">
     <div>
-      <h1 class="text-2xl font-bold text-gray-900">{$_('nav.dashboard')}</h1>
-      <p class="text-sm text-gray-500 mt-1">{$_('projects.manageDesc')}</p>
+      <h1 class="text-2xl font-bold text-ink">{$_('nav.dashboard')}</h1>
+      <p class="text-sm text-ink-muted mt-1">{$_('projects.manageDesc')}</p>
     </div>
     <div class="flex items-center gap-2 w-full sm:w-auto">
-      <button on:click={() => { resetImport(); showImportModal = true; }} class="flex-1 sm:flex-initial justify-center px-4 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 flex items-center gap-2 cursor-pointer">
+      <button on:click={() => { resetImport(); showImportModal = true; }} class="flex-1 sm:flex-initial justify-center px-4 py-2 text-sm font-medium text-ink border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 flex items-center gap-2 cursor-pointer">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
         </svg>
         {$_('common.import')}
       </button>
-      <a href="/projects/new" class="flex-1 sm:flex-initial justify-center bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 flex items-center gap-2 cursor-pointer">
+      <a href="/projects/new" class="flex-1 sm:flex-initial justify-center bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-2 cursor-pointer">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
         </svg>
@@ -185,14 +185,14 @@
 
   {#if $projectsStore.length === 0}
     <div class="flex flex-col items-center justify-center py-24 text-center">
-      <div class="w-20 h-20 bg-primary-50 rounded-2xl flex items-center justify-center mb-6">
+      <div class="w-20 h-20 bg-brand-subtle/10 rounded-2xl flex items-center justify-center mb-6">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.59 14.37a6 6 0 01-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 006.16-12.12A14.98 14.98 0 009.631 8.41m5.96 5.96a14.926 14.926 0 01-5.841 2.58m-.119-8.54a6 6 0 00-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 00-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 01-2.448-2.448 14.9 14.9 0 01.06-.312m-2.24 2.39a4.493 4.493 0 00-1.757 4.306 4.493 4.493 0 004.306-1.758M16.5 9a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z" />
         </svg>
       </div>
-      <h2 class="text-xl font-semibold text-gray-900 mb-2">{$_('projects.empty')}</h2>
-      <p class="text-gray-500 mb-8 max-w-sm">{$_('projects.emptyDesc')}</p>
-      <a href="/projects/new" class="bg-primary-600 text-white px-6 py-3 rounded-xl font-medium hover:bg-primary-700 transition-colors duration-150 shadow-lg shadow-primary-200 cursor-pointer">
+      <h2 class="text-xl font-semibold text-ink mb-2">{$_('projects.empty')}</h2>
+      <p class="text-ink-muted mb-8 max-w-sm">{$_('projects.emptyDesc')}</p>
+      <a href="/projects/new" class="bg-brand text-white px-6 py-3 rounded-xl font-medium hover:brightness-110 transition-colors duration-150 shadow-lg shadow-primary-200 cursor-pointer">
         {$_('projects.create')}
       </a>
     </div>
@@ -202,7 +202,7 @@
         <a
           href="/projects/{project.id}/overview"
           on:click={() => currentProjectStore.set(project)}
-          class="bg-white rounded-xl border border-gray-200 p-6 hover:shadow-md hover:border-primary-200 transition-all duration-150 group cursor-pointer border-t-4 flex flex-col h-full
+          class="bg-surface rounded-xl border border-border p-6 hover:shadow-md hover:border-primary-200 transition-all duration-150 group cursor-pointer border-t-4 flex flex-col h-full
             {project.status === 'ACTIVE' ? 'border-t-green-400' : project.status === 'PAUSED' ? 'border-t-amber-400' : 'border-t-gray-200'}"
         >
           <div class="flex items-start justify-between mb-4">
@@ -215,22 +215,22 @@
                 </div>
               {/if}
               <div class="min-w-0">
-                <h3 class="font-semibold text-gray-900 group-hover:text-primary-700 transition-colors duration-150 truncate">{project.name}</h3>
-                <p class="text-xs text-gray-400 truncate">{project.industry || $_('common.overview')}</p>
+                <h3 class="font-semibold text-ink group-hover:text-primary-700 transition-colors duration-150 truncate">{project.name}</h3>
+                <p class="text-xs text-ink-subtle truncate">{project.industry || $_('common.overview')}</p>
               </div>
             </div>
             <span class="text-xs px-2 py-1 rounded-full flex-shrink-0 ml-2 flex items-center gap-1
-              {project.status === 'ACTIVE' ? 'bg-green-50 text-green-700' : 'bg-gray-100 text-gray-500'}">
+              {project.status === 'ACTIVE' ? 'bg-green-50 text-green-700' : 'bg-surface-2 text-ink-muted'}">
               <span class="w-1.5 h-1.5 rounded-full flex-shrink-0 {project.status === 'ACTIVE' ? 'bg-green-500' : 'bg-gray-400'}"></span>
               {project.status === 'ACTIVE' ? $_('projects.active') : project.status === 'PAUSED' ? $_('projects.paused') : $_('projects.archived')}
             </span>
           </div>
 
           {#if project.description}
-            <p class="text-sm text-gray-500 mb-4 line-clamp-2">{project.description}</p>
+            <p class="text-sm text-ink-muted mb-4 line-clamp-2">{project.description}</p>
           {/if}
 
-          <div class="flex gap-4 text-xs text-gray-400 border-t border-gray-100 pt-4 mt-auto">
+          <div class="flex gap-4 text-xs text-ink-subtle border-t border-border pt-4 mt-auto">
             <span class="flex items-center gap-1">
               <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931z" /></svg>
               {(project as any)._count?.content || 0}
@@ -255,8 +255,8 @@
 <!-- Import Modal -->
 {#if showImportModal}
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showImportModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border">
         <div class="flex items-center gap-3">
           <div class="w-10 h-10 bg-green-50 rounded-xl flex items-center justify-center">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
@@ -264,8 +264,8 @@
             </svg>
           </div>
           <div>
-            <h3 class="text-lg font-semibold text-gray-900">{$_('projectImport.title')}</h3>
-            <p class="text-sm text-gray-500">{$_('projectImport.description')}</p>
+            <h3 class="text-lg font-semibold text-ink">{$_('projectImport.title')}</h3>
+            <p class="text-sm text-ink-muted">{$_('projectImport.description')}</p>
           </div>
         </div>
       </div>
@@ -273,16 +273,16 @@
       <div class="p-6">
         {#if importStep === 'upload'}
           <!-- Upload step -->
-          <label class="flex flex-col items-center justify-center w-full h-40 border-2 border-dashed border-gray-300 rounded-xl cursor-pointer hover:border-primary-400 hover:bg-primary-50/30 transition-colors duration-150">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-gray-400 mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+          <label class="flex flex-col items-center justify-center w-full h-40 border-2 border-dashed border-border rounded-xl cursor-pointer hover:border-primary-400 hover:bg-brand-subtle/10 transition-colors duration-150">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-ink-subtle mb-2" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m6.75 12H9.75m3 0l-3-3m0 0l-3 3m3-3v6.75" />
             </svg>
-            <p class="text-sm text-gray-600 font-medium">{$_('projectImport.uploadFile')}</p>
-            <p class="text-xs text-gray-400 mt-1">{$_('projectImport.uploadHint')}</p>
+            <p class="text-sm text-ink-muted font-medium">{$_('projectImport.uploadFile')}</p>
+            <p class="text-xs text-ink-subtle mt-1">{$_('projectImport.uploadHint')}</p>
             <input type="file" accept=".json" class="hidden" on:change={handleImportFile} />
           </label>
           {#if validating}
-            <div class="flex items-center gap-2 mt-4 text-sm text-gray-500">
+            <div class="flex items-center gap-2 mt-4 text-sm text-ink-muted">
               <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
               {$_('projectImport.validating')}
             </div>
@@ -299,8 +299,8 @@
                 {importValidation?.projectName?.charAt(0) || 'P'}
               </div>
               <div>
-                <p class="text-sm font-semibold text-gray-900">{importValidation?.projectName}</p>
-                <p class="text-xs text-gray-500">{$_('projectImport.previewDesc')}</p>
+                <p class="text-sm font-semibold text-ink">{importValidation?.projectName}</p>
+                <p class="text-xs text-ink-muted">{$_('projectImport.previewDesc')}</p>
               </div>
             </div>
           </div>
@@ -308,13 +308,13 @@
           <div class="space-y-2">
             {#each Object.entries(importValidation?.summary || {}) as [section, count]}
               <label class="flex items-center justify-between p-3 rounded-lg border cursor-pointer transition-colors duration-150
-                {selectedImportSections.has(section) ? 'border-primary-200 bg-primary-50/50' : 'border-gray-200 hover:bg-gray-50'}">
+                {selectedImportSections.has(section) ? 'border-primary-200 bg-brand-subtle/10' : 'border-border hover:bg-surface-2'}">
                 <div class="flex items-center gap-3">
                   <input type="checkbox" checked={selectedImportSections.has(section)} on:change={() => toggleImportSection(section)}
-                    class="w-4 h-4 text-primary-600 rounded border-gray-300 focus:ring-primary-500" />
-                  <span class="text-sm text-gray-700">{$_(sectionLabels[section] || section)}</span>
+                    class="w-4 h-4 text-brand rounded border-border focus:ring-primary-500" />
+                  <span class="text-sm text-ink">{$_(sectionLabels[section] || section)}</span>
                 </div>
-                <span class="text-xs text-gray-400 bg-gray-100 px-2 py-0.5 rounded-full">{count}</span>
+                <span class="text-xs text-ink-subtle bg-surface-2 px-2 py-0.5 rounded-full">{count}</span>
               </label>
             {/each}
           </div>
@@ -325,13 +325,13 @@
         {/if}
       </div>
 
-      <div class="p-6 border-t border-gray-100 flex justify-end gap-3">
+      <div class="p-6 border-t border-border flex justify-end gap-3">
         {#if importStep === 'preview'}
-          <button on:click={() => { importStep = 'upload'; importError = ''; }} class="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 cursor-pointer transition-colors duration-150">
+          <button on:click={() => { importStep = 'upload'; importError = ''; }} class="px-4 py-2 text-sm text-ink border border-border rounded-lg hover:bg-surface-2 cursor-pointer transition-colors duration-150">
             {$_('common.back')}
           </button>
         {/if}
-        <button on:click={() => showImportModal = false} class="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 cursor-pointer transition-colors duration-150">
+        <button on:click={() => showImportModal = false} class="px-4 py-2 text-sm text-ink border border-border rounded-lg hover:bg-surface-2 cursor-pointer transition-colors duration-150">
           {$_('common.cancel')}
         </button>
         {#if importStep === 'preview'}

--- a/apps/web/src/routes/(app)/dashboard/+page.svelte
+++ b/apps/web/src/routes/(app)/dashboard/+page.svelte
@@ -164,13 +164,13 @@
       <p class="text-sm text-ink-muted mt-1">{$_('projects.manageDesc')}</p>
     </div>
     <div class="flex items-center gap-2 w-full sm:w-auto">
-      <button on:click={() => { resetImport(); showImportModal = true; }} class="flex-1 sm:flex-initial justify-center px-4 py-2 text-sm font-medium text-ink border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 flex items-center gap-2 cursor-pointer">
+      <button on:click={() => { resetImport(); showImportModal = true; }} class="btn btn-secondary flex-1 sm:flex-initial">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5m-13.5-9L12 3m0 0l4.5 4.5M12 3v13.5" />
         </svg>
         {$_('common.import')}
       </button>
-      <a href="/projects/new" class="flex-1 sm:flex-initial justify-center bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-2 cursor-pointer">
+      <a href="/projects/new" class="btn btn-primary flex-1 sm:flex-initial">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
         </svg>
@@ -186,13 +186,13 @@
   {#if $projectsStore.length === 0}
     <div class="flex flex-col items-center justify-center py-24 text-center">
       <div class="w-20 h-20 bg-brand-subtle/10 rounded-2xl flex items-center justify-center mb-6">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.59 14.37a6 6 0 01-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 006.16-12.12A14.98 14.98 0 009.631 8.41m5.96 5.96a14.926 14.926 0 01-5.841 2.58m-.119-8.54a6 6 0 00-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 00-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 01-2.448-2.448 14.9 14.9 0 01.06-.312m-2.24 2.39a4.493 4.493 0 00-1.757 4.306 4.493 4.493 0 004.306-1.758M16.5 9a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z" />
         </svg>
       </div>
       <h2 class="text-xl font-semibold text-ink mb-2">{$_('projects.empty')}</h2>
       <p class="text-ink-muted mb-8 max-w-sm">{$_('projects.emptyDesc')}</p>
-      <a href="/projects/new" class="bg-brand text-white px-6 py-3 rounded-xl font-medium hover:brightness-110 transition-colors duration-150 shadow-lg shadow-primary-200 cursor-pointer">
+      <a href="/projects/new" class="btn btn-primary px-6 py-3 text-base">
         {$_('projects.create')}
       </a>
     </div>
@@ -202,26 +202,25 @@
         <a
           href="/projects/{project.id}/overview"
           on:click={() => currentProjectStore.set(project)}
-          class="bg-surface rounded-xl border border-border p-6 hover:shadow-md hover:border-primary-200 transition-all duration-150 group cursor-pointer border-t-4 flex flex-col h-full
-            {project.status === 'ACTIVE' ? 'border-t-green-400' : project.status === 'PAUSED' ? 'border-t-amber-400' : 'border-t-gray-200'}"
+          class="bg-surface rounded-xl border border-border p-6 hover:shadow-glow hover:border-brand/40 transition-all duration-150 group cursor-pointer border-t-4 flex flex-col h-full
+            {project.status === 'ACTIVE' ? 'border-t-ok' : project.status === 'PAUSED' ? 'border-t-warn' : 'border-t-border'}"
         >
           <div class="flex items-start justify-between mb-4">
             <div class="flex items-center gap-3 min-w-0">
               {#if project.logoUrl}
                 <img src={project.logoUrl} alt={project.name} class="w-10 h-10 rounded-xl object-cover flex-shrink-0" />
               {:else}
-                <div class="w-10 h-10 bg-gradient-to-br from-primary-400 to-primary-700 rounded-xl flex items-center justify-center text-white font-bold text-lg flex-shrink-0">
+                <div class="w-10 h-10 bg-gradient-to-br from-iris-400 to-iris-700 rounded-xl flex items-center justify-center text-white font-bold text-lg flex-shrink-0">
                   {project.name.charAt(0)}
                 </div>
               {/if}
               <div class="min-w-0">
-                <h3 class="font-semibold text-ink group-hover:text-primary-700 transition-colors duration-150 truncate">{project.name}</h3>
+                <h3 class="font-semibold text-ink group-hover:text-brand transition-colors duration-150 truncate">{project.name}</h3>
                 <p class="text-xs text-ink-subtle truncate">{project.industry || $_('common.overview')}</p>
               </div>
             </div>
-            <span class="text-xs px-2 py-1 rounded-full flex-shrink-0 ml-2 flex items-center gap-1
-              {project.status === 'ACTIVE' ? 'bg-green-50 text-green-700' : 'bg-surface-2 text-ink-muted'}">
-              <span class="w-1.5 h-1.5 rounded-full flex-shrink-0 {project.status === 'ACTIVE' ? 'bg-green-500' : 'bg-gray-400'}"></span>
+            <span class="badge flex-shrink-0 ml-2 {project.status === 'ACTIVE' ? 'badge-ok' : 'badge-neutral'}">
+              <span class="w-1.5 h-1.5 rounded-full flex-shrink-0 {project.status === 'ACTIVE' ? 'bg-ok' : 'bg-ink-subtle'}"></span>
               {project.status === 'ACTIVE' ? $_('projects.active') : project.status === 'PAUSED' ? $_('projects.paused') : $_('projects.archived')}
             </span>
           </div>

--- a/apps/web/src/routes/(app)/documents/+page.svelte
+++ b/apps/web/src/routes/(app)/documents/+page.svelte
@@ -33,24 +33,24 @@
 </script>
 
 <div class="p-4 sm:p-6">
-  <div class="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 mb-1">
+  <div class="flex items-center gap-1.5 text-sm text-ink-muted mb-1">
     <span>{currentOrg?.name || $_('header.orgContext')}</span>
     {#if $currentProjectStore}
-      <span class="text-gray-300">›</span>
+      <span class="text-ink-subtle">›</span>
       <span class="text-indigo-600 dark:text-indigo-400">{$currentProjectStore.name}</span>
     {/if}
-    <span class="text-gray-300">›</span>
-    <span class="text-gray-700 dark:text-gray-200">{$_('nav.orgDocuments')}</span>
+    <span class="text-ink-subtle">›</span>
+    <span class="text-ink">{$_('nav.orgDocuments')}</span>
   </div>
 
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{$_('nav.orgDocuments')}</h1>
+    <h1 class="text-2xl font-bold text-ink">{$_('nav.orgDocuments')}</h1>
     {#if $currentProjectStore}
       <a href="/projects/{$currentProjectStore.id}/documents" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors">
         + {$_('common.create')}
       </a>
     {:else}
-      <button disabled class="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-400 text-sm font-medium rounded-lg cursor-not-allowed" title={$_('common.selectProjectToCreate')}>
+      <button disabled class="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-ink-subtle text-sm font-medium rounded-lg cursor-not-allowed" title={$_('common.selectProjectToCreate')}>
         + {$_('common.create')}
       </button>
     {/if}
@@ -61,17 +61,17 @@
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500"></div>
     </div>
   {:else if items.length === 0}
-    <div class="text-center py-12 text-gray-500 dark:text-gray-400">
+    <div class="text-center py-12 text-ink-muted">
       <p>{$_('common.noData')}</p>
     </div>
   {:else}
     <div class="space-y-3">
       {#each items as item}
-        <a href="/projects/{item.projectId}/documents" class="block bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
+        <a href="/projects/{item.projectId}/documents" class="block bg-surface rounded-lg border border-border p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
           <div class="flex items-center justify-between">
             <div>
-              <h3 class="font-medium text-gray-900 dark:text-white">{item.title}</h3>
-              <p class="text-sm text-gray-500 dark:text-gray-400">{item.type || ''}</p>
+              <h3 class="font-medium text-ink">{item.title}</h3>
+              <p class="text-sm text-ink-muted">{item.type || ''}</p>
             </div>
             {#if ctx.type === 'organization'}
               <span class="text-xs px-2 py-1 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">

--- a/apps/web/src/routes/(app)/email/+page.svelte
+++ b/apps/web/src/routes/(app)/email/+page.svelte
@@ -33,24 +33,24 @@
 </script>
 
 <div class="p-4 sm:p-6">
-  <div class="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 mb-1">
+  <div class="flex items-center gap-1.5 text-sm text-ink-muted mb-1">
     <span>{currentOrg?.name || $_('header.orgContext')}</span>
     {#if $currentProjectStore}
-      <span class="text-gray-300">›</span>
+      <span class="text-ink-subtle">›</span>
       <span class="text-indigo-600 dark:text-indigo-400">{$currentProjectStore.name}</span>
     {/if}
-    <span class="text-gray-300">›</span>
-    <span class="text-gray-700 dark:text-gray-200">{$_('nav.orgEmail')}</span>
+    <span class="text-ink-subtle">›</span>
+    <span class="text-ink">{$_('nav.orgEmail')}</span>
   </div>
 
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{$_('nav.orgEmail')}</h1>
+    <h1 class="text-2xl font-bold text-ink">{$_('nav.orgEmail')}</h1>
     {#if $currentProjectStore}
       <a href="/projects/{$currentProjectStore.id}/email" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors">
         + {$_('common.create')}
       </a>
     {:else}
-      <button disabled class="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-400 text-sm font-medium rounded-lg cursor-not-allowed" title={$_('common.selectProjectToCreate')}>
+      <button disabled class="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-ink-subtle text-sm font-medium rounded-lg cursor-not-allowed" title={$_('common.selectProjectToCreate')}>
         + {$_('common.create')}
       </button>
     {/if}
@@ -61,17 +61,17 @@
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500"></div>
     </div>
   {:else if items.length === 0}
-    <div class="text-center py-12 text-gray-500 dark:text-gray-400">
+    <div class="text-center py-12 text-ink-muted">
       <p>{$_('common.noData')}</p>
     </div>
   {:else}
     <div class="space-y-3">
       {#each items as item}
-        <a href="/projects/{item.projectId}/email" class="block bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
+        <a href="/projects/{item.projectId}/email" class="block bg-surface rounded-lg border border-border p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
           <div class="flex items-center justify-between">
             <div>
-              <h3 class="font-medium text-gray-900 dark:text-white">{item.name}</h3>
-              <p class="text-sm text-gray-500 dark:text-gray-400">
+              <h3 class="font-medium text-ink">{item.name}</h3>
+              <p class="text-sm text-ink-muted">
                 {item._count?.subscribers ?? item.subscriberCount ?? 0} subscribers
               </p>
             </div>

--- a/apps/web/src/routes/(app)/experiments/+page.svelte
+++ b/apps/web/src/routes/(app)/experiments/+page.svelte
@@ -33,24 +33,24 @@
 </script>
 
 <div class="p-4 sm:p-6">
-  <div class="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 mb-1">
+  <div class="flex items-center gap-1.5 text-sm text-ink-muted mb-1">
     <span>{currentOrg?.name || $_('header.orgContext')}</span>
     {#if $currentProjectStore}
-      <span class="text-gray-300">›</span>
+      <span class="text-ink-subtle">›</span>
       <span class="text-indigo-600 dark:text-indigo-400">{$currentProjectStore.name}</span>
     {/if}
-    <span class="text-gray-300">›</span>
-    <span class="text-gray-700 dark:text-gray-200">{$_('nav.orgExperiments')}</span>
+    <span class="text-ink-subtle">›</span>
+    <span class="text-ink">{$_('nav.orgExperiments')}</span>
   </div>
 
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{$_('nav.orgExperiments')}</h1>
+    <h1 class="text-2xl font-bold text-ink">{$_('nav.orgExperiments')}</h1>
     {#if $currentProjectStore}
       <a href="/projects/{$currentProjectStore.id}/experiments" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors">
         + {$_('common.create')}
       </a>
     {:else}
-      <button disabled class="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-400 text-sm font-medium rounded-lg cursor-not-allowed" title={$_('common.selectProjectToCreate')}>
+      <button disabled class="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-ink-subtle text-sm font-medium rounded-lg cursor-not-allowed" title={$_('common.selectProjectToCreate')}>
         + {$_('common.create')}
       </button>
     {/if}
@@ -61,17 +61,17 @@
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500"></div>
     </div>
   {:else if items.length === 0}
-    <div class="text-center py-12 text-gray-500 dark:text-gray-400">
+    <div class="text-center py-12 text-ink-muted">
       <p>{$_('common.noData')}</p>
     </div>
   {:else}
     <div class="space-y-3">
       {#each items as item}
-        <a href="/projects/{item.projectId}/experiments" class="block bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
+        <a href="/projects/{item.projectId}/experiments" class="block bg-surface rounded-lg border border-border p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
           <div class="flex items-center justify-between">
             <div>
-              <h3 class="font-medium text-gray-900 dark:text-white">{item.name || item.title || 'Experiment'}</h3>
-              <p class="text-sm text-gray-500 dark:text-gray-400">{item.type || ''}{item.status ? ' · ' + item.status : ''}</p>
+              <h3 class="font-medium text-ink">{item.name || item.title || 'Experiment'}</h3>
+              <p class="text-sm text-ink-muted">{item.type || ''}{item.status ? ' · ' + item.status : ''}</p>
             </div>
             {#if ctx.type === 'organization'}
               <span class="text-xs px-2 py-1 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">

--- a/apps/web/src/routes/(app)/finances/+page.svelte
+++ b/apps/web/src/routes/(app)/finances/+page.svelte
@@ -256,14 +256,14 @@
 <div class="p-4 sm:p-6">
   <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
     <div>
-      <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{$_('finances.title')}</h1>
-      <p class="text-sm text-gray-500 dark:text-gray-400 mt-1">{$_('finances.subtitle')}</p>
+      <h1 class="text-2xl font-bold text-ink">{$_('finances.title')}</h1>
+      <p class="text-sm text-ink-muted mt-1">{$_('finances.subtitle')}</p>
     </div>
     <div class="flex items-center gap-3 flex-wrap">
-      <div class="flex bg-gray-100 dark:bg-gray-800 rounded-lg overflow-hidden text-sm">
+      <div class="flex bg-surface-2 rounded-lg overflow-hidden text-sm">
         {#each ['month', 'quarter', 'year'] as p}
           <button
-            class="px-3 py-1.5 cursor-pointer {periodMode === p ? 'bg-indigo-600 text-white' : 'text-gray-400 hover:text-gray-200'}"
+            class="px-3 py-1.5 cursor-pointer {periodMode === p ? 'bg-indigo-600 text-white' : 'text-ink-subtle hover:text-gray-200'}"
             on:click={() => { periodMode = p; }}
           >{$_(`finances.${p}`)}</button>
         {/each}
@@ -281,15 +281,15 @@
     {#if summary}
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
       <div class="bg-green-500/10 border border-green-500/25 rounded-xl p-4 min-w-0">
-        <div class="text-xs text-gray-400">{$_('finances.income')}</div>
+        <div class="text-xs text-ink-subtle">{$_('finances.income')}</div>
         <div class="text-2xl font-bold text-green-400 mt-1 truncate">{formatCurrency(summary.totalIncome)}</div>
       </div>
       <div class="bg-red-500/10 border border-red-500/25 rounded-xl p-4 min-w-0">
-        <div class="text-xs text-gray-400">{$_('finances.expenses')}</div>
+        <div class="text-xs text-ink-subtle">{$_('finances.expenses')}</div>
         <div class="text-2xl font-bold text-red-400 mt-1 truncate">{formatCurrency(summary.totalExpense)}</div>
       </div>
       <div class="bg-indigo-500/10 border border-indigo-500/25 rounded-xl p-4 min-w-0">
-        <div class="text-xs text-gray-400">{$_('finances.profit')}</div>
+        <div class="text-xs text-ink-subtle">{$_('finances.profit')}</div>
         <div class="text-2xl font-bold text-indigo-400 mt-1 truncate">{formatCurrency(summary.profit)}</div>
       </div>
     </div>
@@ -298,11 +298,11 @@
     <!-- Charts -->
     {#if summary?.monthly?.length > 0 || summary?.byCategory?.length > 0}
     <div class="grid grid-cols-1 lg:grid-cols-5 gap-4 mb-6">
-      <div class="lg:col-span-3 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 min-w-0" style="min-height: 250px">
+      <div class="lg:col-span-3 bg-surface border border-border rounded-xl p-4 min-w-0" style="min-height: 250px">
         <h3 class="text-sm font-semibold mb-3">{$_('finances.incomeVsExpenses')}</h3>
         <div style="height: 200px"><canvas bind:this={barCanvas}></canvas></div>
       </div>
-      <div class="lg:col-span-2 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl p-4 min-w-0" style="min-height: 250px">
+      <div class="lg:col-span-2 bg-surface border border-border rounded-xl p-4 min-w-0" style="min-height: 250px">
         <div class="flex items-center justify-between mb-3 gap-2">
           <h3 class="text-sm font-semibold truncate">{$_('finances.byCategory')}</h3>
           <button on:click={toggleDoughnut} class="text-xs px-2 py-1 rounded cursor-pointer flex-shrink-0 {doughnutMode === 'EXPENSE' ? 'text-red-400 bg-red-500/10' : 'text-green-400 bg-green-500/10'}">
@@ -315,11 +315,11 @@
     {/if}
 
     <!-- Table -->
-    <div class="bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl overflow-hidden">
-      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 py-3 border-b border-gray-200 dark:border-gray-700">
+    <div class="bg-surface border border-border rounded-xl overflow-hidden">
+      <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 py-3 border-b border-border">
         <div class="flex gap-2 text-sm flex-wrap">
           {#each ['ALL', 'INCOME', 'EXPENSE'] as t}
-            <button class="px-3 py-1 rounded cursor-pointer {filterType === t ? 'bg-indigo-600 text-white' : 'text-gray-400 hover:text-white'}" on:click={() => { filterType = t; }}>
+            <button class="px-3 py-1 rounded cursor-pointer {filterType === t ? 'bg-indigo-600 text-white' : 'text-ink-subtle hover:text-white'}" on:click={() => { filterType = t; }}>
               {t === 'ALL' ? $_('finances.all') : t === 'INCOME' ? $_('finances.income') : $_('finances.expenses')}
             </button>
           {/each}
@@ -328,11 +328,11 @@
       </div>
 
       {#if records.length === 0}
-        <div class="text-center py-12 text-gray-500">{$_('finances.emptyState')}</div>
+        <div class="text-center py-12 text-ink-muted">{$_('finances.emptyState')}</div>
       {:else}
         <div class="overflow-x-auto">
           <table class="w-full text-sm">
-            <thead class="text-xs text-gray-500 border-b border-gray-200 dark:border-gray-700">
+            <thead class="text-xs text-ink-muted border-b border-border">
               <tr>
                 <th class="px-4 py-2 text-left whitespace-nowrap">{$_('finances.date')}</th>
                 <th class="px-4 py-2 text-left whitespace-nowrap">{$_('finances.type')}</th>
@@ -345,31 +345,31 @@
             </thead>
             <tbody>
               {#each records as record}
-                <tr class="border-b border-gray-200 dark:border-gray-100 dark:border-gray-700/50 hover:bg-gray-50 dark:hover:bg-gray-700/30">
-                  <td class="px-4 py-2.5 text-gray-400 whitespace-nowrap">{formatDate(record.date)}</td>
+                <tr class="border-b border-border hover:bg-surface-2">
+                  <td class="px-4 py-2.5 text-ink-subtle whitespace-nowrap">{formatDate(record.date)}</td>
                   <td class="px-4 py-2.5 whitespace-nowrap">
                     <span class="px-2 py-0.5 rounded text-xs {record.type === 'INCOME' ? 'bg-green-500/15 text-green-400' : 'bg-red-500/15 text-red-400'}">
                       {record.type === 'INCOME' ? $_('finances.income') : $_('finances.expense')}
                     </span>
                   </td>
                   <td class="px-4 py-2.5 whitespace-nowrap">{getCategoryName(record.category)}</td>
-                  <td class="px-4 py-2.5 text-gray-500 whitespace-nowrap">{record.project?.name || 'Organization'}</td>
-                  <td class="px-4 py-2.5 text-gray-400 max-w-[200px] truncate">{record.description || ''}</td>
+                  <td class="px-4 py-2.5 text-ink-muted whitespace-nowrap">{record.project?.name || 'Organization'}</td>
+                  <td class="px-4 py-2.5 text-ink-subtle max-w-[200px] truncate">{record.description || ''}</td>
                   <td class="px-4 py-2.5 text-right whitespace-nowrap {record.type === 'INCOME' ? 'text-green-400' : 'text-red-400'}">{formatCurrency(record.amountInBaseCurrency)}</td>
                   <td class="px-4 py-2.5 whitespace-nowrap text-right">
                     <div class="inline-flex items-center gap-1">
-                      <button on:click={() => openEditModal(record)} class="p-1 text-gray-500 hover:text-gray-300 cursor-pointer" title="Edit">
+                      <button on:click={() => openEditModal(record)} class="p-1 text-ink-muted hover:text-gray-300 cursor-pointer" title="Edit">
                         <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Z" /></svg>
                       </button>
                       {#if deletingId === record.id}
                         <button on:click={() => deleteRecord(record.id)} class="p-1 text-red-400 hover:text-red-300 cursor-pointer" title="Confirm">
                           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
                         </button>
-                        <button on:click={() => deletingId = null} class="p-1 text-gray-400 hover:text-gray-300 cursor-pointer" title="Cancel">
+                        <button on:click={() => deletingId = null} class="p-1 text-ink-subtle hover:text-gray-300 cursor-pointer" title="Cancel">
                           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
                         </button>
                       {:else}
-                        <button on:click={() => deletingId = record.id} class="p-1 text-gray-500 hover:text-red-400 cursor-pointer" title="Delete">
+                        <button on:click={() => deletingId = record.id} class="p-1 text-ink-muted hover:text-red-400 cursor-pointer" title="Delete">
                           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" /></svg>
                         </button>
                       {/if}
@@ -381,7 +381,7 @@
           </table>
         </div>
         {#if totalPages > 1}
-          <div class="flex items-center justify-center gap-2 py-3 text-sm text-gray-400">
+          <div class="flex items-center justify-center gap-2 py-3 text-sm text-ink-subtle">
             <button disabled={currentPage <= 1} on:click={() => { currentPage--; fetchRecords(); }} class="px-2 py-1 disabled:opacity-30 cursor-pointer">←</button>
             <span>{currentPage} / {totalPages}</span>
             <button disabled={currentPage >= totalPages} on:click={() => { currentPage++; fetchRecords(); }} class="px-2 py-1 disabled:opacity-30 cursor-pointer">→</button>
@@ -395,13 +395,13 @@
 <!-- Record Modal -->
 {#if showRecordModal}
 <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showRecordModal = false}>
-  <div class="bg-white dark:bg-gray-800 rounded-xl w-full max-w-md p-6 shadow-xl">
-    <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">{editingRecord ? $_('finances.editRecord') : $_('finances.addRecord')}</h3>
+  <div class="bg-surface rounded-xl w-full max-w-md p-6 shadow-xl">
+    <h3 class="text-lg font-semibold text-ink mb-4">{editingRecord ? $_('finances.editRecord') : $_('finances.addRecord')}</h3>
 
     <!-- Project assignment -->
     <div class="mb-4">
-      <label class="block text-sm text-gray-500 dark:text-gray-400 mb-1">Project</label>
-      <select bind:value={recordForm.projectId} class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-gray-900 dark:text-white">
+      <label class="block text-sm text-ink-muted mb-1">Project</label>
+      <select bind:value={recordForm.projectId} class="w-full bg-surface-2 border border-border rounded-lg px-3 py-2 text-ink">
         <option value="">Organization (general)</option>
         {#each projects as proj}
           <option value={proj.id}>{proj.name}</option>
@@ -410,15 +410,15 @@
     </div>
 
     <div class="mb-4">
-      <div class="flex bg-gray-100 dark:bg-gray-700 rounded-lg overflow-hidden">
-        <button class="flex-1 py-2 text-sm cursor-pointer {recordForm.type === 'EXPENSE' ? 'bg-red-500/20 text-red-400 font-semibold' : 'text-gray-400'}" on:click={() => recordForm.type = 'EXPENSE'}>{$_('finances.expense')}</button>
-        <button class="flex-1 py-2 text-sm cursor-pointer {recordForm.type === 'INCOME' ? 'bg-green-500/20 text-green-400 font-semibold' : 'text-gray-400'}" on:click={() => recordForm.type = 'INCOME'}>{$_('finances.income')}</button>
+      <div class="flex bg-surface-2 rounded-lg overflow-hidden">
+        <button class="flex-1 py-2 text-sm cursor-pointer {recordForm.type === 'EXPENSE' ? 'bg-red-500/20 text-red-400 font-semibold' : 'text-ink-subtle'}" on:click={() => recordForm.type = 'EXPENSE'}>{$_('finances.expense')}</button>
+        <button class="flex-1 py-2 text-sm cursor-pointer {recordForm.type === 'INCOME' ? 'bg-green-500/20 text-green-400 font-semibold' : 'text-ink-subtle'}" on:click={() => recordForm.type = 'INCOME'}>{$_('finances.income')}</button>
       </div>
     </div>
 
     <div class="mb-4">
-      <label class="block text-sm text-gray-500 dark:text-gray-400 mb-1">{$_('finances.category')}</label>
-      <select bind:value={recordForm.categoryId} class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-gray-900 dark:text-white">
+      <label class="block text-sm text-ink-muted mb-1">{$_('finances.category')}</label>
+      <select bind:value={recordForm.categoryId} class="w-full bg-surface-2 border border-border rounded-lg px-3 py-2 text-ink">
         <option value="">—</option>
         {#each filteredCategories as cat}
           <option value={cat.id}>{getCategoryName(cat)}</option>
@@ -428,29 +428,29 @@
 
     <div class="grid grid-cols-3 gap-3 mb-4">
       <div class="col-span-2">
-        <label class="block text-sm text-gray-500 dark:text-gray-400 mb-1">{$_('finances.amount')}</label>
-        <input type="number" step="0.01" min="0.01" bind:value={recordForm.amount} class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-gray-900 dark:text-white" />
+        <label class="block text-sm text-ink-muted mb-1">{$_('finances.amount')}</label>
+        <input type="number" step="0.01" min="0.01" bind:value={recordForm.amount} class="w-full bg-surface-2 border border-border rounded-lg px-3 py-2 text-ink" />
       </div>
       <div>
-        <label class="block text-sm text-gray-500 dark:text-gray-400 mb-1">{$_('finances.currency')}</label>
-        <select bind:value={recordForm.currency} class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-gray-900 dark:text-white">
+        <label class="block text-sm text-ink-muted mb-1">{$_('finances.currency')}</label>
+        <select bind:value={recordForm.currency} class="w-full bg-surface-2 border border-border rounded-lg px-3 py-2 text-ink">
           {#each SUPPORTED_CURRENCIES as c}<option value={c}>{c}</option>{/each}
         </select>
       </div>
     </div>
 
     <div class="mb-4">
-      <label class="block text-sm text-gray-500 dark:text-gray-400 mb-1">{$_('finances.date')}</label>
-      <input type="date" bind:value={recordForm.date} class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-gray-900 dark:text-white" />
+      <label class="block text-sm text-ink-muted mb-1">{$_('finances.date')}</label>
+      <input type="date" bind:value={recordForm.date} class="w-full bg-surface-2 border border-border rounded-lg px-3 py-2 text-ink" />
     </div>
 
     <div class="mb-4">
-      <label class="block text-sm text-gray-500 dark:text-gray-400 mb-1">{$_('finances.description')}</label>
-      <textarea bind:value={recordForm.description} rows="2" class="w-full bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-lg px-3 py-2 text-gray-900 dark:text-white"></textarea>
+      <label class="block text-sm text-ink-muted mb-1">{$_('finances.description')}</label>
+      <textarea bind:value={recordForm.description} rows="2" class="w-full bg-surface-2 border border-border rounded-lg px-3 py-2 text-ink"></textarea>
     </div>
 
     <div class="flex gap-3 justify-end">
-      <button on:click={() => showRecordModal = false} class="px-4 py-2 text-gray-400 hover:text-white cursor-pointer">{$_('finances.cancel')}</button>
+      <button on:click={() => showRecordModal = false} class="px-4 py-2 text-ink-subtle hover:text-white cursor-pointer">{$_('finances.cancel')}</button>
       <button on:click={saveRecord} disabled={recordSaving || !recordForm.categoryId || !recordForm.amount} class="px-4 py-2 bg-indigo-600 text-white rounded-lg hover:bg-indigo-700 disabled:opacity-50 cursor-pointer">
         {recordSaving ? '...' : $_('finances.save')}
       </button>
@@ -462,32 +462,32 @@
 <!-- Categories Modal -->
 {#if showCategoriesModal}
 <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showCategoriesModal = false}>
-  <div class="bg-white dark:bg-gray-800 rounded-xl w-full max-w-md p-6 shadow-xl max-h-[80vh] overflow-y-auto">
+  <div class="bg-surface rounded-xl w-full max-w-md p-6 shadow-xl max-h-[80vh] overflow-y-auto">
     <div class="flex items-center justify-between mb-4">
-      <h3 class="text-lg font-semibold text-gray-900 dark:text-white">{$_('finances.categories.title')}</h3>
-      <button on:click={() => showCategoriesModal = false} class="text-gray-400 hover:text-white cursor-pointer">✕</button>
+      <h3 class="text-lg font-semibold text-ink">{$_('finances.categories.title')}</h3>
+      <button on:click={() => showCategoriesModal = false} class="text-ink-subtle hover:text-white cursor-pointer">✕</button>
     </div>
 
     {#each ['EXPENSE', 'INCOME'] as catType}
-      <h4 class="text-sm font-medium text-gray-400 mb-2 mt-4">{catType === 'EXPENSE' ? $_('finances.categories.expenseCategories') : $_('finances.categories.incomeCategories')}</h4>
+      <h4 class="text-sm font-medium text-ink-subtle mb-2 mt-4">{catType === 'EXPENSE' ? $_('finances.categories.expenseCategories') : $_('finances.categories.incomeCategories')}</h4>
       {#each categories.filter(c => c.type === catType || c.type === 'BOTH') as cat}
-        <div class="flex items-center justify-between py-2 px-3 bg-gray-50 dark:bg-gray-700/30 rounded mb-1">
+        <div class="flex items-center justify-between py-2 px-3 bg-surface-2 rounded mb-1">
           <div class="flex items-center gap-2">
             <div class="w-3 h-3 rounded" style="background: {cat.color}"></div>
             <span class="text-sm">{getCategoryName(cat)}</span>
           </div>
           {#if cat.isDefault}
-            <span class="text-xs text-gray-500">{$_('finances.categories.default')}</span>
+            <span class="text-xs text-ink-muted">{$_('finances.categories.default')}</span>
           {:else}
-            <button on:click={() => deleteCategoryById(cat.id)} class="text-gray-500 hover:text-red-400 text-xs cursor-pointer">🗑️</button>
+            <button on:click={() => deleteCategoryById(cat.id)} class="text-ink-muted hover:text-red-400 text-xs cursor-pointer">🗑️</button>
           {/if}
         </div>
       {/each}
     {/each}
 
     <div class="mt-4 flex gap-2">
-      <input bind:value={newCatName} placeholder={$_('finances.categories.newCategory')} class="flex-1 bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded px-3 py-1.5 text-sm text-gray-900 dark:text-white" />
-      <select bind:value={newCatType} class="bg-gray-50 dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded px-2 py-1.5 text-sm text-gray-900 dark:text-white">
+      <input bind:value={newCatName} placeholder={$_('finances.categories.newCategory')} class="flex-1 bg-surface-2 border border-border rounded px-3 py-1.5 text-sm text-ink" />
+      <select bind:value={newCatType} class="bg-surface-2 border border-border rounded px-2 py-1.5 text-sm text-ink">
         <option value="EXPENSE">{$_('finances.expense')}</option>
         <option value="INCOME">{$_('finances.income')}</option>
       </select>

--- a/apps/web/src/routes/(app)/help/+page.svelte
+++ b/apps/web/src/routes/(app)/help/+page.svelte
@@ -94,8 +94,8 @@
 <div class="p-4 sm:p-6">
   <!-- Header -->
   <div class="mb-6">
-    <h1 class="text-2xl font-bold text-gray-900">{$_('help.title')}</h1>
-    <p class="text-gray-500 mt-1 text-sm">{$_('help.subtitle')}</p>
+    <h1 class="text-2xl font-bold text-ink">{$_('help.title')}</h1>
+    <p class="text-ink-muted mt-1 text-sm">{$_('help.subtitle')}</p>
   </div>
 
   {#if loadingList}
@@ -104,14 +104,14 @@
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-500"></div>
     </div>
   {:else if articles.length === 0}
-    <div class="text-center py-12 text-gray-500">
+    <div class="text-center py-12 text-ink-muted">
       <p>{$_('help.noResults')}</p>
     </div>
   {:else}
     <!-- Mobile: select dropdown -->
     <div class="md:hidden mb-4">
       <select
-        class="w-full rounded-lg border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 focus:border-primary-500 focus:ring-1 focus:ring-primary-500"
+        class="w-full rounded-lg border border-border bg-surface px-3 py-2 text-sm text-ink focus:border-primary-500 focus:ring-1 focus:ring-primary-500"
         value={activeSlug}
         on:change={(e) => selectArticle(e.currentTarget.value)}
       >
@@ -123,15 +123,15 @@
 
     <div class="flex gap-0 md:gap-0">
       <!-- Sidebar (desktop only) -->
-      <aside class="hidden md:block w-64 flex-shrink-0 border-r border-gray-200 pr-4">
+      <aside class="hidden md:block w-64 flex-shrink-0 border-r border-border pr-4">
         <nav class="space-y-1">
           {#each articles as a}
             <button
               on:click={() => selectArticle(a.slug)}
               class="w-full text-left px-3 py-2 rounded-lg text-sm transition-colors duration-150 cursor-pointer
                 {activeSlug === a.slug
-                  ? 'bg-primary-50 text-primary-700 font-medium'
-                  : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'}"
+                  ? 'bg-brand-subtle/10 text-brand font-medium'
+                  : 'text-ink-muted hover:bg-surface-2 hover:text-gray-900'}"
             >
               {a.title}
             </button>
@@ -142,25 +142,25 @@
       <!-- Content -->
       <main class="flex-1 md:pl-6 min-w-0">
         {#if loadingArticle}
-          <div class="bg-white rounded-xl border border-gray-200 p-6">
+          <div class="bg-surface rounded-xl border border-border p-6">
             <div class="animate-pulse space-y-4">
               <div class="h-6 bg-gray-200 rounded w-1/3"></div>
-              <div class="h-4 bg-gray-100 rounded w-full"></div>
-              <div class="h-4 bg-gray-100 rounded w-5/6"></div>
-              <div class="h-4 bg-gray-100 rounded w-4/6"></div>
-              <div class="h-4 bg-gray-100 rounded w-full"></div>
-              <div class="h-4 bg-gray-100 rounded w-3/4"></div>
+              <div class="h-4 bg-surface-2 rounded w-full"></div>
+              <div class="h-4 bg-surface-2 rounded w-5/6"></div>
+              <div class="h-4 bg-surface-2 rounded w-4/6"></div>
+              <div class="h-4 bg-surface-2 rounded w-full"></div>
+              <div class="h-4 bg-surface-2 rounded w-3/4"></div>
             </div>
           </div>
         {:else if article}
-          <div class="bg-white rounded-xl border border-gray-200 p-6">
-            <h2 class="text-xl font-semibold text-gray-900 mb-4">{article.title}</h2>
-            <div class="prose prose-sm max-w-none text-gray-700">
+          <div class="bg-surface rounded-xl border border-border p-6">
+            <h2 class="text-xl font-semibold text-ink mb-4">{article.title}</h2>
+            <div class="prose prose-sm max-w-none text-ink">
               {@html renderedContent}
             </div>
           </div>
         {:else}
-          <div class="text-center py-12 text-gray-500">
+          <div class="text-center py-12 text-ink-muted">
             <p>{$_('help.noResults')}</p>
           </div>
         {/if}

--- a/apps/web/src/routes/(app)/onboarding/+page.svelte
+++ b/apps/web/src/routes/(app)/onboarding/+page.svelte
@@ -85,43 +85,43 @@
 
 <div class="p-6 max-w-lg mx-auto">
   <div class="text-center mb-8">
-    <div class="w-14 h-14 bg-primary-600 rounded-2xl flex items-center justify-center text-white mx-auto mb-4">
+    <div class="w-14 h-14 bg-brand rounded-2xl flex items-center justify-center text-white mx-auto mb-4">
       <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
         <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456z" />
       </svg>
     </div>
-    <h1 class="text-2xl font-bold text-gray-900">{$_('onboarding.welcome')}</h1>
-    <p class="text-gray-500 mt-2 text-sm">{$_('onboarding.welcomeDesc')}</p>
+    <h1 class="text-2xl font-bold text-ink">{$_('onboarding.welcome')}</h1>
+    <p class="text-ink-muted mt-2 text-sm">{$_('onboarding.welcomeDesc')}</p>
   </div>
 
   <!-- Step indicator -->
   <div class="flex justify-center gap-2 mb-8">
     {#each [1, 2, 3, 4] as s}
       <div class="flex items-center gap-2">
-        <div class="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold {step >= s ? 'bg-primary-600 text-white' : 'bg-gray-200 text-gray-500'}">{s}</div>
-        {#if s < 4}<div class="w-8 h-0.5 {step > s ? 'bg-primary-600' : 'bg-gray-200'}"></div>{/if}
+        <div class="w-7 h-7 rounded-full flex items-center justify-center text-xs font-bold {step >= s ? 'bg-brand text-white' : 'bg-gray-200 text-ink-muted'}">{s}</div>
+        {#if s < 4}<div class="w-8 h-0.5 {step > s ? 'bg-brand' : 'bg-gray-200'}"></div>{/if}
       </div>
     {/each}
   </div>
 
-  <div class="bg-white rounded-2xl border border-gray-200 p-6">
+  <div class="bg-surface rounded-2xl border border-border p-6">
     <!-- Step 1: Product info -->
     {#if step === 1}
-      <h2 class="text-lg font-semibold text-gray-900 mb-1">{$_('onboarding.addFirstProject')}</h2>
-      <p class="text-sm text-gray-500 mb-4">{$_('onboarding.step1Desc')}</p>
+      <h2 class="text-lg font-semibold text-ink mb-1">{$_('onboarding.addFirstProject')}</h2>
+      <p class="text-sm text-ink-muted mb-4">{$_('onboarding.step1Desc')}</p>
       <div class="space-y-4">
         <div>
-          <label for="ob-name" class="block text-sm font-medium text-gray-700 mb-1">{$_('projects.name')} *</label>
-          <input id="ob-name" type="text" bind:value={projectName} class="w-full px-3 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm" placeholder={$_('onboarding.projectNamePlaceholder')} />
+          <label for="ob-name" class="block text-sm font-medium text-ink mb-1">{$_('projects.name')} *</label>
+          <input id="ob-name" type="text" bind:value={projectName} class="w-full px-3 py-2.5 border border-border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm" placeholder={$_('onboarding.projectNamePlaceholder')} />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-2">{$_('projects.projectType')}</label>
+          <label class="block text-sm font-medium text-ink mb-2">{$_('projects.projectType')}</label>
           <div class="grid grid-cols-3 gap-2">
             {#each projectTypes as pt}
               <button
                 type="button"
                 on:click={() => projectType = pt}
-                class="px-3 py-2 text-sm rounded-lg border transition-colors duration-150 cursor-pointer {projectType === pt ? 'border-primary-500 bg-primary-50 text-primary-700 font-medium' : 'border-gray-200 text-gray-600 hover:border-gray-300 hover:bg-gray-50'}"
+                class="px-3 py-2 text-sm rounded-lg border transition-colors duration-150 cursor-pointer {projectType === pt ? 'border-primary-500 bg-brand-subtle/10 text-brand font-medium' : 'border-border text-ink-muted hover:border-gray-300 hover:bg-surface-2'}"
               >
                 {$_(`projects.types.${pt}`)}
               </button>
@@ -129,19 +129,19 @@
           </div>
         </div>
         <div>
-          <label for="ob-desc" class="block text-sm font-medium text-gray-700 mb-1">{$_('projects.description')}</label>
-          <textarea id="ob-desc" bind:value={projectDescription} rows="2" class="w-full px-3 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm resize-none" placeholder={$_('onboarding.projectDescPlaceholder')}></textarea>
+          <label for="ob-desc" class="block text-sm font-medium text-ink mb-1">{$_('projects.description')}</label>
+          <textarea id="ob-desc" bind:value={projectDescription} rows="2" class="w-full px-3 py-2.5 border border-border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm resize-none" placeholder={$_('onboarding.projectDescPlaceholder')}></textarea>
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
           {#if showWebsiteUrl}
             <div>
-              <label for="ob-website" class="block text-sm font-medium text-gray-700 mb-1">{$_('onboarding.website')}</label>
-              <input id="ob-website" type="url" bind:value={projectWebsite} class="w-full px-3 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm" placeholder="https://..." />
+              <label for="ob-website" class="block text-sm font-medium text-ink mb-1">{$_('onboarding.website')}</label>
+              <input id="ob-website" type="url" bind:value={projectWebsite} class="w-full px-3 py-2.5 border border-border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm" placeholder="https://..." />
             </div>
           {/if}
           <div>
-            <label for="ob-industry" class="block text-sm font-medium text-gray-700 mb-1">{$_('onboarding.industry')}</label>
-            <select id="ob-industry" bind:value={projectIndustry} class="w-full px-3 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm cursor-pointer">
+            <label for="ob-industry" class="block text-sm font-medium text-ink mb-1">{$_('onboarding.industry')}</label>
+            <select id="ob-industry" bind:value={projectIndustry} class="w-full px-3 py-2.5 border border-border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm cursor-pointer">
               <option value="">{$_('onboarding.selectIndustry')}</option>
               <option>SaaS</option><option>E-commerce</option><option>FinTech</option>
               <option>Agency</option><option>B2B</option><option>Other</option>
@@ -150,10 +150,10 @@
         </div>
       </div>
       <div class="mt-6 flex items-center justify-between">
-        <button on:click={() => goto('/dashboard')} class="text-sm text-gray-400 hover:text-gray-600 transition-colors duration-150 cursor-pointer">
+        <button on:click={() => goto('/dashboard')} class="text-sm text-ink-subtle hover:text-gray-600 transition-colors duration-150 cursor-pointer">
           {$_('onboarding.skip')}
         </button>
-        <button on:click={nextStep} disabled={!projectName} class="bg-primary-600 text-white px-6 py-2.5 rounded-lg font-medium hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={nextStep} disabled={!projectName} class="bg-brand text-white px-6 py-2.5 rounded-lg font-medium hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-150 text-sm cursor-pointer">
           {$_('onboarding.createAndContinue')}
         </button>
       </div>
@@ -161,12 +161,12 @@
 
     <!-- Step 2: Audience -->
     {#if step === 2}
-      <h2 class="text-lg font-semibold text-gray-900 mb-1">{$_('onboarding.step2Title')}</h2>
-      <p class="text-sm text-gray-500 mb-4">{$_('onboarding.step2Desc')}</p>
+      <h2 class="text-lg font-semibold text-ink mb-1">{$_('onboarding.step2Title')}</h2>
+      <p class="text-sm text-ink-muted mb-4">{$_('onboarding.step2Desc')}</p>
       <div class="space-y-4">
         <div>
-          <label for="ob-age" class="block text-sm font-medium text-gray-700 mb-1">{$_('onboarding.audienceAge')}</label>
-          <select id="ob-age" bind:value={audienceAgeRange} class="w-full px-3 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm cursor-pointer">
+          <label for="ob-age" class="block text-sm font-medium text-ink mb-1">{$_('onboarding.audienceAge')}</label>
+          <select id="ob-age" bind:value={audienceAgeRange} class="w-full px-3 py-2.5 border border-border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm cursor-pointer">
             <option value="">{$_('onboarding.audienceAgeAny')}</option>
             <option value="13-24">13–24</option>
             <option value="25-44">25–44</option>
@@ -175,20 +175,20 @@
           </select>
         </div>
         <div>
-          <label for="ob-audience" class="block text-sm font-medium text-gray-700 mb-1">{$_('onboarding.audienceLabel')}</label>
-          <textarea id="ob-audience" bind:value={audienceDescription} rows="2" class="w-full px-3 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm resize-none" placeholder={$_('onboarding.audiencePlaceholder')}></textarea>
+          <label for="ob-audience" class="block text-sm font-medium text-ink mb-1">{$_('onboarding.audienceLabel')}</label>
+          <textarea id="ob-audience" bind:value={audienceDescription} rows="2" class="w-full px-3 py-2.5 border border-border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm resize-none" placeholder={$_('onboarding.audiencePlaceholder')}></textarea>
         </div>
         <div>
-          <label for="ob-pain" class="block text-sm font-medium text-gray-700 mb-1">{$_('onboarding.painPointsLabel')}</label>
-          <textarea id="ob-pain" bind:value={audiencePainPoints} rows="2" class="w-full px-3 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm resize-none" placeholder={$_('onboarding.painPointsPlaceholder')}></textarea>
+          <label for="ob-pain" class="block text-sm font-medium text-ink mb-1">{$_('onboarding.painPointsLabel')}</label>
+          <textarea id="ob-pain" bind:value={audiencePainPoints} rows="2" class="w-full px-3 py-2.5 border border-border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm resize-none" placeholder={$_('onboarding.painPointsPlaceholder')}></textarea>
         </div>
       </div>
       <div class="mt-6 flex items-center justify-between">
-        <button on:click={prevStep} class="text-sm text-gray-500 hover:text-gray-700 transition-colors duration-150 cursor-pointer flex items-center gap-1">
+        <button on:click={prevStep} class="text-sm text-ink-muted hover:text-gray-700 transition-colors duration-150 cursor-pointer flex items-center gap-1">
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" /></svg>
           {$_('common.back')}
         </button>
-        <button on:click={nextStep} disabled={!audienceDescription} class="bg-primary-600 text-white px-6 py-2.5 rounded-lg font-medium hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={nextStep} disabled={!audienceDescription} class="bg-brand text-white px-6 py-2.5 rounded-lg font-medium hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.next')} →
         </button>
       </div>
@@ -196,16 +196,16 @@
 
     <!-- Step 3: Goals -->
     {#if step === 3}
-      <h2 class="text-lg font-semibold text-gray-900 mb-1">{$_('onboarding.step3Title')}</h2>
-      <p class="text-sm text-gray-500 mb-4">{$_('onboarding.step3Desc')}</p>
+      <h2 class="text-lg font-semibold text-ink mb-1">{$_('onboarding.step3Title')}</h2>
+      <p class="text-sm text-ink-muted mb-4">{$_('onboarding.step3Desc')}</p>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
         {#each goalOptions as goal}
           <button
             on:click={() => toggleGoal(goal.value)}
             class="flex items-center gap-2 p-3 rounded-lg border text-left transition-all duration-150 cursor-pointer text-sm
               {selectedGoals.includes(goal.value)
-                ? 'border-primary-500 bg-primary-50 text-primary-700 font-medium'
-                : 'border-gray-200 hover:border-primary-300 hover:bg-gray-50 text-gray-700'}"
+                ? 'border-primary-500 bg-brand-subtle/10 text-brand font-medium'
+                : 'border-border hover:border-primary-300 hover:bg-surface-2 text-ink'}"
           >
             <span class="text-base">{goal.emoji}</span>
             <span class="leading-tight">{$_(goal.labelKey)}</span>
@@ -213,12 +213,12 @@
         {/each}
       </div>
       <div class="mt-6 flex items-center justify-between">
-        <button on:click={prevStep} class="text-sm text-gray-500 hover:text-gray-700 transition-colors duration-150 cursor-pointer flex items-center gap-1">
+        <button on:click={prevStep} class="text-sm text-ink-muted hover:text-gray-700 transition-colors duration-150 cursor-pointer flex items-center gap-1">
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" /></svg>
           {$_('common.back')}
         </button>
         <button on:click={generatePlan} disabled={selectedGoals.length === 0 || planLoading}
-          class="bg-primary-600 text-white px-6 py-2.5 rounded-lg font-medium hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-150 text-sm cursor-pointer">
+          class="bg-brand text-white px-6 py-2.5 rounded-lg font-medium hover:brightness-110 disabled:opacity-50 disabled:cursor-not-allowed transition-colors duration-150 text-sm cursor-pointer">
           {planLoading ? $_('onboarding.generatingPlan') : $_('onboarding.createPlan')}
         </button>
       </div>
@@ -232,30 +232,30 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900 mb-1">{$_('onboarding.step4Title')}</h2>
-        <p class="text-sm text-gray-500 mb-5">{$_('onboarding.planReady')}</p>
-        <div class="bg-gray-50 rounded-xl p-4 text-left space-y-2.5 mb-6">
+        <h2 class="text-lg font-semibold text-ink mb-1">{$_('onboarding.step4Title')}</h2>
+        <p class="text-sm text-ink-muted mb-5">{$_('onboarding.planReady')}</p>
+        <div class="bg-surface-2 rounded-xl p-4 text-left space-y-2.5 mb-6">
           <div class="flex items-start gap-2.5">
             <div class="w-5 h-5 bg-green-100 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">
               <svg class="w-3 h-3 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" /></svg>
             </div>
-            <p class="text-sm text-gray-700">{$_('onboarding.planReadyAudience')}</p>
+            <p class="text-sm text-ink">{$_('onboarding.planReadyAudience')}</p>
           </div>
           <div class="flex items-start gap-2.5">
             <div class="w-5 h-5 bg-green-100 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">
               <svg class="w-3 h-3 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" /></svg>
             </div>
-            <p class="text-sm text-gray-700">{$_('onboarding.planReadyPlan')}</p>
+            <p class="text-sm text-ink">{$_('onboarding.planReadyPlan')}</p>
           </div>
           <div class="flex items-start gap-2.5">
             <div class="w-5 h-5 bg-green-100 rounded-full flex items-center justify-center flex-shrink-0 mt-0.5">
               <svg class="w-3 h-3 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12.75l6 6 9-13.5" /></svg>
             </div>
-            <p class="text-sm text-gray-700">{$_('onboarding.planReadyGoals', { values: { goals: selectedGoals.join(', ') } })}</p>
+            <p class="text-sm text-ink">{$_('onboarding.planReadyGoals', { values: { goals: selectedGoals.join(', ') } })}</p>
           </div>
         </div>
         <button on:click={acceptAndStart}
-          class="w-full bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 text-sm cursor-pointer">
+          class="w-full bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 text-sm cursor-pointer">
           {$_('onboarding.acceptAndStart')}
         </button>
       </div>

--- a/apps/web/src/routes/(app)/projects/[id]/analytics/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/analytics/+page.svelte
@@ -333,19 +333,19 @@
 
   {#if !surfacesLoaded}
     <div class="flex items-center justify-center py-20">
-      <div class="w-8 h-8 rounded-full border-2 border-gray-200 border-t-primary-600 animate-spin"></div>
+      <div class="w-8 h-8 rounded-full border-2 border-border border-t-primary-600 animate-spin"></div>
     </div>
   {:else}
     {#if showSurfaceTabs}
-      <div class="inline-flex bg-gray-100 rounded-lg p-0.5 mb-6">
+      <div class="inline-flex bg-surface-2 rounded-lg p-0.5 mb-6">
         <button on:click={() => switchSurface('web')}
           class="px-4 py-1.5 text-sm font-medium rounded-md transition-colors duration-150 cursor-pointer
-            {activeSurface === 'web' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'}">
+            {activeSurface === 'web' ? 'bg-surface text-ink shadow-sm' : 'text-ink-muted hover:text-gray-700'}">
           {$_('analytics.surface.web')}
         </button>
         <button on:click={() => switchSurface('app')}
           class="px-4 py-1.5 text-sm font-medium rounded-md transition-colors duration-150 cursor-pointer
-            {activeSurface === 'app' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'}">
+            {activeSurface === 'app' ? 'bg-surface text-ink shadow-sm' : 'text-ink-muted hover:text-gray-700'}">
           {$_('analytics.surface.app')}
         </button>
       </div>
@@ -357,14 +357,14 @@
     {:else}
   <div class="flex items-center justify-between mb-6">
     <div>
-      <h1 class="text-2xl font-bold text-gray-900">{$_('analytics.title')}</h1>
-      <p class="text-sm text-gray-500 mt-1">{$_('analytics.subtitle')}</p>
+      <h1 class="text-2xl font-bold text-ink">{$_('analytics.title')}</h1>
+      <p class="text-sm text-ink-muted mt-1">{$_('analytics.subtitle')}</p>
     </div>
-    <div class="flex bg-gray-100 rounded-lg p-0.5">
+    <div class="flex bg-surface-2 rounded-lg p-0.5">
       {#each [7, 30, 90] as period}
         <button on:click={() => switchPeriod(period)}
           class="px-3 py-1.5 text-sm font-medium rounded-md transition-colors duration-150
-            {selectedPeriod === period ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'}">
+            {selectedPeriod === period ? 'bg-surface text-ink shadow-sm' : 'text-ink-muted hover:text-gray-700'}">
           {$_('analytics.period' + period)}
         </button>
       {/each}
@@ -378,11 +378,11 @@
   <InstagramAnalyticsDashboard projectId={projectId ?? ''} />
 
   <!-- Tabs -->
-  <div class="flex border-b border-gray-200 mb-6">
+  <div class="flex border-b border-border mb-6">
     {#each tabs as tab}
       <button on:click={() => switchTab(tab.id)}
         class="px-4 py-2.5 text-sm font-medium border-b-2 transition-colors duration-150 -mb-px cursor-pointer
-          {activeTab === tab.id ? 'border-primary-600 text-primary-600' : 'border-transparent text-gray-500 hover:text-gray-700'}">
+          {activeTab === tab.id ? 'border-primary-600 text-brand' : 'border-transparent text-ink-muted hover:text-gray-700'}">
         {$_(tab.labelKey)}
       </button>
     {/each}
@@ -403,42 +403,42 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
           </svg>
         </div>
-        <h2 class="text-xl font-semibold text-gray-900 mb-2">{$_('analytics.empty')}</h2>
-        <p class="text-gray-500 max-w-md">{$_('analytics.emptyDesc')}</p>
+        <h2 class="text-xl font-semibold text-ink mb-2">{$_('analytics.empty')}</h2>
+        <p class="text-ink-muted max-w-md">{$_('analytics.emptyDesc')}</p>
       </div>
     {:else}
       <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
         {#each kpiCards as card}
-          <div class="bg-white rounded-xl border border-gray-200 p-4 border-t-4 {card.borderColor}">
+          <div class="bg-surface rounded-xl border border-border p-4 border-t-4 {card.borderColor}">
             <div class="flex items-center justify-between mb-3">
               <div class="w-9 h-9 {card.color} rounded-lg flex items-center justify-center flex-shrink-0">{@html card.icon}</div>
               {#if card.change !== 0}
-                <span class="text-xs font-medium flex items-center gap-0.5 {card.trend === 'up' ? 'text-green-600' : card.trend === 'down' ? 'text-red-500' : 'text-gray-400'}">
+                <span class="text-xs font-medium flex items-center gap-0.5 {card.trend === 'up' ? 'text-green-600' : card.trend === 'down' ? 'text-red-500' : 'text-ink-subtle'}">
                   {#if card.trend === 'up'}<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 19.5l15-15m0 0H8.25m11.25 0v11.25" /></svg>
                   {:else if card.trend === 'down'}<svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 4.5l15 15m0 0V8.25m0 11.25H8.25" /></svg>{/if}
                   {card.change > 0 ? '+' : ''}{card.change}%
                 </span>
               {/if}
             </div>
-            <div class="text-2xl font-bold text-gray-900">{card.value}</div>
-            <div class="text-xs text-gray-500 mt-1">{$_(card.labelKey)}</div>
+            <div class="text-2xl font-bold text-ink">{card.value}</div>
+            <div class="text-xs text-ink-muted mt-1">{$_(card.labelKey)}</div>
           </div>
         {/each}
       </div>
 
-      <div class="bg-white rounded-xl border border-gray-200 p-5 mb-6">
-        <h3 class="text-sm font-semibold text-gray-700 mb-4">{$_('analytics.trafficOverview')}</h3>
+      <div class="bg-surface rounded-xl border border-border p-5 mb-6">
+        <h3 class="text-sm font-semibold text-ink mb-4">{$_('analytics.trafficOverview')}</h3>
         <div class="relative" style="height: 288px;"><canvas bind:this={trafficCanvas} style="width: 100%; height: 100%;"></canvas></div>
       </div>
 
-      <div class="bg-white rounded-xl border border-gray-200 p-5 mb-6">
-        <h3 class="text-sm font-semibold text-gray-700 mb-4">{$_('analytics.emailPerformance')}</h3>
+      <div class="bg-surface rounded-xl border border-border p-5 mb-6">
+        <h3 class="text-sm font-semibold text-ink mb-4">{$_('analytics.emailPerformance')}</h3>
         <div class="relative" style="height: 256px;"><canvas bind:this={emailCanvas} style="width: 100%; height: 100%;"></canvas></div>
       </div>
 
       <div class="max-w-md mx-auto">
-        <div class="bg-white rounded-xl border border-gray-200 p-5">
-          <h3 class="text-sm font-semibold text-gray-700 mb-4 text-center">{$_('analytics.conversionFunnel')}</h3>
+        <div class="bg-surface rounded-xl border border-border p-5">
+          <h3 class="text-sm font-semibold text-ink mb-4 text-center">{$_('analytics.conversionFunnel')}</h3>
           <div class="relative" style="height: 256px;"><canvas bind:this={funnelCanvas} style="width: 100%; height: 100%;"></canvas></div>
         </div>
       </div>
@@ -452,32 +452,32 @@
         <div class="w-16 h-16 bg-blue-50 rounded-2xl flex items-center justify-center mb-4">
           <svg class="w-8 h-8 text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 011.242 7.244l-4.5 4.5a4.5 4.5 0 01-6.364-6.364l1.757-1.757m13.35-.622l1.757-1.757a4.5 4.5 0 00-6.364-6.364l-4.5 4.5a4.5 4.5 0 001.242 7.244" /></svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900 mb-2">{$_('analytics.utmEmpty')}</h2>
-        <p class="text-sm text-gray-500 max-w-sm">{$_('analytics.utmEmptyDesc')}</p>
+        <h2 class="text-lg font-semibold text-ink mb-2">{$_('analytics.utmEmpty')}</h2>
+        <p class="text-sm text-ink-muted max-w-sm">{$_('analytics.utmEmptyDesc')}</p>
       </div>
     {:else}
-      <div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
+      <div class="bg-surface rounded-xl border border-border overflow-hidden">
         <table class="w-full">
           <thead>
-            <tr class="border-b border-gray-200 bg-gray-50">
-              <th class="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase">{$_('analytics.utmSource')}</th>
-              <th class="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase">{$_('analytics.utmMedium')}</th>
-              <th class="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase">{$_('analytics.utmCampaign')}</th>
-              <th class="text-right px-4 py-3 text-xs font-semibold text-gray-500 uppercase">{$_('analytics.visits')}</th>
-              <th class="text-right px-4 py-3 text-xs font-semibold text-gray-500 uppercase">{$_('analytics.conversions')}</th>
-              <th class="text-right px-4 py-3 text-xs font-semibold text-gray-500 uppercase">{$_('analytics.conversionRate')}</th>
+            <tr class="border-b border-border bg-surface-2">
+              <th class="text-left px-4 py-3 text-xs font-semibold text-ink-muted uppercase">{$_('analytics.utmSource')}</th>
+              <th class="text-left px-4 py-3 text-xs font-semibold text-ink-muted uppercase">{$_('analytics.utmMedium')}</th>
+              <th class="text-left px-4 py-3 text-xs font-semibold text-ink-muted uppercase">{$_('analytics.utmCampaign')}</th>
+              <th class="text-right px-4 py-3 text-xs font-semibold text-ink-muted uppercase">{$_('analytics.visits')}</th>
+              <th class="text-right px-4 py-3 text-xs font-semibold text-ink-muted uppercase">{$_('analytics.conversions')}</th>
+              <th class="text-right px-4 py-3 text-xs font-semibold text-ink-muted uppercase">{$_('analytics.conversionRate')}</th>
             </tr>
           </thead>
           <tbody>
             {#each utmData as row}
-              <tr class="border-b border-gray-100 hover:bg-gray-50">
-                <td class="px-4 py-3 text-sm font-medium text-gray-900">{row.source || '(direct)'}</td>
-                <td class="px-4 py-3 text-sm text-gray-600">{row.medium || '—'}</td>
-                <td class="px-4 py-3 text-sm text-gray-600">{row.campaign || '—'}</td>
-                <td class="px-4 py-3 text-sm text-gray-900 text-right font-medium">{formatNumber(row.visits)}</td>
-                <td class="px-4 py-3 text-sm text-gray-900 text-right">{formatNumber(row.conversions)}</td>
+              <tr class="border-b border-border hover:bg-surface-2">
+                <td class="px-4 py-3 text-sm font-medium text-ink">{row.source || '(direct)'}</td>
+                <td class="px-4 py-3 text-sm text-ink-muted">{row.medium || '—'}</td>
+                <td class="px-4 py-3 text-sm text-ink-muted">{row.campaign || '—'}</td>
+                <td class="px-4 py-3 text-sm text-ink text-right font-medium">{formatNumber(row.visits)}</td>
+                <td class="px-4 py-3 text-sm text-ink text-right">{formatNumber(row.conversions)}</td>
                 <td class="px-4 py-3 text-right">
-                  <span class="text-sm font-medium {row.conversionRate > 5 ? 'text-green-600' : row.conversionRate > 2 ? 'text-amber-600' : 'text-gray-600'}">
+                  <span class="text-sm font-medium {row.conversionRate > 5 ? 'text-green-600' : row.conversionRate > 2 ? 'text-amber-600' : 'text-ink-muted'}">
                     {row.conversionRate?.toFixed(1)}%
                   </span>
                 </td>
@@ -496,22 +496,22 @@
         <div class="w-16 h-16 bg-purple-50 rounded-2xl flex items-center justify-center mb-4">
           <svg class="w-8 h-8 text-purple-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M12 3c2.755 0 5.455.232 8.083.678.533.09.917.556.917 1.096v1.044a2.25 2.25 0 01-.659 1.591l-5.432 5.432a2.25 2.25 0 00-.659 1.591v2.927a2.25 2.25 0 01-1.244 2.013L9.75 21v-6.568a2.25 2.25 0 00-.659-1.591L3.659 7.409A2.25 2.25 0 013 5.818V4.774c0-.54.384-1.006.917-1.096A48.32 48.32 0 0112 3z" /></svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900 mb-2">{$_('analytics.funnelEmpty')}</h2>
-        <p class="text-sm text-gray-500 max-w-sm">{$_('analytics.funnelEmptyDesc')}</p>
+        <h2 class="text-lg font-semibold text-ink mb-2">{$_('analytics.funnelEmpty')}</h2>
+        <p class="text-sm text-ink-muted max-w-sm">{$_('analytics.funnelEmptyDesc')}</p>
       </div>
     {:else}
       <div class="max-w-2xl mx-auto space-y-3">
         {#each funnelData.steps as step, i}
           {@const maxCount = funnelData.steps[0]?.count || 1}
           {@const widthPct = Math.max(10, (step.count / maxCount) * 100)}
-          <div class="bg-white rounded-xl border border-gray-200 p-4">
+          <div class="bg-surface rounded-xl border border-border p-4">
             <div class="flex items-center justify-between mb-2">
               <div class="flex items-center gap-2">
-                <span class="w-6 h-6 bg-primary-100 text-primary-700 rounded-full text-xs font-bold flex items-center justify-center">{i + 1}</span>
-                <span class="text-sm font-medium text-gray-900">{step.name}</span>
+                <span class="w-6 h-6 bg-primary-100 text-brand rounded-full text-xs font-bold flex items-center justify-center">{i + 1}</span>
+                <span class="text-sm font-medium text-ink">{step.name}</span>
               </div>
               <div class="flex items-center gap-3">
-                <span class="text-sm font-bold text-gray-900">{formatNumber(step.count)}</span>
+                <span class="text-sm font-bold text-ink">{formatNumber(step.count)}</span>
                 {#if i > 0}
                   <span class="text-xs font-medium {step.dropOff > 50 ? 'text-red-500' : step.dropOff > 25 ? 'text-amber-500' : 'text-green-500'}">
                     -{step.dropOff?.toFixed(1)}%
@@ -519,15 +519,15 @@
                 {/if}
               </div>
             </div>
-            <div class="w-full bg-gray-100 rounded-full h-3">
+            <div class="w-full bg-surface-2 rounded-full h-3">
               <div class="h-3 rounded-full transition-all duration-500 {i === 0 ? 'bg-primary-500' : i === funnelData.steps.length - 1 ? 'bg-green-500' : 'bg-primary-400'}"
                 style="width: {widthPct}%"></div>
             </div>
           </div>
         {/each}
         {#if funnelData.overallConversionRate !== undefined}
-          <div class="bg-primary-50 border border-primary-200 rounded-xl p-4 text-center mt-6">
-            <p class="text-sm text-primary-700">{$_('analytics.overallConversion')}</p>
+          <div class="bg-brand-subtle/10 border border-primary-200 rounded-xl p-4 text-center mt-6">
+            <p class="text-sm text-brand">{$_('analytics.overallConversion')}</p>
             <p class="text-3xl font-bold text-primary-800 mt-1">{funnelData.overallConversionRate?.toFixed(1)}%</p>
           </div>
         {/if}
@@ -542,30 +542,30 @@
         <div class="w-16 h-16 bg-amber-50 rounded-2xl flex items-center justify-center mb-4">
           <svg class="w-8 h-8 text-amber-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" /></svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900 mb-2">{$_('analytics.pagesEmpty')}</h2>
-        <p class="text-sm text-gray-500 max-w-sm">{$_('analytics.pagesEmptyDesc')}</p>
+        <h2 class="text-lg font-semibold text-ink mb-2">{$_('analytics.pagesEmpty')}</h2>
+        <p class="text-sm text-ink-muted max-w-sm">{$_('analytics.pagesEmptyDesc')}</p>
       </div>
     {:else}
-      <div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
+      <div class="bg-surface rounded-xl border border-border overflow-hidden">
         <table class="w-full">
           <thead>
-            <tr class="border-b border-gray-200 bg-gray-50">
-              <th class="text-left px-4 py-3 text-xs font-semibold text-gray-500 uppercase">{$_('analytics.pagePath')}</th>
-              <th class="text-right px-4 py-3 text-xs font-semibold text-gray-500 uppercase">{$_('analytics.pageViews')}</th>
-              <th class="text-right px-4 py-3 text-xs font-semibold text-gray-500 uppercase">{$_('analytics.uniqueVisitors')}</th>
-              <th class="text-right px-4 py-3 text-xs font-semibold text-gray-500 uppercase">{$_('analytics.conversions')}</th>
-              <th class="text-right px-4 py-3 text-xs font-semibold text-gray-500 uppercase">{$_('analytics.conversionRate')}</th>
+            <tr class="border-b border-border bg-surface-2">
+              <th class="text-left px-4 py-3 text-xs font-semibold text-ink-muted uppercase">{$_('analytics.pagePath')}</th>
+              <th class="text-right px-4 py-3 text-xs font-semibold text-ink-muted uppercase">{$_('analytics.pageViews')}</th>
+              <th class="text-right px-4 py-3 text-xs font-semibold text-ink-muted uppercase">{$_('analytics.uniqueVisitors')}</th>
+              <th class="text-right px-4 py-3 text-xs font-semibold text-ink-muted uppercase">{$_('analytics.conversions')}</th>
+              <th class="text-right px-4 py-3 text-xs font-semibold text-ink-muted uppercase">{$_('analytics.conversionRate')}</th>
             </tr>
           </thead>
           <tbody>
             {#each pagesData as pg}
-              <tr class="border-b border-gray-100 hover:bg-gray-50">
-                <td class="px-4 py-3 text-sm font-medium text-gray-900 max-w-xs truncate">{pg.path}</td>
-                <td class="px-4 py-3 text-sm text-gray-900 text-right">{formatNumber(pg.views)}</td>
-                <td class="px-4 py-3 text-sm text-gray-600 text-right">{formatNumber(pg.uniqueVisitors)}</td>
-                <td class="px-4 py-3 text-sm text-gray-900 text-right">{formatNumber(pg.conversions)}</td>
+              <tr class="border-b border-border hover:bg-surface-2">
+                <td class="px-4 py-3 text-sm font-medium text-ink max-w-xs truncate">{pg.path}</td>
+                <td class="px-4 py-3 text-sm text-ink text-right">{formatNumber(pg.views)}</td>
+                <td class="px-4 py-3 text-sm text-ink-muted text-right">{formatNumber(pg.uniqueVisitors)}</td>
+                <td class="px-4 py-3 text-sm text-ink text-right">{formatNumber(pg.conversions)}</td>
                 <td class="px-4 py-3 text-right">
-                  <span class="text-sm font-medium {pg.conversionRate > 5 ? 'text-green-600' : pg.conversionRate > 2 ? 'text-amber-600' : 'text-gray-600'}">
+                  <span class="text-sm font-medium {pg.conversionRate > 5 ? 'text-green-600' : pg.conversionRate > 2 ? 'text-amber-600' : 'text-ink-muted'}">
                     {pg.conversionRate?.toFixed(1)}%
                   </span>
                 </td>

--- a/apps/web/src/routes/(app)/projects/[id]/calendar/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/calendar/+page.svelte
@@ -43,7 +43,7 @@
   const CONTENT_TYPES = ['SOCIAL_POST', 'BLOG_ARTICLE', 'EMAIL', 'NEWSLETTER', 'AD_COPY', 'LANDING_PAGE'];
 
   const statusBadge: Record<string, string> = {
-    DRAFT: 'bg-gray-100 text-gray-600',
+    DRAFT: 'bg-surface-2 text-ink-muted',
     REVIEW: 'bg-yellow-100 text-yellow-700',
     APPROVED: 'bg-green-100 text-green-700',
     PUBLISHED: 'bg-blue-100 text-blue-700',
@@ -312,25 +312,25 @@
   <SectionHint sectionKey="calendar" titleKey="hints.calendar.title" descKey="hints.calendar.desc" />
   <!-- Header -->
   <div class="flex items-center justify-between mb-5">
-    <h1 class="text-2xl font-bold text-gray-900">{$_('calendar.title')}</h1>
+    <h1 class="text-2xl font-bold text-ink">{$_('calendar.title')}</h1>
     <div class="flex items-center gap-2">
       <!-- View toggle (desktop only) -->
-      <div class="hidden md:flex items-center border border-gray-300 rounded-lg overflow-hidden">
+      <div class="hidden md:flex items-center border border-border rounded-lg overflow-hidden">
         <button on:click={() => viewMode = 'month'}
           class="text-xs px-3 py-1.5 transition-colors duration-150 cursor-pointer
-            {viewMode === 'month' ? 'bg-primary-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}">
+            {viewMode === 'month' ? 'bg-brand text-white' : 'bg-surface text-ink-muted hover:bg-surface-2'}">
           {$_('calendar.monthView')}
         </button>
         <button on:click={() => { viewMode = 'week'; currentWeekStart = getWeekStart(new Date(currentYear, currentMonth, 1)); }}
           class="text-xs px-3 py-1.5 transition-colors duration-150 cursor-pointer
-            {viewMode === 'week' ? 'bg-primary-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}">
+            {viewMode === 'week' ? 'bg-brand text-white' : 'bg-surface text-ink-muted hover:bg-surface-2'}">
           {$_('calendar.weekView')}
         </button>
       </div>
       <!-- Today button -->
       <button on:click={goToToday}
-        class="text-xs px-3 py-1.5 border border-gray-300 rounded-lg bg-white hover:bg-gray-50
-               transition-colors duration-150 cursor-pointer font-medium text-gray-700">
+        class="text-xs px-3 py-1.5 border border-border rounded-lg bg-surface hover:bg-surface-2
+               transition-colors duration-150 cursor-pointer font-medium text-ink">
         {$_('calendar.today')}
       </button>
     </div>
@@ -341,17 +341,17 @@
     <!-- Month/week navigation -->
     <div class="flex items-center gap-2">
       <button on:click={() => viewMode === 'week' ? prevWeek() : prevMonth()}
-        class="p-1.5 rounded-lg border border-gray-300 hover:bg-gray-50 transition-colors duration-150 cursor-pointer">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        class="p-1.5 rounded-lg border border-border hover:bg-surface-2 transition-colors duration-150 cursor-pointer">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-ink-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
         </svg>
       </button>
-      <h2 class="text-lg font-semibold text-gray-900 min-w-[180px] text-center capitalize">
+      <h2 class="text-lg font-semibold text-ink min-w-[180px] text-center capitalize">
         {formatMonthYear(currentYear, currentMonth)}
       </h2>
       <button on:click={() => viewMode === 'week' ? nextWeek() : nextMonth()}
-        class="p-1.5 rounded-lg border border-gray-300 hover:bg-gray-50 transition-colors duration-150 cursor-pointer">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        class="p-1.5 rounded-lg border border-border hover:bg-surface-2 transition-colors duration-150 cursor-pointer">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-ink-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
         </svg>
       </button>
@@ -360,7 +360,7 @@
     <!-- Filters -->
     <div class="flex items-center gap-2">
       <select bind:value={filterStatus}
-        class="text-xs px-2 py-1.5 border border-gray-300 rounded-lg bg-white cursor-pointer
+        class="text-xs px-2 py-1.5 border border-border rounded-lg bg-surface cursor-pointer
                focus:outline-none focus:ring-2 focus:ring-primary-500">
         <option value="">{$_('calendar.allStatuses')}</option>
         {#each STATUSES as s}
@@ -368,7 +368,7 @@
         {/each}
       </select>
       <select bind:value={filterType}
-        class="text-xs px-2 py-1.5 border border-gray-300 rounded-lg bg-white cursor-pointer
+        class="text-xs px-2 py-1.5 border border-border rounded-lg bg-surface cursor-pointer
                focus:outline-none focus:ring-2 focus:ring-primary-500">
         <option value="">{$_('calendar.allTypes')}</option>
         {#each CONTENT_TYPES as t}
@@ -380,7 +380,7 @@
 
   <!-- Campaign legend -->
   {#if activeCampaigns.length > 0}
-    <div class="flex flex-wrap items-center gap-3 mb-3 text-xs text-gray-500">
+    <div class="flex flex-wrap items-center gap-3 mb-3 text-xs text-ink-muted">
       {#each activeCampaigns as campaign, idx}
         <span class="flex items-center gap-1.5">
           <span class="w-3 h-3 rounded {campaignLegendColors[idx % campaignLegendColors.length]}"></span>
@@ -392,20 +392,20 @@
 
   {#if loading}
     <!-- Loading skeleton -->
-    <div class="bg-white rounded-xl border border-gray-200 p-4 flex-1 min-h-0">
+    <div class="bg-surface rounded-xl border border-border p-4 flex-1 min-h-0">
       <div class="grid grid-cols-7 gap-px h-full">
         {#each Array(42) as _}
-          <div class="bg-gray-50 rounded animate-pulse"></div>
+          <div class="bg-surface-2 rounded animate-pulse"></div>
         {/each}
       </div>
     </div>
   {:else if viewMode === 'month'}
     <!-- Month view -->
-    <div class="bg-white rounded-xl border border-gray-200 overflow-hidden flex-1 min-h-0 flex flex-col">
+    <div class="bg-surface rounded-xl border border-border overflow-hidden flex-1 min-h-0 flex flex-col">
       <!-- Day-of-week header -->
-      <div class="grid grid-cols-7 border-b border-gray-200 bg-gray-50/50 flex-shrink-0">
+      <div class="grid grid-cols-7 border-b border-border bg-surface-2/50 flex-shrink-0">
         {#each ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] as dayKey}
-          <div class="py-2.5 text-center text-xs font-medium text-gray-500 uppercase tracking-wide">
+          <div class="py-2.5 text-center text-xs font-medium text-ink-muted uppercase tracking-wide">
             {$_(`calendar.${dayKey}`)}
           </div>
         {/each}
@@ -424,8 +424,8 @@
           <!-- svelte-ignore a11y-click-events-have-key-events -->
           <!-- svelte-ignore a11y-no-static-element-interactions -->
           <div
-            class="min-h-[100px] p-1.5 border-b border-r border-gray-100 cursor-pointer
-                   hover:bg-gray-50/50 transition-colors duration-100
+            class="min-h-[100px] p-1.5 border-b border-r border-border cursor-pointer
+                   hover:bg-surface-2/50 transition-colors duration-100
                    flex flex-col overflow-hidden
                    {dayInfo.isCurrentMonth ? '' : 'opacity-40'}
                    {campBg}"
@@ -434,11 +434,11 @@
             <!-- Day number -->
             <div class="flex items-start justify-between mb-1 flex-shrink-0">
               {#if todayHighlight}
-                <span class="bg-primary-600 text-white text-xs font-semibold w-6 h-6 rounded-full flex items-center justify-center">
+                <span class="bg-brand text-white text-xs font-semibold w-6 h-6 rounded-full flex items-center justify-center">
                   {dayInfo.day}
                 </span>
               {:else}
-                <span class="text-xs font-medium text-gray-700 w-6 h-6 flex items-center justify-center">
+                <span class="text-xs font-medium text-ink w-6 h-6 flex items-center justify-center">
                   {dayInfo.day}
                 </span>
               {/if}
@@ -453,7 +453,7 @@
                   class="flex items-center gap-1 px-1.5 py-0.5 rounded
                          text-[10px] leading-tight truncate cursor-pointer
                          hover:opacity-80 transition-opacity duration-100
-                         {statusBadge[content.status] || 'bg-gray-100 text-gray-600'}"
+                         {statusBadge[content.status] || 'bg-surface-2 text-ink-muted'}"
                   on:click|stopPropagation={() => onContentClick(content)}
                   title={content.title}
                 >
@@ -477,31 +477,31 @@
         {@const dayContents = contentByDate[dateKey] || []}
         {@const todayHighlight = isSameDay(weekDay, today)}
 
-        <div class="bg-white rounded-xl border border-gray-200
+        <div class="bg-surface rounded-xl border border-border
           {todayHighlight ? 'border-primary-300 ring-1 ring-primary-100' : ''} p-3">
 
           <div class="flex items-center justify-between mb-2">
             <div class="flex items-center gap-2">
               <span class="text-sm font-semibold
-                {todayHighlight ? 'text-primary-600' : 'text-gray-900'}">
+                {todayHighlight ? 'text-brand' : 'text-ink'}">
                 {weekDay.toLocaleDateString(undefined, {
                   weekday: 'short', day: 'numeric', month: 'short'
                 })}
               </span>
               {#if todayHighlight}
-                <span class="text-[10px] px-1.5 py-0.5 bg-primary-100 text-primary-700
+                <span class="text-[10px] px-1.5 py-0.5 bg-primary-100 text-brand
                   rounded-full font-medium">
                   {todayLabel}
                 </span>
               {/if}
             </div>
-            <span class="text-xs text-gray-400">{dayContents.length}</span>
+            <span class="text-xs text-ink-subtle">{dayContents.length}</span>
           </div>
 
           {#if dayContents.length === 0}
             <!-- svelte-ignore a11y-click-events-have-key-events -->
             <!-- svelte-ignore a11y-no-static-element-interactions -->
-            <div class="text-xs text-gray-400 py-2 text-center cursor-pointer hover:text-primary-500 transition-colors duration-150"
+            <div class="text-xs text-ink-subtle py-2 text-center cursor-pointer hover:text-primary-500 transition-colors duration-150"
               on:click={() => onDayClick({
                 day: weekDay.getDate(),
                 month: weekDay.getMonth(),
@@ -514,14 +514,14 @@
               {#each dayContents as content (content.id)}
                 <!-- svelte-ignore a11y-click-events-have-key-events -->
                 <!-- svelte-ignore a11y-no-static-element-interactions -->
-                <div class="flex items-center gap-2 p-2 rounded-lg border border-gray-100
-                  cursor-pointer hover:bg-gray-50 transition-colors duration-150"
+                <div class="flex items-center gap-2 p-2 rounded-lg border border-border
+                  cursor-pointer hover:bg-surface-2 transition-colors duration-150"
                   on:click={() => onContentClick(content)}>
                   <span class="w-2 h-2 rounded-full flex-shrink-0
                     {statusDot[content.status]}"></span>
                   <div class="flex-1 min-w-0">
-                    <div class="text-sm font-medium text-gray-900 truncate">{content.title}</div>
-                    <div class="text-xs text-gray-500">{content.type.replace('_', ' ')}</div>
+                    <div class="text-sm font-medium text-ink truncate">{content.title}</div>
+                    <div class="text-xs text-ink-muted">{content.type.replace('_', ' ')}</div>
                   </div>
                   <span class="text-[10px] px-1.5 py-0.5 rounded
                     {statusBadge[content.status]}">
@@ -539,15 +539,15 @@
   <!-- Empty state (when no content at all and not loading) -->
   {#if !loading && contents.length === 0}
     <div class="flex flex-col items-center justify-center py-16 text-center">
-      <div class="w-20 h-20 bg-primary-50 rounded-2xl flex items-center justify-center mb-6">
+      <div class="w-20 h-20 bg-brand-subtle/10 rounded-2xl flex items-center justify-center mb-6">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
         </svg>
       </div>
-      <h2 class="text-xl font-semibold text-gray-900 mb-2">{$_('calendar.noContent')}</h2>
-      <p class="text-gray-500 mb-6">{$_('calendar.noContentDesc')}</p>
+      <h2 class="text-xl font-semibold text-ink mb-2">{$_('calendar.noContent')}</h2>
+      <p class="text-ink-muted mb-6">{$_('calendar.noContentDesc')}</p>
       <a href="/projects/{projectId}/content"
-        class="bg-primary-600 text-white px-6 py-3 rounded-xl font-medium hover:bg-primary-700
+        class="bg-brand text-white px-6 py-3 rounded-xl font-medium hover:brightness-110
                transition-colors duration-150 inline-flex items-center gap-2">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
@@ -563,13 +563,13 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex justify-end z-50" on:click|self={() => selectedContent = null}>
-    <div class="bg-white h-full w-full max-w-md shadow-2xl overflow-y-auto">
+    <div class="bg-surface h-full w-full max-w-md shadow-2xl overflow-y-auto">
       <!-- Header -->
-      <div class="p-6 border-b border-gray-100 flex items-center justify-between">
-        <h2 class="text-lg font-semibold text-gray-900">{$_('calendar.contentDetails')}</h2>
+      <div class="p-6 border-b border-border flex items-center justify-between">
+        <h2 class="text-lg font-semibold text-ink">{$_('calendar.contentDetails')}</h2>
         <button on:click={() => selectedContent = null}
-          class="p-1.5 rounded-lg hover:bg-gray-100 transition-colors duration-150 cursor-pointer">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          class="p-1.5 rounded-lg hover:bg-surface-2 transition-colors duration-150 cursor-pointer">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-ink-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
           </svg>
         </button>
@@ -578,7 +578,7 @@
       <div class="p-6 space-y-5">
         <!-- Badges -->
         <div class="flex flex-wrap items-center gap-1.5">
-          <span class="text-xs px-2 py-0.5 bg-gray-100 text-gray-600 rounded font-medium">
+          <span class="text-xs px-2 py-0.5 bg-surface-2 text-ink-muted rounded font-medium">
             {selectedContent.type.replace('_', ' ')}
           </span>
           {#if selectedContent.platform}
@@ -586,7 +586,7 @@
               {selectedContent.platform}
             </span>
           {/if}
-          <span class="text-xs px-2 py-0.5 rounded {statusBadge[selectedContent.status] || 'bg-gray-100 text-gray-600'}">
+          <span class="text-xs px-2 py-0.5 rounded {statusBadge[selectedContent.status] || 'bg-surface-2 text-ink-muted'}">
             {$_(statusLabel[selectedContent.status] || 'content.draft')}
           </span>
           {#if selectedContent.aiGenerated}
@@ -600,21 +600,21 @@
         </div>
 
         <!-- Title -->
-        <h3 class="text-xl font-semibold text-gray-900">{selectedContent.title}</h3>
+        <h3 class="text-xl font-semibold text-ink">{selectedContent.title}</h3>
 
         <!-- Body preview -->
-        <div class="text-sm text-gray-600 leading-relaxed whitespace-pre-wrap line-clamp-[10]">
+        <div class="text-sm text-ink-muted leading-relaxed whitespace-pre-wrap line-clamp-[10]">
           {selectedContent.body}
         </div>
 
         <!-- Schedule & campaign info -->
-        <div class="border-t border-gray-100 pt-4 space-y-3">
+        <div class="border-t border-border pt-4 space-y-3">
           <div class="flex items-center gap-2 text-sm">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-ink-subtle flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
             </svg>
             {#if selectedContent.scheduledAt}
-              <span class="text-gray-600">
+              <span class="text-ink-muted">
                 {$_('calendar.scheduledFor', {
                   values: {
                     date: new Date(selectedContent.scheduledAt)
@@ -623,24 +623,24 @@
                 })}
               </span>
             {:else}
-              <span class="text-gray-400 italic">{$_('calendar.unscheduled')}</span>
+              <span class="text-ink-subtle italic">{$_('calendar.unscheduled')}</span>
             {/if}
           </div>
           {#if selectedContent.campaign}
             <div class="flex items-center gap-2 text-sm">
-              <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-ink-subtle flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46" />
               </svg>
-              <span class="text-gray-500">{$_('calendar.campaign')}:</span>
-              <span class="font-medium text-gray-700">{selectedContent.campaign.name}</span>
+              <span class="text-ink-muted">{$_('calendar.campaign')}:</span>
+              <span class="font-medium text-ink">{selectedContent.campaign.name}</span>
             </div>
           {/if}
           {#if selectedContent.createdAt}
             <div class="flex items-center gap-2 text-sm">
-              <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-400 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-ink-subtle flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
               </svg>
-              <span class="text-gray-500">
+              <span class="text-ink-muted">
                 {$_('calendar.createdOn', {
                   values: {
                     date: new Date(selectedContent.createdAt)
@@ -653,14 +653,14 @@
         </div>
 
         <!-- Actions -->
-        <div class="border-t border-gray-100 pt-4 flex gap-2">
+        <div class="border-t border-border pt-4 flex gap-2">
           <a href="/projects/{projectId}/content"
-            class="flex-1 text-center bg-primary-600 text-white py-2.5 rounded-lg text-sm
-                   font-medium hover:bg-primary-700 transition-colors duration-150">
+            class="flex-1 text-center bg-brand text-white py-2.5 rounded-lg text-sm
+                   font-medium hover:brightness-110 transition-colors duration-150">
             {$_('calendar.viewDetails')}
           </a>
           <button on:click={() => selectedContent = null}
-            class="px-5 py-2.5 border border-gray-300 rounded-lg text-sm hover:bg-gray-50
+            class="px-5 py-2.5 border border-border rounded-lg text-sm hover:bg-surface-2
                    transition-colors duration-150 cursor-pointer">
             {$_('common.close')}
           </button>
@@ -675,16 +675,16 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => schedulingDate = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
-        <div class="w-8 h-8 bg-primary-50 rounded-lg flex items-center justify-center flex-shrink-0">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
+        <div class="w-8 h-8 bg-brand-subtle/10 rounded-lg flex items-center justify-center flex-shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M6.75 3v2.25M17.25 3v2.25M3 18.75V7.5a2.25 2.25 0 0 1 2.25-2.25h13.5A2.25 2.25 0 0 1 21 7.5v11.25m-18 0A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75m-18 0v-7.5A2.25 2.25 0 0 1 5.25 9h13.5A2.25 2.25 0 0 1 21 11.25v7.5" />
           </svg>
         </div>
         <div>
-          <h2 class="text-lg font-semibold text-gray-900">{$_('calendar.scheduleContent')}</h2>
-          <p class="text-xs text-gray-500">
+          <h2 class="text-lg font-semibold text-ink">{$_('calendar.scheduleContent')}</h2>
+          <p class="text-xs text-ink-muted">
             {new Date(schedulingDate + 'T12:00:00').toLocaleDateString(undefined, {
               weekday: 'long', day: 'numeric', month: 'long', year: 'numeric'
             })}
@@ -692,10 +692,10 @@
         </div>
       </div>
       <div class="p-6">
-        <p class="text-sm text-gray-600 mb-3">{$_('calendar.selectContent')}</p>
+        <p class="text-sm text-ink-muted mb-3">{$_('calendar.selectContent')}</p>
         {#if unscheduledContents.length === 0}
           <div class="text-center py-8">
-            <p class="text-sm text-gray-400">{$_('calendar.noUnscheduled')}</p>
+            <p class="text-sm text-ink-subtle">{$_('calendar.noUnscheduled')}</p>
           </div>
         {:else}
           <div class="space-y-2 max-h-[300px] overflow-y-auto">
@@ -704,14 +704,14 @@
                 on:click={() => scheduleContentOnDate(content.id)}
                 disabled={scheduling}
                 class="w-full text-left flex items-center gap-3 p-3 rounded-xl border
-                       border-gray-200 hover:border-primary-300 hover:bg-primary-50/50
+                       border-border hover:border-primary-300 hover:bg-brand-subtle/10
                        transition-colors duration-150 cursor-pointer disabled:opacity-50"
               >
                 <span class="w-2 h-2 rounded-full flex-shrink-0
                   {statusDot[content.status]}"></span>
                 <div class="flex-1 min-w-0">
-                  <div class="text-sm font-medium text-gray-900 truncate">{content.title}</div>
-                  <div class="text-xs text-gray-500">{content.type.replace('_', ' ')}</div>
+                  <div class="text-sm font-medium text-ink truncate">{content.title}</div>
+                  <div class="text-xs text-ink-muted">{content.type.replace('_', ' ')}</div>
                 </div>
                 <span class="text-[10px] px-1.5 py-0.5 rounded
                   {statusBadge[content.status]}">
@@ -722,9 +722,9 @@
           </div>
         {/if}
       </div>
-      <div class="p-6 border-t border-gray-100">
+      <div class="p-6 border-t border-border">
         <button on:click={() => schedulingDate = null}
-          class="w-full py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50
+          class="w-full py-2.5 border border-border rounded-lg hover:bg-surface-2
                  transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>

--- a/apps/web/src/routes/(app)/projects/[id]/campaigns/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/campaigns/+page.svelte
@@ -55,7 +55,7 @@
   const CAMPAIGN_STATUSES = ['DRAFT', 'SCHEDULED', 'ACTIVE', 'PAUSED', 'COMPLETED'];
 
   const statusBadge: Record<string, string> = {
-    DRAFT: 'bg-gray-100 text-gray-600',
+    DRAFT: 'bg-surface-2 text-ink-muted',
     SCHEDULED: 'bg-yellow-100 text-yellow-700',
     ACTIVE: 'bg-green-100 text-green-700',
     PAUSED: 'bg-orange-100 text-orange-700',
@@ -185,10 +185,10 @@
 <div class="p-4 sm:p-6">
   <SectionHint sectionKey="campaigns" titleKey="hints.campaigns.title" descKey="hints.campaigns.desc" />
   <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 mb-6">
-    <h1 class="text-2xl font-bold text-gray-900">{$_('campaigns.title')}</h1>
+    <h1 class="text-2xl font-bold text-ink">{$_('campaigns.title')}</h1>
     <button
       on:click={() => showCreateModal = true}
-      class="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+      class="bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
     >
       <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -200,21 +200,21 @@
   {#if loading}
     <div class="space-y-3">
       {#each Array(4) as _}
-        <div class="bg-white rounded-xl border border-gray-200 p-4 animate-pulse h-24"></div>
+        <div class="bg-surface rounded-xl border border-border p-4 animate-pulse h-24"></div>
       {/each}
     </div>
   {:else if campaigns.length === 0}
     <div class="flex flex-col items-center justify-center py-20 text-center">
-      <div class="w-20 h-20 bg-primary-50 rounded-2xl flex items-center justify-center mb-6">
+      <div class="w-20 h-20 bg-brand-subtle/10 rounded-2xl flex items-center justify-center mb-6">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M10.34 15.84c-.688-.06-1.386-.09-2.09-.09H7.5a4.5 4.5 0 1 1 0-9h.75c.704 0 1.402-.03 2.09-.09m0 9.18c.253.962.584 1.892.985 2.783.247.55.06 1.21-.463 1.511l-.657.38c-.551.318-1.26.117-1.527-.461a20.845 20.845 0 0 1-1.44-4.282m3.102.069a18.03 18.03 0 0 1-.59-4.59c0-1.586.205-3.124.59-4.59m0 9.18a23.848 23.848 0 0 1 8.835 2.535M10.34 6.66a23.847 23.847 0 0 0 8.835-2.535m0 0A23.74 23.74 0 0 0 18.795 3m.38 1.125a23.91 23.91 0 0 1 1.014 5.395m-1.014 8.855c-.118.38-.245.754-.38 1.125m.38-1.125a23.91 23.91 0 0 0 1.014-5.395m0-3.46c.495.413.811 1.035.811 1.73 0 .695-.316 1.317-.811 1.73m0-3.46a24.347 24.347 0 0 1 0 3.46" />
         </svg>
       </div>
-      <h2 class="text-xl font-semibold text-gray-900 mb-2">{$_('campaigns.empty')}</h2>
-      <p class="text-gray-500 mb-6">{$_('campaigns.emptyDesc')}</p>
+      <h2 class="text-xl font-semibold text-ink mb-2">{$_('campaigns.empty')}</h2>
+      <p class="text-ink-muted mb-6">{$_('campaigns.emptyDesc')}</p>
       <button
         on:click={() => showCreateModal = true}
-        class="bg-primary-600 text-white px-6 py-3 rounded-xl font-medium hover:bg-primary-700 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+        class="bg-brand text-white px-6 py-3 rounded-xl font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -225,18 +225,18 @@
   {:else}
     <div class="space-y-3">
       {#each campaigns as campaign}
-        <a href="/projects/{projectId}/campaigns/{campaign.id}" class="block bg-white rounded-xl border border-gray-200 border-l-4 {statusBorderAccent[campaign.status] || 'border-l-gray-300'} p-5 hover:shadow-sm transition-shadow duration-150 cursor-pointer">
+        <a href="/projects/{projectId}/campaigns/{campaign.id}" class="block bg-surface rounded-xl border border-border border-l-4 {statusBorderAccent[campaign.status] || 'border-l-gray-300'} p-5 hover:shadow-sm transition-shadow duration-150 cursor-pointer">
           <div class="flex flex-col sm:flex-row items-start justify-between gap-3 sm:gap-4">
             <div class="flex-1 min-w-0">
               <div class="flex flex-wrap items-center gap-1.5 mb-2">
-                <span class="text-xs px-2 py-0.5 rounded font-medium {typeBadge[campaign.type] || 'bg-gray-100 text-gray-600'}">{$_(typeLabel[campaign.type] || 'campaigns.email')}</span>
-                <span class="text-xs px-2 py-0.5 rounded {statusBadge[campaign.status] || 'bg-gray-100 text-gray-600'}">{$_(statusLabel[campaign.status] || 'campaigns.draft')}</span>
+                <span class="text-xs px-2 py-0.5 rounded font-medium {typeBadge[campaign.type] || 'bg-surface-2 text-ink-muted'}">{$_(typeLabel[campaign.type] || 'campaigns.email')}</span>
+                <span class="text-xs px-2 py-0.5 rounded {statusBadge[campaign.status] || 'bg-surface-2 text-ink-muted'}">{$_(statusLabel[campaign.status] || 'campaigns.draft')}</span>
                 {#if campaign._count?.content > 0}
-                  <span class="text-xs px-2 py-0.5 bg-gray-50 text-gray-500 rounded">{$_('campaigns.contentCount', { values: { count: campaign._count.content } })}</span>
+                  <span class="text-xs px-2 py-0.5 bg-surface-2 text-ink-muted rounded">{$_('campaigns.contentCount', { values: { count: campaign._count.content } })}</span>
                 {/if}
               </div>
-              <h3 class="font-medium text-gray-900 truncate">{campaign.name}</h3>
-              <div class="flex flex-wrap items-center gap-3 mt-1.5 text-xs text-gray-500">
+              <h3 class="font-medium text-ink truncate">{campaign.name}</h3>
+              <div class="flex flex-wrap items-center gap-3 mt-1.5 text-xs text-ink-muted">
                 {#if campaign.startDate || campaign.endDate}
                   <span class="flex items-center gap-1">
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -257,7 +257,7 @@
                 {/if}
               </div>
               {#if campaign.goals}
-                <p class="text-sm text-gray-500 mt-1.5 line-clamp-1">{campaign.goals}</p>
+                <p class="text-sm text-ink-muted mt-1.5 line-clamp-1">{campaign.goals}</p>
               {/if}
             </div>
             <div class="flex items-center gap-2 flex-shrink-0 flex-wrap">
@@ -265,7 +265,7 @@
                 value={campaign.status}
                 on:click|preventDefault|stopPropagation
                 on:change={e => updateStatus(campaign.id, (e.target as HTMLSelectElement).value)}
-                class="text-xs px-2 py-1.5 border border-gray-300 rounded-lg bg-white hover:bg-gray-50 transition-colors duration-150 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-500"
+                class="text-xs px-2 py-1.5 border border-border rounded-lg bg-surface hover:bg-surface-2 transition-colors duration-150 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-500"
               >
                 {#each CAMPAIGN_STATUSES as s}
                   <option value={s}>{$_(statusLabel[s])}</option>
@@ -273,7 +273,7 @@
               </select>
               <button
                 on:click|preventDefault|stopPropagation={() => openEdit(campaign)}
-                class="text-xs px-3 py-1.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
+                class="text-xs px-3 py-1.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
               >
                 {$_('common.edit')}
               </button>
@@ -299,23 +299,23 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showCreateModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md max-h-[calc(100vh-2rem)] flex flex-col">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5 flex-shrink-0">
-        <div class="w-8 h-8 bg-primary-50 rounded-lg flex items-center justify-center flex-shrink-0">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md max-h-[calc(100vh-2rem)] flex flex-col">
+      <div class="p-6 border-b border-border flex items-center gap-2.5 flex-shrink-0">
+        <div class="w-8 h-8 bg-brand-subtle/10 rounded-lg flex items-center justify-center flex-shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900">{$_('campaigns.create')}</h2>
+        <h2 class="text-lg font-semibold text-ink">{$_('campaigns.create')}</h2>
       </div>
       <div class="p-6 space-y-4 overflow-y-auto flex-1">
         <div>
-          <label for="c-name" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.name')} *</label>
-          <input id="c-name" type="text" bind:value={createForm.name} placeholder={$_('campaigns.namePlaceholder')} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
+          <label for="c-name" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.name')} *</label>
+          <input id="c-name" type="text" bind:value={createForm.name} placeholder={$_('campaigns.namePlaceholder')} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
         </div>
         <div>
-          <label for="c-type" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.type')}</label>
-          <select id="c-type" bind:value={createForm.type} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+          <label for="c-type" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.type')}</label>
+          <select id="c-type" bind:value={createForm.type} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
             {#each CAMPAIGN_TYPES as t}
               <option value={t}>{$_(typeLabel[t])}</option>
             {/each}
@@ -323,28 +323,28 @@
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>
-            <label for="c-start" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.startDate')}</label>
-            <input id="c-start" type="date" bind:value={createForm.startDate} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
+            <label for="c-start" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.startDate')}</label>
+            <input id="c-start" type="date" bind:value={createForm.startDate} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
           </div>
           <div>
-            <label for="c-end" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.endDate')}</label>
-            <input id="c-end" type="date" bind:value={createForm.endDate} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
+            <label for="c-end" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.endDate')}</label>
+            <input id="c-end" type="date" bind:value={createForm.endDate} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
           </div>
         </div>
         <div>
-          <label for="c-budget" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.budget')}</label>
-          <input id="c-budget" type="number" step="0.01" min="0" bind:value={createForm.budget} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
+          <label for="c-budget" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.budget')}</label>
+          <input id="c-budget" type="number" step="0.01" min="0" bind:value={createForm.budget} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
         </div>
         <div>
-          <label for="c-goals" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.goals')}</label>
-          <textarea id="c-goals" bind:value={createForm.goals} rows="3" placeholder={$_('campaigns.goalsPlaceholder')} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"></textarea>
+          <label for="c-goals" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.goals')}</label>
+          <textarea id="c-goals" bind:value={createForm.goals} rows="3" placeholder={$_('campaigns.goalsPlaceholder')} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"></textarea>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3 flex-shrink-0">
+      <div class="p-6 border-t border-border flex gap-3 flex-shrink-0">
         <button
           on:click={createCampaign}
           disabled={creating || !createForm.name.trim()}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
         >
           {#if creating}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -356,7 +356,7 @@
             {$_('campaigns.create')}
           {/if}
         </button>
-        <button on:click={() => showCreateModal = false} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={() => showCreateModal = false} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>
@@ -369,32 +369,32 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => editingCampaign = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-lg max-h-[calc(100vh-2rem)] flex flex-col">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5 flex-shrink-0">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-lg max-h-[calc(100vh-2rem)] flex flex-col">
+      <div class="p-6 border-b border-border flex items-center gap-2.5 flex-shrink-0">
         <div class="w-8 h-8 bg-blue-50 rounded-lg flex items-center justify-center flex-shrink-0">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900">{$_('campaigns.editCampaign')}</h2>
+        <h2 class="text-lg font-semibold text-ink">{$_('campaigns.editCampaign')}</h2>
       </div>
       <div class="p-6 space-y-4 overflow-y-auto flex-1">
         <div>
-          <label for="e-name" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.name')} *</label>
-          <input id="e-name" type="text" bind:value={editForm.name} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
+          <label for="e-name" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.name')} *</label>
+          <input id="e-name" type="text" bind:value={editForm.name} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>
-            <label for="e-type" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.type')}</label>
-            <select id="e-type" bind:value={editForm.type} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+            <label for="e-type" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.type')}</label>
+            <select id="e-type" bind:value={editForm.type} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
               {#each CAMPAIGN_TYPES as t}
                 <option value={t}>{$_(typeLabel[t])}</option>
               {/each}
             </select>
           </div>
           <div>
-            <label for="e-status" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.status')}</label>
-            <select id="e-status" bind:value={editForm.status} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+            <label for="e-status" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.status')}</label>
+            <select id="e-status" bind:value={editForm.status} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
               {#each CAMPAIGN_STATUSES as s}
                 <option value={s}>{$_(statusLabel[s])}</option>
               {/each}
@@ -403,28 +403,28 @@
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>
-            <label for="e-start" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.startDate')}</label>
-            <input id="e-start" type="date" bind:value={editForm.startDate} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
+            <label for="e-start" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.startDate')}</label>
+            <input id="e-start" type="date" bind:value={editForm.startDate} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
           </div>
           <div>
-            <label for="e-end" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.endDate')}</label>
-            <input id="e-end" type="date" bind:value={editForm.endDate} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
+            <label for="e-end" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.endDate')}</label>
+            <input id="e-end" type="date" bind:value={editForm.endDate} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
           </div>
         </div>
         <div>
-          <label for="e-budget" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.budget')}</label>
-          <input id="e-budget" type="number" step="0.01" min="0" bind:value={editForm.budget} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
+          <label for="e-budget" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.budget')}</label>
+          <input id="e-budget" type="number" step="0.01" min="0" bind:value={editForm.budget} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
         </div>
         <div>
-          <label for="e-goals" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('campaigns.goals')}</label>
-          <textarea id="e-goals" bind:value={editForm.goals} rows="3" placeholder={$_('campaigns.goalsPlaceholder')} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"></textarea>
+          <label for="e-goals" class="block text-sm font-medium text-ink mb-1.5">{$_('campaigns.goals')}</label>
+          <textarea id="e-goals" bind:value={editForm.goals} rows="3" placeholder={$_('campaigns.goalsPlaceholder')} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"></textarea>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3 flex-shrink-0">
+      <div class="p-6 border-t border-border flex gap-3 flex-shrink-0">
         <button
           on:click={saveEdit}
           disabled={editSaving}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
         >
           {#if editSaving}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -436,7 +436,7 @@
             {$_('common.save')}
           {/if}
         </button>
-        <button on:click={() => editingCampaign = null} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={() => editingCampaign = null} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>
@@ -449,15 +449,15 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => deletingId = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm">
       <div class="p-6">
         <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-4">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900 mb-2">{$_('campaigns.deleteCampaign')}</h2>
-        <p class="text-sm text-gray-500 mb-6">{$_('campaigns.confirmDelete')}</p>
+        <h2 class="text-lg font-semibold text-ink mb-2">{$_('campaigns.deleteCampaign')}</h2>
+        <p class="text-sm text-ink-muted mb-6">{$_('campaigns.confirmDelete')}</p>
         <div class="flex gap-3">
           <button
             on:click={() => deleteCampaign(deletingId!)}
@@ -465,7 +465,7 @@
           >
             {$_('common.delete')}
           </button>
-          <button on:click={() => deletingId = null} class="flex-1 px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+          <button on:click={() => deletingId = null} class="flex-1 px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
             {$_('common.cancel')}
           </button>
         </div>

--- a/apps/web/src/routes/(app)/projects/[id]/checklists/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/checklists/+page.svelte
@@ -707,19 +707,19 @@
 <div class="p-4 sm:p-6">
   <SectionHint sectionKey="checklists" titleKey="hints.checklists.title" descKey="hints.checklists.desc" />
   <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
-    <h1 class="text-2xl font-bold text-gray-900">{$_('checklists.title')}</h1>
+    <h1 class="text-2xl font-bold text-ink">{$_('checklists.title')}</h1>
     <div class="flex items-center gap-2 flex-wrap">
-      <button on:click={() => showCreateModal = true} class="bg-primary-600 text-white px-3 sm:px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition flex items-center gap-1.5">
+      <button on:click={() => showCreateModal = true} class="bg-brand text-white px-3 sm:px-4 py-2 rounded-lg text-sm font-medium hover:brightness-110 transition flex items-center gap-1.5">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" /></svg>
         <span class="hidden sm:inline">{$_('checklists.createManual')}</span>
         <span class="sm:hidden">{$_('common.create')}</span>
       </button>
-      <button on:click={() => { showImportModal = true; importParsed = null; importError = ''; }} class="border border-gray-300 text-gray-700 px-3 sm:px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 transition flex items-center gap-1.5">
+      <button on:click={() => { showImportModal = true; importParsed = null; importError = ''; }} class="border border-border text-ink px-3 sm:px-4 py-2 rounded-lg text-sm font-medium hover:bg-surface-2 transition flex items-center gap-1.5">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" /></svg>
         <span class="hidden sm:inline">{$_('checklists.importFromMD')}</span>
         <span class="sm:hidden">MD</span>
       </button>
-      <button on:click={() => showAIModal = true} class="border border-gray-300 text-gray-700 px-3 sm:px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 transition flex items-center gap-1.5">
+      <button on:click={() => showAIModal = true} class="border border-border text-ink px-3 sm:px-4 py-2 rounded-lg text-sm font-medium hover:bg-surface-2 transition flex items-center gap-1.5">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" /></svg>
         <span class="hidden sm:inline">{$_('checklists.generateWithAI')}</span>
         <span class="sm:hidden">AI</span>
@@ -728,20 +728,20 @@
   </div>
 
   {#if loading}
-    <div class="space-y-4">{#each Array(2) as _}<div class="bg-white rounded-xl border border-gray-200 p-6 h-48 animate-pulse"></div>{/each}</div>
+    <div class="space-y-4">{#each Array(2) as _}<div class="bg-surface rounded-xl border border-border p-6 h-48 animate-pulse"></div>{/each}</div>
   {:else if checklists.length === 0}
     <div class="flex flex-col items-center justify-center py-20 text-center">
-      <div class="w-20 h-20 bg-primary-50 rounded-2xl flex items-center justify-center mb-4 mx-auto">
+      <div class="w-20 h-20 bg-brand-subtle/10 rounded-2xl flex items-center justify-center mb-4 mx-auto">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" /></svg>
       </div>
-      <h2 class="text-xl font-semibold text-gray-900 mb-2">{$_('checklists.empty')}</h2>
-      <p class="text-gray-500 mb-6 max-w-sm">{$_('checklists.emptyDesc')}</p>
+      <h2 class="text-xl font-semibold text-ink mb-2">{$_('checklists.empty')}</h2>
+      <p class="text-ink-muted mb-6 max-w-sm">{$_('checklists.emptyDesc')}</p>
       <div class="flex gap-3">
-        <button on:click={() => showCreateModal = true} class="bg-primary-600 text-white px-6 py-3 rounded-xl font-medium hover:bg-primary-700 transition flex items-center gap-2">
+        <button on:click={() => showCreateModal = true} class="bg-brand text-white px-6 py-3 rounded-xl font-medium hover:brightness-110 transition flex items-center gap-2">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" /></svg>
           {$_('checklists.createManual')}
         </button>
-        <button on:click={() => showAIModal = true} class="border border-gray-300 text-gray-700 px-6 py-3 rounded-xl font-medium hover:bg-gray-50 transition flex items-center gap-2">
+        <button on:click={() => showAIModal = true} class="border border-border text-ink px-6 py-3 rounded-xl font-medium hover:bg-surface-2 transition flex items-center gap-2">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" /></svg>
           {$_('checklists.generateWithAI')}
         </button>
@@ -755,7 +755,7 @@
         <select
           value={activeChecklistId}
           on:change={(e) => activeChecklistId = e.currentTarget.value}
-          class="w-full px-3 py-2.5 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+          class="w-full px-3 py-2.5 border border-border rounded-lg text-sm font-medium text-ink bg-surface focus:ring-2 focus:ring-primary-500 focus:border-transparent"
         >
           {#each checklists as cl}
             {@const clItems = cl.items || []}
@@ -767,7 +767,7 @@
         </select>
       </div>
       <!-- Desktop: tabs -->
-      <div class="hidden sm:flex gap-1 mb-4 overflow-x-auto pb-1 border-b border-gray-200">
+      <div class="hidden sm:flex gap-1 mb-4 overflow-x-auto pb-1 border-b border-border">
         {#each checklists as cl}
           {@const clItems = cl.items || []}
           {@const clCompleted = clItems.filter((i: any) => i.isCompleted).length}
@@ -777,12 +777,12 @@
             on:click={() => activeChecklistId = cl.id}
             class="flex items-center gap-2 px-4 py-2.5 text-sm font-medium whitespace-nowrap border-b-2 -mb-px transition-colors duration-150 cursor-pointer
               {activeChecklist?.id === cl.id
-                ? 'border-primary-600 text-primary-700'
-                : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}"
+                ? 'border-primary-600 text-brand'
+                : 'border-transparent text-ink-muted hover:text-gray-700 hover:border-gray-300'}"
           >
             <span class="truncate max-w-[200px]">{cl.name}</span>
             <span class="inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-medium
-              {clProgress === 100 ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600'}">
+              {clProgress === 100 ? 'bg-green-100 text-green-700' : 'bg-surface-2 text-ink-muted'}">
               {clProgress}%
             </span>
           </button>
@@ -797,21 +797,21 @@
         {@const total = items.length}
         {@const progress = total > 0 ? Math.round((completed / total) * 100) : 0}
         {@const sections = groupBySection(items)}
-        <div class="bg-white rounded-xl border border-gray-200 p-4 sm:p-6">
+        <div class="bg-surface rounded-xl border border-border p-4 sm:p-6">
           <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2 mb-3">
             <div class="flex-1 min-w-0">
               <div class="flex items-center gap-2">
-                <h3 class="font-semibold text-gray-900 text-lg truncate">{checklist.name}</h3>
-                <button on:click={() => openEditChecklist(checklist)} class="p-1 rounded text-gray-400 hover:text-primary-600 hover:bg-primary-50 transition flex-shrink-0" title={$_('checklists.editChecklist')}>
+                <h3 class="font-semibold text-ink text-lg truncate">{checklist.name}</h3>
+                <button on:click={() => openEditChecklist(checklist)} class="p-1 rounded text-ink-subtle hover:text-primary-600 hover:bg-brand-subtle/10 transition flex-shrink-0" title={$_('checklists.editChecklist')}>
                   <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Z" /></svg>
                 </button>
               </div>
-              {#if checklist.description}<p class="text-sm text-gray-500 mt-0.5">{checklist.description}</p>{/if}
+              {#if checklist.description}<p class="text-sm text-ink-muted mt-0.5">{checklist.description}</p>{/if}
             </div>
             <div class="flex items-center sm:items-start gap-3 flex-shrink-0">
               <div class="sm:text-right">
-                <span class="text-xl font-bold text-primary-600">{progress}%</span>
-                <span class="text-xs text-gray-400 ml-1 sm:ml-0 sm:block">{completed}/{total} done</span>
+                <span class="text-xl font-bold text-brand">{progress}%</span>
+                <span class="text-xs text-ink-subtle ml-1 sm:ml-0 sm:block">{completed}/{total} done</span>
               </div>
               {#if deletingId === checklist.id}
                 <div class="flex items-center gap-1">
@@ -820,20 +820,20 @@
                     <span class="hidden sm:inline">{$_('common.delete')}</span>
                     <span class="sm:hidden">{$_('common.delete')}</span>
                   </button>
-                  <button on:click={() => deletingId = null} class="px-3 py-1.5 rounded-lg bg-gray-50 text-gray-500 hover:bg-gray-100 transition text-xs font-medium">
+                  <button on:click={() => deletingId = null} class="px-3 py-1.5 rounded-lg bg-surface-2 text-ink-muted hover:bg-surface-2 transition text-xs font-medium">
                     <svg class="w-4 h-4 sm:hidden inline" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
                     <span>{$_('common.cancel')}</span>
                   </button>
                 </div>
               {:else}
-                <button on:click={() => deletingId = checklist.id} class="p-1.5 rounded-lg text-gray-400 hover:text-red-500 hover:bg-red-50 transition" title={$_('common.delete')}>
+                <button on:click={() => deletingId = checklist.id} class="p-1.5 rounded-lg text-ink-subtle hover:text-red-500 hover:bg-red-50 transition" title={$_('common.delete')}>
                   <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" /></svg>
                 </button>
               {/if}
             </div>
           </div>
-          <div class="w-full bg-gray-100 rounded-full h-1.5 mb-5">
-            <div class="bg-primary-600 h-1.5 rounded-full transition-all duration-500" style="width: {progress}%"></div>
+          <div class="w-full bg-surface-2 rounded-full h-1.5 mb-5">
+            <div class="bg-brand h-1.5 rounded-full transition-all duration-500" style="width: {progress}%"></div>
           </div>
           <div class="space-y-1">
             {#each sections as group, gi (`${gi}::${group.section ?? ''}`)}
@@ -847,10 +847,10 @@
                   {#if sectionComplete}
                     <svg class="w-3.5 h-3.5 text-green-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M10 18a8 8 0 1 0 0-16 8 8 0 0 0 0 16Zm3.857-9.809a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z" clip-rule="evenodd" /></svg>
                   {:else}
-                    <svg class="w-3.5 h-3.5 text-gray-400 transition-transform duration-150 {collapsedSections.has(sectionKey) ? '-rotate-90' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" /></svg>
+                    <svg class="w-3.5 h-3.5 text-ink-subtle transition-transform duration-150 {collapsedSections.has(sectionKey) ? '-rotate-90' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" /></svg>
                   {/if}
-                  <h4 class="text-xs font-semibold uppercase tracking-wider {sectionComplete ? 'text-green-500 line-through' : 'text-gray-400'}">{group.section}</h4>
-                  <span class="text-xs {sectionComplete ? 'text-green-400' : 'text-gray-300'}">{sectionDone}/{group.items.length}</span>
+                  <h4 class="text-xs font-semibold uppercase tracking-wider {sectionComplete ? 'text-green-500 line-through' : 'text-ink-subtle'}">{group.section}</h4>
+                  <span class="text-xs {sectionComplete ? 'text-green-400' : 'text-ink-subtle'}">{sectionDone}/{group.items.length}</span>
                 </div>
               {/if}
               {#if !group.section || !collapsedSections.has(`${checklist.id}::${group.section}`)}
@@ -858,11 +858,11 @@
               {#each group.items.slice(0, visibleLimit) as item, itemInGroup (item.id)}
                 {@const itemIndex = group.items === items ? itemInGroup : items.indexOf(item)}
               <!-- svelte-ignore a11y_no_static_element_interactions -->
-              <div class="rounded-lg transition-colors {expandedItems.has(item.id) ? 'bg-gray-50' : 'hover:bg-gray-50/50'}" on:mouseenter={() => hoveredItemId = item.id} on:mouseleave={() => { if (hoveredItemId === item.id) hoveredItemId = null; }}>
+              <div class="rounded-lg transition-colors {expandedItems.has(item.id) ? 'bg-surface-2' : 'hover:bg-surface-2/50'}" on:mouseenter={() => hoveredItemId = item.id} on:mouseleave={() => { if (hoveredItemId === item.id) hoveredItemId = null; }}>
                 <div class="flex items-center gap-3 py-2 px-2">
                   <button
                     on:click|stopPropagation={() => toggleItem(checklist.id, item.id, !item.isCompleted)}
-                    class="w-5 h-5 rounded-md border-2 flex-shrink-0 flex items-center justify-center transition-all {item.isCompleted ? 'bg-primary-600 border-primary-600' : 'border-gray-300 hover:border-primary-400'}"
+                    class="w-5 h-5 rounded-md border-2 flex-shrink-0 flex items-center justify-center transition-all {item.isCompleted ? 'bg-brand border-primary-600' : 'border-border hover:border-primary-400'}"
                   >
                     {#if item.isCompleted}
                       <svg class="w-3 h-3 text-white" fill="currentColor" viewBox="0 0 20 20">
@@ -873,11 +873,11 @@
                   <!-- svelte-ignore a11y_click_events_have_key_events -->
                   <!-- svelte-ignore a11y_no_static_element_interactions -->
                   <div class="flex-1 min-w-0 flex items-center gap-2 cursor-pointer select-none" on:click={() => toggleExpand(item.id)}>
-                    <span class="text-sm {item.isCompleted ? 'text-gray-400 line-through' : 'text-gray-700'}">{item.title}</span>
+                    <span class="text-sm {item.isCompleted ? 'text-ink-subtle line-through' : 'text-ink'}">{item.title}</span>
                     {#if item.note}
                       <svg class="w-3.5 h-3.5 flex-shrink-0 {highlightedNotes.has(item.id) ? 'text-yellow-500 animate-pulse' : 'text-yellow-400'}" fill="currentColor" viewBox="0 0 24 24"><path d="M21.731 2.269a2.625 2.625 0 0 0-3.712 0l-1.157 1.157 3.712 3.712 1.157-1.157a2.625 2.625 0 0 0 0-3.712ZM19.513 8.199l-3.712-3.712-8.4 8.4a5.25 5.25 0 0 0-1.32 2.214l-.8 2.685a.75.75 0 0 0 .933.933l2.685-.8a5.25 5.25 0 0 0 2.214-1.32l8.4-8.4Z" /><path d="M5.25 5.25a3 3 0 0 0-3 3v10.5a3 3 0 0 0 3 3h10.5a3 3 0 0 0 3-3V13.5a.75.75 0 0 0-1.5 0v5.25a1.5 1.5 0 0 1-1.5 1.5H5.25a1.5 1.5 0 0 1-1.5-1.5V8.25a1.5 1.5 0 0 1 1.5-1.5h5.25a.75.75 0 0 0 0-1.5H5.25Z" /></svg>
                     {/if}
-                    <svg class="w-4 h-4 flex-shrink-0 text-gray-400 transition-transform duration-200 {expandedItems.has(item.id) ? 'rotate-180' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <svg class="w-4 h-4 flex-shrink-0 text-ink-subtle transition-transform duration-200 {expandedItems.has(item.id) ? 'rotate-180' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
                     </svg>
                   </div>
@@ -885,27 +885,27 @@
                   {#if hoveredItemId === item.id || deletingItemId === item.id}
                   <div class="flex items-center gap-0.5">
                     {#if itemIndex > 0}
-                      <button on:click|stopPropagation={() => moveItem(checklist.id, items, itemIndex, 'up')} class="p-1 rounded text-gray-400 hover:text-gray-600 hover:bg-gray-100" title={$_('checklists.moveUp')}>
+                      <button on:click|stopPropagation={() => moveItem(checklist.id, items, itemIndex, 'up')} class="p-1 rounded text-ink-subtle hover:text-gray-600 hover:bg-surface-2" title={$_('checklists.moveUp')}>
                         <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M4.5 15.75l7.5-7.5 7.5 7.5" /></svg>
                       </button>
                     {/if}
                     {#if itemIndex < items.length - 1}
-                      <button on:click|stopPropagation={() => moveItem(checklist.id, items, itemIndex, 'down')} class="p-1 rounded text-gray-400 hover:text-gray-600 hover:bg-gray-100" title={$_('checklists.moveDown')}>
+                      <button on:click|stopPropagation={() => moveItem(checklist.id, items, itemIndex, 'down')} class="p-1 rounded text-ink-subtle hover:text-gray-600 hover:bg-surface-2" title={$_('checklists.moveDown')}>
                         <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" /></svg>
                       </button>
                     {/if}
-                    <button on:click|stopPropagation={() => openEditItem(item)} class="p-1 rounded text-gray-400 hover:text-primary-600 hover:bg-primary-50" title={$_('checklists.editItem')}>
+                    <button on:click|stopPropagation={() => openEditItem(item)} class="p-1 rounded text-ink-subtle hover:text-primary-600 hover:bg-brand-subtle/10" title={$_('checklists.editItem')}>
                       <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487Z" /></svg>
                     </button>
                     {#if deletingItemId === item.id}
                       <button on:click|stopPropagation={() => deleteItem(checklist.id, item.id)} class="p-1 rounded bg-red-50 text-red-600 hover:bg-red-100">
                         <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="m4.5 12.75 6 6 9-13.5" /></svg>
                       </button>
-                      <button on:click|stopPropagation={() => deletingItemId = null} class="p-1 rounded text-gray-400 hover:text-gray-600 hover:bg-gray-100">
+                      <button on:click|stopPropagation={() => deletingItemId = null} class="p-1 rounded text-ink-subtle hover:text-gray-600 hover:bg-surface-2">
                         <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
                       </button>
                     {:else}
-                      <button on:click|stopPropagation={() => deletingItemId = item.id} class="p-1 rounded text-gray-400 hover:text-red-500 hover:bg-red-50" title={$_('checklists.deleteItem')}>
+                      <button on:click|stopPropagation={() => deletingItemId = item.id} class="p-1 rounded text-ink-subtle hover:text-red-500 hover:bg-red-50" title={$_('checklists.deleteItem')}>
                         <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" /></svg>
                       </button>
                     {/if}
@@ -916,25 +916,25 @@
                 {#if expandedItems.has(item.id)}
                   <div class="px-2 pb-3 pl-12">
                     {#if item.description}
-                      <p class="text-sm text-gray-500 border-l-2 border-primary-200 pl-3 mb-3">{item.description}</p>
+                      <p class="text-sm text-ink-muted border-l-2 border-primary-200 pl-3 mb-3">{item.description}</p>
                     {/if}
 
                     <!-- Notes -->
                     <div class="mb-3">
-                      <label class="block text-xs font-medium text-gray-500 mb-1">{$_('checklists.notes')}</label>
+                      <label class="block text-xs font-medium text-ink-muted mb-1">{$_('checklists.notes')}</label>
                       <textarea
                         value={item.note || ''}
                         on:input={(e) => { const val = e.currentTarget.value; checklists = checklists.map(c => ({ ...c, items: (c.items || []).map((i: any) => i.id === item.id ? { ...i, note: val } : i) })); scheduleNoteSave(item.id, val); }}
                         placeholder={$_('checklists.notesPlaceholder')}
                         rows="2"
-                        class="w-full text-sm px-3 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400 resize-none"
+                        class="w-full text-sm px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400 resize-none"
                       ></textarea>
                       <div class="flex items-center gap-2 mt-0.5">
                         {#if noteSaving.has(item.id)}
-                          <span class="text-xs text-gray-400">{$_('common.loading')}...</span>
+                          <span class="text-xs text-ink-subtle">{$_('common.loading')}...</span>
                         {/if}
                         {#if item.noteUpdatedAt}
-                          <span class="text-xs text-gray-400">{$_('checklists.noteLastUpdated', { values: { time: new Date(item.noteUpdatedAt).toLocaleString() } })}</span>
+                          <span class="text-xs text-ink-subtle">{$_('checklists.noteLastUpdated', { values: { time: new Date(item.noteUpdatedAt).toLocaleString() } })}</span>
                         {/if}
                       </div>
                     </div>
@@ -944,7 +944,7 @@
                         {#each itemChats[item.id].messages as msg, idx (idx)}
                           <div class="flex {msg.role === 'user' ? 'justify-end' : 'justify-start'}">
                             {#if msg.role === 'assistant'}
-                              <div class="max-w-[80%] px-3 py-2 rounded-lg text-sm bg-gray-100 text-gray-700 prose prose-sm prose-gray max-w-none [&>p]:m-0 [&>ul]:m-0 [&>ol]:m-0 [&>p+p]:mt-1.5">
+                              <div class="max-w-[80%] px-3 py-2 rounded-lg text-sm bg-surface-2 text-ink prose prose-sm prose-gray max-w-none [&>p]:m-0 [&>ul]:m-0 [&>ol]:m-0 [&>p+p]:mt-1.5">
                                 {@html renderMarkdownCached(msg.content)}
                               </div>
                             {:else}
@@ -956,7 +956,7 @@
                         {/each}
                         {#if itemChats[item.id].loading}
                           <div class="flex justify-start">
-                            <div class="bg-gray-100 rounded-lg px-3 py-2 text-sm text-gray-400 animate-pulse">...</div>
+                            <div class="bg-surface-2 rounded-lg px-3 py-2 text-sm text-ink-subtle animate-pulse">...</div>
                           </div>
                         {/if}
                       </div>
@@ -968,12 +968,12 @@
                         bind:value={itemChats[item.id].input}
                         on:keydown={(e) => e.key === 'Enter' && !e.shiftKey && sendItemMessage(item, checklist)}
                         placeholder={$_('checklists.askAI')}
-                        class="flex-1 text-sm px-3 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400"
+                        class="flex-1 text-sm px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400"
                       />
                       <button
                         on:click={() => sendItemMessage(item, checklist)}
                         disabled={!itemChats[item.id].input.trim() || itemChats[item.id].loading}
-                        class="px-3 py-2 bg-primary-600 text-white rounded-lg text-sm hover:bg-primary-700 disabled:opacity-50 transition flex-shrink-0"
+                        class="px-3 py-2 bg-brand text-white rounded-lg text-sm hover:brightness-110 disabled:opacity-50 transition flex-shrink-0"
                       >
                         <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                           <path stroke-linecap="round" stroke-linejoin="round" d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5" />
@@ -989,10 +989,10 @@
           </div>
           <!-- Add Item inline -->
           {#if addingItemToId === checklist.id}
-            <div class="mt-3 p-3 border border-dashed border-gray-300 rounded-lg">
+            <div class="mt-3 p-3 border border-dashed border-border rounded-lg">
               <div class="flex gap-2 mb-2">
-                <input type="text" bind:value={newItemForm.title} placeholder={$_('checklists.itemTitlePlaceholder')} class="flex-1 text-sm px-3 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-1 focus:ring-primary-400" on:keydown={(e) => e.key === 'Enter' && addItemToChecklist(checklist.id)} />
-                <select bind:value={newItemForm.priority} class="text-sm px-2 py-2 border border-gray-200 rounded-lg">
+                <input type="text" bind:value={newItemForm.title} placeholder={$_('checklists.itemTitlePlaceholder')} class="flex-1 text-sm px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-1 focus:ring-primary-400" on:keydown={(e) => e.key === 'Enter' && addItemToChecklist(checklist.id)} />
+                <select bind:value={newItemForm.priority} class="text-sm px-2 py-2 border border-border rounded-lg">
                   <option value="LOW">{$_('checklists.low')}</option>
                   <option value="MEDIUM">{$_('checklists.medium')}</option>
                   <option value="HIGH">{$_('checklists.high')}</option>
@@ -1000,16 +1000,16 @@
                 </select>
               </div>
               <div class="flex gap-2 mb-2">
-                <textarea bind:value={newItemForm.description} placeholder={$_('checklists.descriptionLabel')} rows="2" class="flex-1 text-sm px-3 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-1 focus:ring-primary-400"></textarea>
-                <input type="text" bind:value={newItemForm.section} placeholder={$_('checklists.sectionPlaceholder')} class="w-40 text-sm px-3 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-1 focus:ring-primary-400" />
+                <textarea bind:value={newItemForm.description} placeholder={$_('checklists.descriptionLabel')} rows="2" class="flex-1 text-sm px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-1 focus:ring-primary-400"></textarea>
+                <input type="text" bind:value={newItemForm.section} placeholder={$_('checklists.sectionPlaceholder')} class="w-40 text-sm px-3 py-2 border border-border rounded-lg focus:outline-none focus:ring-1 focus:ring-primary-400" />
               </div>
               <div class="flex gap-2 justify-end">
-                <button on:click={() => { addingItemToId = null; newItemForm = { title: '', description: '', priority: 'MEDIUM', section: '' }; }} class="px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 rounded-lg transition">{$_('common.cancel')}</button>
-                <button on:click={() => addItemToChecklist(checklist.id)} disabled={!newItemForm.title.trim()} class="px-3 py-1.5 text-sm bg-primary-600 text-white rounded-lg hover:bg-primary-700 disabled:opacity-50 transition">{$_('checklists.addItemToList')}</button>
+                <button on:click={() => { addingItemToId = null; newItemForm = { title: '', description: '', priority: 'MEDIUM', section: '' }; }} class="px-3 py-1.5 text-sm text-ink-muted hover:bg-surface-2 rounded-lg transition">{$_('common.cancel')}</button>
+                <button on:click={() => addItemToChecklist(checklist.id)} disabled={!newItemForm.title.trim()} class="px-3 py-1.5 text-sm bg-brand text-white rounded-lg hover:brightness-110 disabled:opacity-50 transition">{$_('checklists.addItemToList')}</button>
               </div>
             </div>
           {:else}
-            <button on:click={() => { addingItemToId = checklist.id; newItemForm = { title: '', description: '', priority: 'MEDIUM', section: '' }; }} class="mt-3 w-full py-2 border border-dashed border-gray-300 rounded-lg text-sm text-gray-500 hover:text-primary-600 hover:border-primary-400 transition flex items-center justify-center gap-1.5">
+            <button on:click={() => { addingItemToId = checklist.id; newItemForm = { title: '', description: '', priority: 'MEDIUM', section: '' }; }} class="mt-3 w-full py-2 border border-dashed border-border rounded-lg text-sm text-ink-muted hover:text-primary-600 hover:border-primary-400 transition flex items-center justify-center gap-1.5">
               <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" /></svg>
               {$_('checklists.addItemToList')}
             </button>
@@ -1025,18 +1025,18 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showAIModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm p-6">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm p-6">
       <h2 class="text-lg font-semibold mb-4">{$_('checklists.generateWithAI')}</h2>
       <div class="mb-6">
-        <label for="checklist-type" class="block text-sm font-medium text-gray-700 mb-1">{$_('checklists.type')}</label>
-        <select id="checklist-type" bind:value={aiForm.type} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm">
+        <label for="checklist-type" class="block text-sm font-medium text-ink mb-1">{$_('checklists.type')}</label>
+        <select id="checklist-type" bind:value={aiForm.type} class="w-full px-3 py-2 border border-border rounded-lg text-sm">
           {#each typeOptions.filter(t => t !== 'CUSTOM') as t}
             <option value={t}>{$_(typeLabel[t])}</option>
           {/each}
         </select>
       </div>
       <div class="flex gap-3">
-        <button on:click={generateWithAI} disabled={creating} class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 disabled:opacity-50 transition text-sm flex items-center justify-center gap-2">
+        <button on:click={generateWithAI} disabled={creating} class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 disabled:opacity-50 transition text-sm flex items-center justify-center gap-2">
           {#if creating}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
           {:else}
@@ -1044,7 +1044,7 @@
           {/if}
           {creating ? $_('common.loading') : $_('checklists.generateWithAI')}
         </button>
-        <button on:click={() => showAIModal = false} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition text-sm">{$_('common.cancel')}</button>
+        <button on:click={() => showAIModal = false} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition text-sm">{$_('common.cancel')}</button>
       </div>
     </div>
   </div>
@@ -1055,13 +1055,13 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showImportModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md p-6">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md p-6">
       <h2 class="text-lg font-semibold mb-2">{$_('checklists.importTitle')}</h2>
-      <p class="text-sm text-gray-500 mb-4">{$_('checklists.importDesc')}</p>
+      <p class="text-sm text-ink-muted mb-4">{$_('checklists.importDesc')}</p>
 
       <label class="block mb-4">
         <span class="sr-only">{$_('checklists.importChooseFile')}</span>
-        <input type="file" accept=".md" on:change={handleFileUpload} class="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-primary-50 file:text-primary-700 hover:file:bg-primary-100 cursor-pointer" />
+        <input type="file" accept=".md" on:change={handleFileUpload} class="block w-full text-sm text-ink-muted file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-brand-subtle/10 file:text-primary-700 hover:file:bg-primary-100 cursor-pointer" />
       </label>
 
       {#if importError}
@@ -1069,21 +1069,21 @@
       {/if}
 
       {#if importParsed}
-        <div class="mb-4 border border-gray-200 rounded-lg p-4 max-h-64 overflow-y-auto">
-          <h3 class="font-medium text-gray-900 text-sm mb-1">{importParsed.name}</h3>
+        <div class="mb-4 border border-border rounded-lg p-4 max-h-64 overflow-y-auto">
+          <h3 class="font-medium text-ink text-sm mb-1">{importParsed.name}</h3>
           {#if importParsed.description}
-            <p class="text-xs text-gray-500 mb-2">{importParsed.description}</p>
+            <p class="text-xs text-ink-muted mb-2">{importParsed.description}</p>
           {/if}
-          <div class="text-xs text-primary-600 font-medium mb-2">{$_('checklists.importItems', { values: { count: importParsed.items.length } })}</div>
+          <div class="text-xs text-brand font-medium mb-2">{$_('checklists.importItems', { values: { count: importParsed.items.length } })}</div>
           <ul class="space-y-1">
             {#each importParsed.items as item}
               <li class="flex items-center gap-2 text-sm">
-                <div class="w-4 h-4 rounded border-2 flex-shrink-0 flex items-center justify-center {item.isCompleted ? 'bg-primary-600 border-primary-600' : 'border-gray-300'}">
+                <div class="w-4 h-4 rounded border-2 flex-shrink-0 flex items-center justify-center {item.isCompleted ? 'bg-brand border-primary-600' : 'border-border'}">
                   {#if item.isCompleted}
                     <svg class="w-2.5 h-2.5 text-white" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" /></svg>
                   {/if}
                 </div>
-                <span class="text-gray-700 {item.isCompleted ? 'line-through text-gray-400' : ''}">{item.title}</span>
+                <span class="text-ink {item.isCompleted ? 'line-through text-ink-subtle' : ''}">{item.title}</span>
                 <div class="w-1.5 h-1.5 rounded-full flex-shrink-0 {priorityDot[item.priority] || 'bg-gray-300'}"></div>
               </li>
             {/each}
@@ -1093,14 +1093,14 @@
 
       <div class="flex gap-3">
         {#if importParsed}
-          <button on:click={importChecklist} disabled={importing} class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 disabled:opacity-50 transition text-sm flex items-center justify-center gap-2">
+          <button on:click={importChecklist} disabled={importing} class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 disabled:opacity-50 transition text-sm flex items-center justify-center gap-2">
             {#if importing}
               <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/></svg>
             {/if}
             {$_('checklists.importConfirm')}
           </button>
         {/if}
-        <button on:click={() => showImportModal = false} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition text-sm">{$_('common.cancel')}</button>
+        <button on:click={() => showImportModal = false} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition text-sm">{$_('common.cancel')}</button>
       </div>
     </div>
   </div>
@@ -1111,42 +1111,42 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showCreateModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-lg p-6 max-h-[90vh] overflow-y-auto">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-lg p-6 max-h-[90vh] overflow-y-auto">
       <h2 class="text-lg font-semibold mb-4">{$_('checklists.manualCreateTitle')}</h2>
 
       <div class="space-y-4 mb-6">
         <div>
-          <label for="create-name" class="block text-sm font-medium text-gray-700 mb-1">{$_('checklists.checklistName')}</label>
-          <input id="create-name" type="text" bind:value={createForm.name} placeholder={$_('checklists.checklistNamePlaceholder')} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400" />
+          <label for="create-name" class="block text-sm font-medium text-ink mb-1">{$_('checklists.checklistName')}</label>
+          <input id="create-name" type="text" bind:value={createForm.name} placeholder={$_('checklists.checklistNamePlaceholder')} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400" />
         </div>
         <div>
-          <label for="create-type" class="block text-sm font-medium text-gray-700 mb-1">{$_('checklists.type')}</label>
-          <select id="create-type" bind:value={createForm.type} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm">
+          <label for="create-type" class="block text-sm font-medium text-ink mb-1">{$_('checklists.type')}</label>
+          <select id="create-type" bind:value={createForm.type} class="w-full px-3 py-2 border border-border rounded-lg text-sm">
             {#each typeOptions as t}
               <option value={t}>{$_(typeLabel[t])}</option>
             {/each}
           </select>
         </div>
         <div>
-          <label for="create-desc" class="block text-sm font-medium text-gray-700 mb-1">{$_('checklists.checklistDescription')}</label>
-          <textarea id="create-desc" bind:value={createForm.description} placeholder={$_('checklists.checklistDescriptionPlaceholder')} rows="2" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400"></textarea>
+          <label for="create-desc" class="block text-sm font-medium text-ink mb-1">{$_('checklists.checklistDescription')}</label>
+          <textarea id="create-desc" bind:value={createForm.description} placeholder={$_('checklists.checklistDescriptionPlaceholder')} rows="2" class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400"></textarea>
         </div>
 
         <!-- Items builder -->
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-2">{$_('checklists.title')}</label>
+          <label class="block text-sm font-medium text-ink mb-2">{$_('checklists.title')}</label>
           {#if createForm.items.length === 0}
-            <p class="text-sm text-gray-400 mb-2">{$_('checklists.noItemsYet')}</p>
+            <p class="text-sm text-ink-subtle mb-2">{$_('checklists.noItemsYet')}</p>
           {:else}
             <div class="space-y-2 mb-2">
               {#each createForm.items as item, i}
-                <div class="flex gap-2 items-start p-2 bg-gray-50 rounded-lg">
+                <div class="flex gap-2 items-start p-2 bg-surface-2 rounded-lg">
                   <div class="flex-1 space-y-1.5">
-                    <input type="text" bind:value={item.title} placeholder={$_('checklists.itemTitlePlaceholder')} class="w-full text-sm px-2 py-1.5 border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-primary-400" />
+                    <input type="text" bind:value={item.title} placeholder={$_('checklists.itemTitlePlaceholder')} class="w-full text-sm px-2 py-1.5 border border-border rounded focus:outline-none focus:ring-1 focus:ring-primary-400" />
                     <div class="flex gap-2">
-                      <input type="text" bind:value={item.description} placeholder={$_('checklists.descriptionLabel')} class="flex-1 text-sm px-2 py-1.5 border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-primary-400" />
-                      <input type="text" bind:value={item.section} placeholder={$_('checklists.sectionPlaceholder')} class="w-32 text-sm px-2 py-1.5 border border-gray-200 rounded focus:outline-none focus:ring-1 focus:ring-primary-400" />
-                      <select bind:value={item.priority} class="text-xs px-2 py-1.5 border border-gray-200 rounded">
+                      <input type="text" bind:value={item.description} placeholder={$_('checklists.descriptionLabel')} class="flex-1 text-sm px-2 py-1.5 border border-border rounded focus:outline-none focus:ring-1 focus:ring-primary-400" />
+                      <input type="text" bind:value={item.section} placeholder={$_('checklists.sectionPlaceholder')} class="w-32 text-sm px-2 py-1.5 border border-border rounded focus:outline-none focus:ring-1 focus:ring-primary-400" />
+                      <select bind:value={item.priority} class="text-xs px-2 py-1.5 border border-border rounded">
                         <option value="LOW">{$_('checklists.low')}</option>
                         <option value="MEDIUM">{$_('checklists.medium')}</option>
                         <option value="HIGH">{$_('checklists.high')}</option>
@@ -1154,14 +1154,14 @@
                       </select>
                     </div>
                   </div>
-                  <button on:click={() => removeCreateItem(i)} class="p-1 text-gray-400 hover:text-red-500 mt-1">
+                  <button on:click={() => removeCreateItem(i)} class="p-1 text-ink-subtle hover:text-red-500 mt-1">
                     <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" /></svg>
                   </button>
                 </div>
               {/each}
             </div>
           {/if}
-          <button on:click={addCreateItem} class="text-sm text-primary-600 hover:text-primary-700 font-medium flex items-center gap-1">
+          <button on:click={addCreateItem} class="text-sm text-brand hover:text-primary-700 font-medium flex items-center gap-1">
             <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" /></svg>
             {$_('checklists.addAnotherItem')}
           </button>
@@ -1169,10 +1169,10 @@
       </div>
 
       <div class="flex gap-3">
-        <button on:click={createManualChecklist} disabled={!createForm.name.trim() || creatingManual} class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 disabled:opacity-50 transition text-sm">
+        <button on:click={createManualChecklist} disabled={!createForm.name.trim() || creatingManual} class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 disabled:opacity-50 transition text-sm">
           {creatingManual ? $_('common.loading') : $_('checklists.createManual')}
         </button>
-        <button on:click={() => showCreateModal = false} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition text-sm">{$_('common.cancel')}</button>
+        <button on:click={() => showCreateModal = false} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition text-sm">{$_('common.cancel')}</button>
       </div>
     </div>
   </div>
@@ -1183,21 +1183,21 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => editingChecklist = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm p-6">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm p-6">
       <h2 class="text-lg font-semibold mb-4">{$_('checklists.editChecklist')}</h2>
       <div class="space-y-4 mb-6">
         <div>
-          <label for="edit-name" class="block text-sm font-medium text-gray-700 mb-1">{$_('checklists.checklistName')}</label>
-          <input id="edit-name" type="text" bind:value={editChecklistForm.name} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400" />
+          <label for="edit-name" class="block text-sm font-medium text-ink mb-1">{$_('checklists.checklistName')}</label>
+          <input id="edit-name" type="text" bind:value={editChecklistForm.name} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400" />
         </div>
         <div>
-          <label for="edit-desc" class="block text-sm font-medium text-gray-700 mb-1">{$_('checklists.descriptionLabel')}</label>
-          <textarea id="edit-desc" bind:value={editChecklistForm.description} rows="3" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400"></textarea>
+          <label for="edit-desc" class="block text-sm font-medium text-ink mb-1">{$_('checklists.descriptionLabel')}</label>
+          <textarea id="edit-desc" bind:value={editChecklistForm.description} rows="3" class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400"></textarea>
         </div>
       </div>
       <div class="flex gap-3">
-        <button on:click={saveEditChecklist} disabled={!editChecklistForm.name.trim()} class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 disabled:opacity-50 transition text-sm">{$_('checklists.save')}</button>
-        <button on:click={() => editingChecklist = null} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition text-sm">{$_('common.cancel')}</button>
+        <button on:click={saveEditChecklist} disabled={!editChecklistForm.name.trim()} class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 disabled:opacity-50 transition text-sm">{$_('checklists.save')}</button>
+        <button on:click={() => editingChecklist = null} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition text-sm">{$_('common.cancel')}</button>
       </div>
     </div>
   </div>
@@ -1208,24 +1208,24 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => editingItem = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm p-6">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm p-6">
       <h2 class="text-lg font-semibold mb-4">{$_('checklists.editItem')}</h2>
       <div class="space-y-4 mb-6">
         <div>
-          <label for="edit-item-title" class="block text-sm font-medium text-gray-700 mb-1">{$_('checklists.itemTitle')}</label>
-          <input id="edit-item-title" type="text" bind:value={editItemForm.title} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400" />
+          <label for="edit-item-title" class="block text-sm font-medium text-ink mb-1">{$_('checklists.itemTitle')}</label>
+          <input id="edit-item-title" type="text" bind:value={editItemForm.title} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400" />
         </div>
         <div>
-          <label for="edit-item-desc" class="block text-sm font-medium text-gray-700 mb-1">{$_('checklists.descriptionLabel')}</label>
-          <textarea id="edit-item-desc" bind:value={editItemForm.description} rows="3" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400"></textarea>
+          <label for="edit-item-desc" class="block text-sm font-medium text-ink mb-1">{$_('checklists.descriptionLabel')}</label>
+          <textarea id="edit-item-desc" bind:value={editItemForm.description} rows="3" class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400"></textarea>
         </div>
         <div>
-          <label for="edit-item-section" class="block text-sm font-medium text-gray-700 mb-1">{$_('checklists.section')}</label>
-          <input id="edit-item-section" type="text" bind:value={editItemForm.section} placeholder={$_('checklists.sectionPlaceholder')} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400" />
+          <label for="edit-item-section" class="block text-sm font-medium text-ink mb-1">{$_('checklists.section')}</label>
+          <input id="edit-item-section" type="text" bind:value={editItemForm.section} placeholder={$_('checklists.sectionPlaceholder')} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-1 focus:ring-primary-400 focus:border-primary-400" />
         </div>
         <div>
-          <label for="edit-item-priority" class="block text-sm font-medium text-gray-700 mb-1">{$_('checklists.priority')}</label>
-          <select id="edit-item-priority" bind:value={editItemForm.priority} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm">
+          <label for="edit-item-priority" class="block text-sm font-medium text-ink mb-1">{$_('checklists.priority')}</label>
+          <select id="edit-item-priority" bind:value={editItemForm.priority} class="w-full px-3 py-2 border border-border rounded-lg text-sm">
             <option value="LOW">{$_('checklists.low')}</option>
             <option value="MEDIUM">{$_('checklists.medium')}</option>
             <option value="HIGH">{$_('checklists.high')}</option>
@@ -1234,8 +1234,8 @@
         </div>
       </div>
       <div class="flex gap-3">
-        <button on:click={saveEditItem} disabled={!editItemForm.title.trim()} class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 disabled:opacity-50 transition text-sm">{$_('checklists.save')}</button>
-        <button on:click={() => editingItem = null} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition text-sm">{$_('common.cancel')}</button>
+        <button on:click={saveEditItem} disabled={!editItemForm.title.trim()} class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 disabled:opacity-50 transition text-sm">{$_('checklists.save')}</button>
+        <button on:click={() => editingItem = null} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition text-sm">{$_('common.cancel')}</button>
       </div>
     </div>
   </div>

--- a/apps/web/src/routes/(app)/projects/[id]/competitors/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/competitors/+page.svelte
@@ -298,8 +298,8 @@
   <!-- Header -->
   <div class="flex items-center justify-between mb-6">
     <div>
-      <h1 class="text-2xl font-bold text-gray-900">{$_('competitors.title')}</h1>
-      <p class="text-sm text-gray-500 mt-1">{$_('competitors.subtitle')}</p>
+      <h1 class="text-2xl font-bold text-ink">{$_('competitors.title')}</h1>
+      <p class="text-sm text-ink-muted mt-1">{$_('competitors.subtitle')}</p>
     </div>
     <div class="flex items-center gap-2">
       <!-- Suggest with AI -->
@@ -315,7 +315,7 @@
       <!-- Add manually -->
       <button
         on:click={() => showModal = true}
-        class="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+        class="bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -332,19 +332,19 @@
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-purple-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" />
         </svg>
-        <h2 class="text-sm font-semibold text-gray-700">{$_('seo.competitors.suggestedSection')}</h2>
+        <h2 class="text-sm font-semibold text-ink">{$_('seo.competitors.suggestedSection')}</h2>
       </div>
       <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
         {#each suggestedCompetitors as suggestion}
           <div class="bg-purple-50 border border-purple-200 rounded-xl p-5">
             <div class="flex items-start justify-between mb-2">
               <div class="flex-1 min-w-0">
-                <h3 class="font-semibold text-gray-900">{suggestion.name}</h3>
+                <h3 class="font-semibold text-ink">{suggestion.name}</h3>
                 <a
                   href={suggestion.websiteUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="text-sm text-primary-600 hover:text-primary-700 hover:underline flex items-center gap-1 truncate"
+                  class="text-sm text-brand hover:text-primary-700 hover:underline flex items-center gap-1 truncate"
                 >
                   {suggestion.websiteUrl}
                   <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -354,7 +354,7 @@
               </div>
             </div>
             {#if suggestion.aiRationale}
-              <p class="text-sm text-gray-500 italic mb-4">{suggestion.aiRationale}</p>
+              <p class="text-sm text-ink-muted italic mb-4">{suggestion.aiRationale}</p>
             {/if}
             <div class="flex items-center gap-2">
               <button
@@ -377,7 +377,7 @@
               <button
                 on:click={() => dismissCompetitor(suggestion.id)}
                 disabled={approvingId === suggestion.id || dismissingId === suggestion.id}
-                class="flex-1 border border-gray-300 text-gray-600 py-1.5 rounded-lg text-xs font-medium hover:bg-gray-100 transition-colors duration-150 disabled:opacity-50 flex items-center justify-center gap-1.5 cursor-pointer"
+                class="flex-1 border border-border text-ink-muted py-1.5 rounded-lg text-xs font-medium hover:bg-surface-2 transition-colors duration-150 disabled:opacity-50 flex items-center justify-center gap-1.5 cursor-pointer"
               >
                 {#if dismissingId === suggestion.id}
                   <svg class="animate-spin w-3.5 h-3.5" fill="none" viewBox="0 0 24 24">
@@ -402,7 +402,7 @@
     <!-- Loading skeleton -->
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       {#each Array(4) as _}
-        <div class="bg-white rounded-xl border border-gray-200 p-5 h-44 animate-pulse">
+        <div class="bg-surface rounded-xl border border-border p-5 h-44 animate-pulse">
           <div class="flex items-center gap-3 mb-4">
             <div class="w-10 h-10 bg-gray-200 rounded-full"></div>
             <div class="flex-1">
@@ -418,16 +418,16 @@
   {:else if competitors.length === 0}
     <!-- Empty state -->
     <div class="flex flex-col items-center justify-center py-20 text-center">
-      <div class="w-20 h-20 bg-primary-50 rounded-2xl flex items-center justify-center mb-6">
+      <div class="w-20 h-20 bg-brand-subtle/10 rounded-2xl flex items-center justify-center mb-6">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 3v11.25A2.25 2.25 0 0 0 6 16.5h2.25M3.75 3h-1.5m1.5 0h16.5m0 0h1.5m-1.5 0v11.25A2.25 2.25 0 0 1 18 16.5h-2.25m-7.5 0h7.5m-7.5 0-1 3m8.5-3 1 3m0 0 .5 1.5m-.5-1.5h-9.5m0 0-.5 1.5M9 11.25v1.5M12 9v3.75m3-6v6" />
         </svg>
       </div>
-      <h2 class="text-xl font-semibold text-gray-900 mb-2">{$_('competitors.empty')}</h2>
-      <p class="text-gray-500 mb-6 max-w-md">{$_('competitors.emptyDesc')}</p>
+      <h2 class="text-xl font-semibold text-ink mb-2">{$_('competitors.empty')}</h2>
+      <p class="text-ink-muted mb-6 max-w-md">{$_('competitors.emptyDesc')}</p>
       <button
         on:click={() => showModal = true}
-        class="bg-primary-600 text-white px-6 py-3 rounded-xl font-medium hover:bg-primary-700 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+        class="bg-brand text-white px-6 py-3 rounded-xl font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -439,7 +439,7 @@
     <!-- Competitor cards -->
     <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
       {#each competitors as competitor}
-        <div class="bg-white rounded-xl border border-gray-200 p-5 hover:shadow-sm transition-shadow duration-150">
+        <div class="bg-surface rounded-xl border border-border p-5 hover:shadow-sm transition-shadow duration-150">
           <!-- Card header -->
           <div class="flex items-start justify-between mb-3">
             <div class="flex items-center gap-3 flex-1 min-w-0">
@@ -454,12 +454,12 @@
                 ></div>
               </div>
               <div class="flex-1 min-w-0">
-                <h3 class="font-semibold text-gray-900 truncate">{competitor.name}</h3>
+                <h3 class="font-semibold text-ink truncate">{competitor.name}</h3>
                 <a
                   href={competitor.websiteUrl}
                   target="_blank"
                   rel="noopener noreferrer"
-                  class="text-sm text-primary-600 hover:text-primary-700 hover:underline truncate block"
+                  class="text-sm text-brand hover:text-primary-700 hover:underline truncate block"
                 >
                   {competitor.websiteUrl}
                 </a>
@@ -500,11 +500,11 @@
 
           <!-- Description -->
           {#if competitor.description}
-            <p class="text-sm text-gray-500 mb-3 line-clamp-2">{competitor.description}</p>
+            <p class="text-sm text-ink-muted mb-3 line-clamp-2">{competitor.description}</p>
           {/if}
 
           <!-- Meta info -->
-          <div class="flex items-center gap-4 text-xs text-gray-400 mb-3">
+          <div class="flex items-center gap-4 text-xs text-ink-subtle mb-3">
             <span class="inline-flex items-center gap-1">
               <span class="inline-block w-2 h-2 rounded-full {competitor.isActive ? 'bg-green-500' : 'bg-gray-300'}"></span>
               {competitor.isActive ? $_('competitors.active') : $_('competitors.inactive')}
@@ -520,7 +520,7 @@
           <!-- Snapshot toggle -->
           <button
             on:click={() => toggleSnapshot(competitor.id)}
-            class="w-full text-left text-xs font-medium text-gray-600 hover:text-primary-600 flex items-center gap-1.5 py-2 border-t border-gray-100 transition-colors duration-150 cursor-pointer"
+            class="w-full text-left text-xs font-medium text-ink-muted hover:text-primary-600 flex items-center gap-1.5 py-2 border-t border-border transition-colors duration-150 cursor-pointer"
           >
             <svg
               class="w-3.5 h-3.5 transition-transform duration-200 {expandedSnapshotId === competitor.id ? 'rotate-180' : ''}"
@@ -536,31 +536,31 @@
             <div class="mt-2">
               {#if !snapshotCache[competitor.id]}
                 <div class="py-4 text-center">
-                  <svg class="animate-spin w-5 h-5 text-gray-400 mx-auto" fill="none" viewBox="0 0 24 24">
+                  <svg class="animate-spin w-5 h-5 text-ink-subtle mx-auto" fill="none" viewBox="0 0 24 24">
                     <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
                     <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"/>
                   </svg>
                 </div>
               {:else if snapshotCache[competitor.id].length === 0}
-                <p class="text-xs text-gray-400 py-2">{$_('competitors.noSnapshot')}</p>
+                <p class="text-xs text-ink-subtle py-2">{$_('competitors.noSnapshot')}</p>
               {:else}
                 {@const latestSnapshot = snapshotCache[competitor.id][0]}
                 {@const kvPairs = flattenJson(latestSnapshot.data)}
                 {#if kvPairs.length === 0}
-                  <p class="text-xs text-gray-400 py-2">{$_('competitors.noSnapshot')}</p>
+                  <p class="text-xs text-ink-subtle py-2">{$_('competitors.noSnapshot')}</p>
                 {:else}
-                  <div class="bg-gray-50 rounded-lg p-3 max-h-64 overflow-y-auto">
+                  <div class="bg-surface-2 rounded-lg p-3 max-h-64 overflow-y-auto">
                     <table class="w-full text-xs">
                       <tbody>
                         {#each kvPairs as { key, value }, i}
-                          <tr class="{i % 2 === 0 ? 'bg-white' : 'bg-gray-50'}">
-                            <td class="py-1.5 px-2 font-medium text-gray-700 whitespace-nowrap align-top">{key}</td>
-                            <td class="py-1.5 px-2 text-gray-600 break-all">{value}</td>
+                          <tr class="{i % 2 === 0 ? 'bg-surface' : 'bg-surface-2'}">
+                            <td class="py-1.5 px-2 font-medium text-ink whitespace-nowrap align-top">{key}</td>
+                            <td class="py-1.5 px-2 text-ink-muted break-all">{value}</td>
                           </tr>
                         {/each}
                       </tbody>
                     </table>
-                    <div class="mt-2 pt-2 border-t border-gray-200 text-xs text-gray-400">
+                    <div class="mt-2 pt-2 border-t border-border text-xs text-ink-subtle">
                       {formatDate(latestSnapshot.createdAt)}
                     </div>
                   </div>
@@ -579,55 +579,55 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
-        <div class="w-8 h-8 bg-primary-50 rounded-lg flex items-center justify-center flex-shrink-0">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
+        <div class="w-8 h-8 bg-brand-subtle/10 rounded-lg flex items-center justify-center flex-shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900">{$_('competitors.addCompetitor')}</h2>
+        <h2 class="text-lg font-semibold text-ink">{$_('competitors.addCompetitor')}</h2>
       </div>
       <div class="p-6 space-y-4">
         <div>
-          <label for="competitor-name" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('competitors.name')}</label>
+          <label for="competitor-name" class="block text-sm font-medium text-ink mb-1.5">{$_('competitors.name')}</label>
           <input
             id="competitor-name"
             type="text"
             bind:value={form.name}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             placeholder={$_('competitors.namePlaceholder')}
           />
         </div>
         <div>
-          <label for="competitor-url" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('competitors.websiteUrl')}</label>
+          <label for="competitor-url" class="block text-sm font-medium text-ink mb-1.5">{$_('competitors.websiteUrl')}</label>
           <input
             id="competitor-url"
             type="url"
             bind:value={form.websiteUrl}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             placeholder={$_('competitors.websiteUrlPlaceholder')}
           />
         </div>
         <div>
-          <label for="competitor-desc" class="block text-sm font-medium text-gray-700 mb-1.5">
+          <label for="competitor-desc" class="block text-sm font-medium text-ink mb-1.5">
             {$_('competitors.description')}
-            <span class="text-gray-400 font-normal ml-1">({$_('common.optional')})</span>
+            <span class="text-ink-subtle font-normal ml-1">({$_('common.optional')})</span>
           </label>
           <textarea
             id="competitor-desc"
             bind:value={form.description}
             rows="3"
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"
             placeholder={$_('competitors.descriptionPlaceholder')}
           ></textarea>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={addCompetitor}
           disabled={creating || !form.name.trim() || !form.websiteUrl.trim()}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
         >
           {#if creating}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -642,7 +642,7 @@
             {$_('competitors.addCompetitor')}
           {/if}
         </button>
-        <button on:click={() => showModal = false} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={() => showModal = false} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>
@@ -655,19 +655,19 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={closeSuggestModal}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
         <div class="w-8 h-8 bg-purple-50 rounded-lg flex items-center justify-center flex-shrink-0">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-purple-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900">{$_('seo.competitors.suggestModal.title')}</h2>
+        <h2 class="text-lg font-semibold text-ink">{$_('seo.competitors.suggestModal.title')}</h2>
       </div>
       <div class="p-6 space-y-4">
-        <p class="text-sm text-gray-500">{$_('seo.competitors.suggestModal.description')}</p>
+        <p class="text-sm text-ink-muted">{$_('seo.competitors.suggestModal.description')}</p>
         <div>
-          <label for="suggest-note" class="block text-sm font-medium text-gray-700 mb-1.5">
+          <label for="suggest-note" class="block text-sm font-medium text-ink mb-1.5">
             {$_('seo.competitors.suggestModal.noteLabel')}
           </label>
           <!-- svelte-ignore a11y_autofocus -->
@@ -679,12 +679,12 @@
             rows="4"
             autofocus
             placeholder={$_('seo.competitors.suggestModal.notePlaceholder')}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent resize-none"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-purple-500 focus:border-transparent resize-none"
           ></textarea>
-          <div class="text-xs text-gray-400 mt-1 text-right">{suggestNote.length} / 500</div>
+          <div class="text-xs text-ink-subtle mt-1 text-right">{suggestNote.length} / 500</div>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={submitSuggestion}
           disabled={suggesting}
@@ -703,7 +703,7 @@
         <button
           on:click={closeSuggestModal}
           disabled={suggesting}
-          class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer disabled:opacity-50"
+          class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer disabled:opacity-50"
         >
           {$_('common.cancel')}
         </button>
@@ -717,15 +717,15 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => deletingId = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm">
       <div class="p-6">
         <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-4">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900 mb-2">{$_('competitors.delete')}</h2>
-        <p class="text-sm text-gray-500 mb-6">{$_('competitors.confirmDelete')}</p>
+        <h2 class="text-lg font-semibold text-ink mb-2">{$_('competitors.delete')}</h2>
+        <p class="text-sm text-ink-muted mb-6">{$_('competitors.confirmDelete')}</p>
         <div class="flex gap-3">
           <button
             on:click={() => deleteCompetitor(deletingId)}
@@ -733,7 +733,7 @@
           >
             {$_('common.delete')}
           </button>
-          <button on:click={() => deletingId = null} class="flex-1 px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+          <button on:click={() => deletingId = null} class="flex-1 px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
             {$_('common.cancel')}
           </button>
         </div>

--- a/apps/web/src/routes/(app)/projects/[id]/content/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/content/+page.svelte
@@ -343,7 +343,7 @@
   }
 
   const statusBadge: Record<string, string> = {
-    DRAFT: 'bg-gray-100 text-gray-600',
+    DRAFT: 'bg-surface-2 text-ink-muted',
     REVIEW: 'bg-yellow-100 text-yellow-700',
     APPROVED: 'bg-green-100 text-green-700',
     PUBLISHED: 'bg-blue-100 text-blue-700',
@@ -480,11 +480,11 @@
 <div class="p-4 sm:p-6">
   <SectionHint sectionKey="content" titleKey="hints.content.title" descKey="hints.content.desc" />
   <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 mb-6">
-    <h1 class="text-2xl font-bold text-gray-900">{$_('content.title')}</h1>
+    <h1 class="text-2xl font-bold text-ink">{$_('content.title')}</h1>
     <div class="flex items-center gap-2">
       <button
         on:click={() => showCreateModal = true}
-        class="bg-white border border-gray-300 text-gray-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+        class="bg-surface border border-border text-ink px-4 py-2 rounded-lg text-sm font-medium hover:bg-surface-2 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -493,7 +493,7 @@
       </button>
       <button
         on:click={() => showModal = true}
-        class="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+        class="bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" />
@@ -531,21 +531,21 @@
   {#if loading}
     <div class="space-y-3">
       {#each Array(4) as _}
-        <div class="bg-white rounded-xl border border-gray-200 p-4 animate-pulse h-20"></div>
+        <div class="bg-surface rounded-xl border border-border p-4 animate-pulse h-20"></div>
       {/each}
     </div>
   {:else if contents.length === 0}
     <div class="flex flex-col items-center justify-center py-20 text-center">
-      <div class="w-20 h-20 bg-primary-50 rounded-2xl flex items-center justify-center mb-6">
+      <div class="w-20 h-20 bg-brand-subtle/10 rounded-2xl flex items-center justify-center mb-6">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10" />
         </svg>
       </div>
-      <h2 class="text-xl font-semibold text-gray-900 mb-2">{$_('content.empty')}</h2>
-      <p class="text-gray-500 mb-6">{$_('content.emptyDesc')}</p>
+      <h2 class="text-xl font-semibold text-ink mb-2">{$_('content.empty')}</h2>
+      <p class="text-ink-muted mb-6">{$_('content.emptyDesc')}</p>
       <button
         on:click={() => showModal = true}
-        class="bg-primary-600 text-white px-6 py-3 rounded-xl font-medium hover:bg-primary-700 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+        class="bg-brand text-white px-6 py-3 rounded-xl font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" />
@@ -560,18 +560,18 @@
           <!-- Grouped content -->
           <!-- svelte-ignore a11y-click-events-have-key-events -->
           <!-- svelte-ignore a11y-no-static-element-interactions -->
-          <div class="bg-white rounded-xl border border-gray-200 border-l-4 {statusBorderAccent[group.items[0].status] || 'border-l-gray-300'} overflow-hidden">
+          <div class="bg-surface rounded-xl border border-border border-l-4 {statusBorderAccent[group.items[0].status] || 'border-l-gray-300'} overflow-hidden">
             <div
-              class="p-5 cursor-pointer hover:bg-gray-50 transition-colors duration-150"
+              class="p-5 cursor-pointer hover:bg-surface-2 transition-colors duration-150"
               on:click={() => toggleGroup(group.groupId)}
             >
               <div class="flex flex-col sm:flex-row items-start justify-between gap-3 sm:gap-4">
                 <div class="flex-1 min-w-0">
                   <div class="flex flex-wrap items-center gap-1.5 mb-2">
-                    <span class="text-xs px-2 py-0.5 bg-gray-100 text-gray-600 rounded font-medium">{typeLabel[group.items[0].type] ? $_(typeLabel[group.items[0].type]) : group.items[0].type.replace(/_/g, ' ')}</span>
-                    <span class="text-xs px-2 py-0.5 rounded {statusBadge[group.items[0].status] || 'bg-gray-100 text-gray-600'}">{$_(statusLabel[group.items[0].status] || 'content.draft')}</span>
+                    <span class="text-xs px-2 py-0.5 bg-surface-2 text-ink-muted rounded font-medium">{typeLabel[group.items[0].type] ? $_(typeLabel[group.items[0].type]) : group.items[0].type.replace(/_/g, ' ')}</span>
+                    <span class="text-xs px-2 py-0.5 rounded {statusBadge[group.items[0].status] || 'bg-surface-2 text-ink-muted'}">{$_(statusLabel[group.items[0].status] || 'content.draft')}</span>
                     {#each group.items as item}
-                      <span class="text-xs px-2 py-0.5 rounded font-medium {langBadgeColor[item.language] || 'bg-gray-100 text-gray-600'}">{(item.language || 'en').toUpperCase()}</span>
+                      <span class="text-xs px-2 py-0.5 rounded font-medium {langBadgeColor[item.language] || 'bg-surface-2 text-ink-muted'}">{(item.language || 'en').toUpperCase()}</span>
                     {/each}
                     {#if group.items[0].aiGenerated}
                       <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-purple-50 text-purple-600 rounded">
@@ -582,11 +582,11 @@
                       </span>
                     {/if}
                   </div>
-                  <h3 class="font-medium text-gray-900 truncate">{group.items[0].title}</h3>
-                  <p class="text-sm text-gray-500 mt-1 line-clamp-2">{group.items[0].body}</p>
+                  <h3 class="font-medium text-ink truncate">{group.items[0].title}</h3>
+                  <p class="text-sm text-ink-muted mt-1 line-clamp-2">{group.items[0].body}</p>
                 </div>
                 <div class="flex items-center gap-2 flex-shrink-0">
-                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-gray-400 transition-transform duration-200 {expandedGroups.has(group.groupId) ? 'rotate-180' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-ink-subtle transition-transform duration-200 {expandedGroups.has(group.groupId) ? 'rotate-180' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="m19.5 8.25-7.5 7.5-7.5-7.5" />
                   </svg>
                   <button
@@ -603,14 +603,14 @@
             </div>
 
             {#if expandedGroups.has(group.groupId)}
-              <div class="border-t border-gray-200">
+              <div class="border-t border-border">
                 {#each group.items as content}
-                  <div class="p-5 border-b border-gray-100 last:border-b-0 bg-gray-50/50">
+                  <div class="p-5 border-b border-border last:border-b-0 bg-surface-2/50">
                     <div class="flex flex-col sm:flex-row items-start justify-between gap-3 sm:gap-4">
                       <div class="flex-1 min-w-0">
                         <div class="flex flex-wrap items-center gap-1.5 mb-2">
-                          <span class="text-xs px-2 py-0.5 rounded font-bold {langBadgeColor[content.language] || 'bg-gray-100 text-gray-600'}">{(content.language || 'en').toUpperCase()}</span>
-                          <span class="text-xs px-2 py-0.5 rounded {statusBadge[content.status] || 'bg-gray-100 text-gray-600'}">{$_(statusLabel[content.status] || 'content.draft')}</span>
+                          <span class="text-xs px-2 py-0.5 rounded font-bold {langBadgeColor[content.language] || 'bg-surface-2 text-ink-muted'}">{(content.language || 'en').toUpperCase()}</span>
+                          <span class="text-xs px-2 py-0.5 rounded {statusBadge[content.status] || 'bg-surface-2 text-ink-muted'}">{$_(statusLabel[content.status] || 'content.draft')}</span>
                           {#if content.scheduledAt && content.status !== 'PUBLISHED'}
                             <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-amber-50 text-amber-700">
                               <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
@@ -621,14 +621,14 @@
                             <span class="text-xs px-2 py-0.5 rounded font-medium {scoreColor(getScore(content.id))}">{$_('content.score')}: {getScore(content.id)}</span>
                           {/if}
                         </div>
-                        <h3 class="font-medium text-gray-900 truncate">{content.title}</h3>
-                        <p class="text-sm text-gray-500 mt-1 line-clamp-2">{content.body}</p>
+                        <h3 class="font-medium text-ink truncate">{content.title}</h3>
+                        <p class="text-sm text-ink-muted mt-1 line-clamp-2">{content.body}</p>
                       </div>
                       <div class="flex items-center gap-2 flex-shrink-0 flex-wrap">
                         <select
                           value={content.status}
                           on:change={e => updateStatus(content.id, (e.target as HTMLSelectElement).value)}
-                          class="text-xs px-2 py-1.5 border border-gray-300 rounded-lg bg-white hover:bg-gray-50 transition-colors duration-150 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-500"
+                          class="text-xs px-2 py-1.5 border border-border rounded-lg bg-surface hover:bg-surface-2 transition-colors duration-150 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-500"
                         >
                           {#each STATUSES as s}
                             <option value={s}>{$_(statusLabel[s])}</option>
@@ -656,7 +656,7 @@
                         <a
                           on:click|stopPropagation
                           href="/projects/{projectId}/content/{content.id}/edit"
-                          class="text-xs px-3 py-1.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
+                          class="text-xs px-3 py-1.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
                         >
                           {$_('common.edit')}
                         </a>
@@ -679,11 +679,11 @@
         {:else}
           <!-- Single content item -->
           {@const content = group.items[0]}
-          <div class="bg-white rounded-xl border border-gray-200 border-l-4 {statusBorderAccent[content.status] || 'border-l-gray-300'} p-5 hover:shadow-sm transition-shadow duration-150">
+          <div class="bg-surface rounded-xl border border-border border-l-4 {statusBorderAccent[content.status] || 'border-l-gray-300'} p-5 hover:shadow-sm transition-shadow duration-150">
             <div class="flex flex-col sm:flex-row items-start justify-between gap-3 sm:gap-4">
               <div class="flex-1 min-w-0">
                 <div class="flex flex-wrap items-center gap-1.5 mb-2">
-                  <span class="text-xs px-2 py-0.5 bg-gray-100 text-gray-600 rounded font-medium">{typeLabel[content.type] ? $_(typeLabel[content.type]) : content.type.replace(/_/g, ' ')}</span>
+                  <span class="text-xs px-2 py-0.5 bg-surface-2 text-ink-muted rounded font-medium">{typeLabel[content.type] ? $_(typeLabel[content.type]) : content.type.replace(/_/g, ' ')}</span>
                   {#if content.platforms?.length}
                     {#each content.platforms as p}
                       <span class="text-xs px-2 py-0.5 bg-blue-50 text-blue-600 rounded">{p}</span>
@@ -691,7 +691,7 @@
                   {:else if content.platform}
                     <span class="text-xs px-2 py-0.5 bg-blue-50 text-blue-600 rounded">{content.platform}</span>
                   {/if}
-                  <span class="text-xs px-2 py-0.5 rounded {statusBadge[content.status] || 'bg-gray-100 text-gray-600'}">{$_(statusLabel[content.status] || 'content.draft')}</span>
+                  <span class="text-xs px-2 py-0.5 rounded {statusBadge[content.status] || 'bg-surface-2 text-ink-muted'}">{$_(statusLabel[content.status] || 'content.draft')}</span>
                   {#if content.scheduledAt && content.status !== 'PUBLISHED'}
                     <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-amber-50 text-amber-700">
                       <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"/></svg>
@@ -699,7 +699,7 @@
                     </span>
                   {/if}
                   {#if content.language}
-                    <span class="text-xs px-2 py-0.5 rounded font-medium {langBadgeColor[content.language] || 'bg-gray-100 text-gray-600'}">{content.language.toUpperCase()}</span>
+                    <span class="text-xs px-2 py-0.5 rounded font-medium {langBadgeColor[content.language] || 'bg-surface-2 text-ink-muted'}">{content.language.toUpperCase()}</span>
                   {/if}
                   {#if content.aiGenerated}
                     <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-purple-50 text-purple-600 rounded">
@@ -716,15 +716,15 @@
                     <span class="text-xs px-2 py-0.5 rounded font-medium {scoreColor(getScore(content.id))}">{$_('content.score')}: {getScore(content.id)}</span>
                   {/if}
                 </div>
-                <h3 class="font-medium text-gray-900 truncate">{content.title}</h3>
-                <p class="text-sm text-gray-500 mt-1 line-clamp-2">{content.body}</p>
+                <h3 class="font-medium text-ink truncate">{content.title}</h3>
+                <p class="text-sm text-ink-muted mt-1 line-clamp-2">{content.body}</p>
               </div>
               <div class="flex items-center gap-2 flex-shrink-0 flex-wrap">
                 <!-- Status dropdown -->
                 <select
                   value={content.status}
                   on:change={e => updateStatus(content.id, (e.target as HTMLSelectElement).value)}
-                  class="text-xs px-2 py-1.5 border border-gray-300 rounded-lg bg-white hover:bg-gray-50 transition-colors duration-150 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  class="text-xs px-2 py-1.5 border border-border rounded-lg bg-surface hover:bg-surface-2 transition-colors duration-150 cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-500"
                 >
                   {#each STATUSES as s}
                     <option value={s}>{$_(statusLabel[s])}</option>
@@ -765,7 +765,7 @@
                 <!-- Edit button -->
                 <a
                   href="/projects/{projectId}/content/{content.id}/edit"
-                  class="text-xs px-3 py-1.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
+                  class="text-xs px-3 py-1.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
                 >
                   {$_('common.edit')}
                 </a>
@@ -793,19 +793,19 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
-        <div class="w-8 h-8 bg-primary-50 rounded-lg flex items-center justify-center flex-shrink-0">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
+        <div class="w-8 h-8 bg-brand-subtle/10 rounded-lg flex items-center justify-center flex-shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900">{$_('content.generate')}</h2>
+        <h2 class="text-lg font-semibold text-ink">{$_('content.generate')}</h2>
       </div>
       <div class="p-6 space-y-4">
         <div>
-          <label for="content-type" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('content.type')}</label>
-          <select id="content-type" bind:value={form.type} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+          <label for="content-type" class="block text-sm font-medium text-ink mb-1.5">{$_('content.type')}</label>
+          <select id="content-type" bind:value={form.type} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
             <option value="SOCIAL_POST">{$_('content.socialPost')}</option>
             <option value="BLOG_ARTICLE">{$_('content.blogArticle')}</option>
             <option value="EMAIL">{$_('content.emailContent')}</option>
@@ -818,13 +818,13 @@
           </select>
         </div>
         <div>
-          <label for="content-topic" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('content.topic')}</label>
-          <input id="content-topic" type="text" bind:value={form.topic} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" placeholder={$_('content.topicPlaceholder')} />
+          <label for="content-topic" class="block text-sm font-medium text-ink mb-1.5">{$_('content.topic')}</label>
+          <input id="content-topic" type="text" bind:value={form.topic} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" placeholder={$_('content.topicPlaceholder')} />
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>
-            <label for="content-tone" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('content.tone')}</label>
-            <select id="content-tone" bind:value={form.tone} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+            <label for="content-tone" class="block text-sm font-medium text-ink mb-1.5">{$_('content.tone')}</label>
+            <select id="content-tone" bind:value={form.tone} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
               <option value="professional">{$_('content.tones.professional')}</option>
               <option value="casual">{$_('content.tones.casual')}</option>
               <option value="inspiring">{$_('content.tones.inspiring')}</option>
@@ -833,8 +833,8 @@
             </select>
           </div>
           <div>
-            <label for="content-length" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('content.length')}</label>
-            <select id="content-length" bind:value={form.length} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+            <label for="content-length" class="block text-sm font-medium text-ink mb-1.5">{$_('content.length')}</label>
+            <select id="content-length" bind:value={form.length} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
               <option value="short">{$_('content.lengths.short')}</option>
               <option value="medium">{$_('content.lengths.medium')}</option>
               <option value="long">{$_('content.lengths.long')}</option>
@@ -842,15 +842,15 @@
           </div>
         </div>
         <label class="flex items-center gap-2 mt-3">
-          <input type="checkbox" bind:checked={generateAllLanguages} class="rounded border-gray-300 text-primary-600 focus:ring-primary-500" />
-          <span class="text-sm text-gray-700">{$_('content.generateAllLanguages')}</span>
+          <input type="checkbox" bind:checked={generateAllLanguages} class="rounded border-border text-brand focus:ring-primary-500" />
+          <span class="text-sm text-ink">{$_('content.generateAllLanguages')}</span>
         </label>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={generateContent}
           disabled={generating}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
         >
           {#if generating}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -865,7 +865,7 @@
             {$_('content.generate')}
           {/if}
         </button>
-        <button on:click={() => showModal = false} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={() => showModal = false} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>
@@ -878,25 +878,25 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => editingContent = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-[90vw] h-[90vh] flex flex-col">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5 flex-shrink-0">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-[90vw] h-[90vh] flex flex-col">
+      <div class="p-6 border-b border-border flex items-center gap-2.5 flex-shrink-0">
         <div class="w-8 h-8 bg-blue-50 rounded-lg flex items-center justify-center flex-shrink-0">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900">{$_('content.editContent')}</h2>
+        <h2 class="text-lg font-semibold text-ink">{$_('content.editContent')}</h2>
         {#if editingContent.language}
-          <span class="text-xs px-2 py-0.5 rounded font-medium {langBadgeColor[editingContent.language] || 'bg-gray-100 text-gray-600'}">{editingContent.language.toUpperCase()}</span>
+          <span class="text-xs px-2 py-0.5 rounded font-medium {langBadgeColor[editingContent.language] || 'bg-surface-2 text-ink-muted'}">{editingContent.language.toUpperCase()}</span>
         {/if}
       </div>
       <div class="p-6 space-y-4 flex-1 flex flex-col overflow-y-auto">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1.5">{$_('content.topic')}</label>
-          <input type="text" bind:value={editForm.title} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
+          <label class="block text-sm font-medium text-ink mb-1.5">{$_('content.topic')}</label>
+          <input type="text" bind:value={editForm.title} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
         </div>
         <div class="flex-1 flex flex-col min-h-[400px]">
-          <label class="block text-sm font-medium text-gray-700 mb-1.5 flex-shrink-0">{$_('content.type')}</label>
+          <label class="block text-sm font-medium text-ink mb-1.5 flex-shrink-0">{$_('content.type')}</label>
           <div class="flex-1 min-h-0">
             <MarkdownEditor
               bind:value={editForm.body}
@@ -908,10 +908,10 @@
         <!-- Attached images -->
         {#if editForm.mediaUrls.length > 0}
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1.5">{$_('content.attachedImages')}</label>
+            <label class="block text-sm font-medium text-ink mb-1.5">{$_('content.attachedImages')}</label>
             <div class="flex flex-wrap gap-2">
               {#each editForm.mediaUrls as url, i}
-                <div class="relative group w-20 h-20 rounded-lg overflow-hidden border border-gray-200">
+                <div class="relative group w-20 h-20 rounded-lg overflow-hidden border border-border">
                   <img src={url} alt="Attached" class="w-full h-full object-cover" />
                   <button
                     on:click={() => removeImage(i)}
@@ -929,13 +929,13 @@
 
         <!-- Generate image with DALL-E -->
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1.5">{$_('content.generateImage')}</label>
+          <label class="block text-sm font-medium text-ink mb-1.5">{$_('content.generateImage')}</label>
           <div class="flex gap-2">
             <input
               type="text"
               bind:value={imagePrompt}
               placeholder={$_('content.imagePromptPlaceholder')}
-              class="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="flex-1 px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             />
             <button
               on:click={() => generateImage(imagePrompt)}
@@ -960,7 +960,7 @@
         <!-- Schedule block (hidden when content is PUBLISHED) -->
         {#if editingContent.status !== 'PUBLISHED'}
           <div class="border-t pt-4 mt-4">
-            <label class="flex items-center gap-2 text-sm font-medium text-gray-700">
+            <label class="flex items-center gap-2 text-sm font-medium text-ink">
               <input type="checkbox" bind:checked={scheduleEnabled} />
               {$_('content.schedule.scheduleForLater')}
             </label>
@@ -968,17 +968,17 @@
             {#if scheduleEnabled}
               <div class="mt-3 space-y-3">
                 <div>
-                  <label class="block text-xs font-medium text-gray-600 mb-1">{$_('content.schedule.scheduledAt')}</label>
+                  <label class="block text-xs font-medium text-ink-muted mb-1">{$_('content.schedule.scheduledAt')}</label>
                   <input type="datetime-local" bind:value={scheduleAt}
                          class="w-full border rounded-lg px-3 py-2 text-sm" />
                 </div>
 
                 <div>
-                  <label class="block text-xs font-medium text-gray-600 mb-1">{$_('content.schedule.selectAccounts')}</label>
+                  <label class="block text-xs font-medium text-ink-muted mb-1">{$_('content.schedule.selectAccounts')}</label>
                   {#if projectAccounts.length === 0}
-                    <p class="text-xs text-gray-500">{$_('content.schedule.noProjectAccounts')}</p>
+                    <p class="text-xs text-ink-muted">{$_('content.schedule.noProjectAccounts')}</p>
                   {:else}
-                    <p class="text-xs text-gray-500 mb-1">{$_('content.schedule.languageRoutingHint')}</p>
+                    <p class="text-xs text-ink-muted mb-1">{$_('content.schedule.languageRoutingHint')}</p>
                     <div class="space-y-1 max-h-40 overflow-y-auto border rounded-lg p-2">
                       {#each projectAccounts as acc}
                         <label class="flex items-center gap-2 text-sm">
@@ -989,8 +989,8 @@
                                    else scheduleAccountIds = scheduleAccountIds.filter(id => id !== acc.id);
                                  }} />
                           <span class="font-medium">{acc.platform}</span>
-                          <span class="text-gray-500 truncate">{acc.accountName}</span>
-                          {#if acc.language}<span class="text-xs px-1.5 py-0.5 bg-gray-100 rounded">{acc.language.toUpperCase()}</span>{/if}
+                          <span class="text-ink-muted truncate">{acc.accountName}</span>
+                          {#if acc.language}<span class="text-xs px-1.5 py-0.5 bg-surface-2 rounded">{acc.language.toUpperCase()}</span>{/if}
                         </label>
                       {/each}
                     </div>
@@ -1001,14 +1001,14 @@
           </div>
         {/if}
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3 justify-end flex-shrink-0">
-        <button on:click={() => editingContent = null} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+      <div class="p-6 border-t border-border flex gap-3 justify-end flex-shrink-0">
+        <button on:click={() => editingContent = null} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
         <button
           on:click={saveEdit}
           disabled={editSaving}
-          class="px-6 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
+          class="px-6 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
         >
           {#if editSaving}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -1028,16 +1028,16 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => publishingContent = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
         <div class="w-8 h-8 bg-blue-50 rounded-lg flex items-center justify-center flex-shrink-0">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M6 12 3.269 3.125A59.769 59.769 0 0 1 21.485 12 59.768 59.768 0 0 1 3.27 20.875L5.999 12Zm0 0h7.5" />
           </svg>
         </div>
         <div>
-          <h2 class="text-lg font-semibold text-gray-900">{$_('social.publishTo')}</h2>
-          <p class="text-xs text-gray-500">{publishingContent.title}</p>
+          <h2 class="text-lg font-semibold text-ink">{$_('social.publishTo')}</h2>
+          <p class="text-xs text-ink-muted">{publishingContent.title}</p>
         </div>
       </div>
 
@@ -1060,50 +1060,50 @@
             </div>
           {/each}
         </div>
-        <div class="p-6 border-t border-gray-100">
-          <button on:click={() => publishingContent = null} class="w-full py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <div class="p-6 border-t border-border">
+          <button on:click={() => publishingContent = null} class="w-full py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
             {$_('common.close')}
           </button>
         </div>
       {:else if socialAccounts.length === 0}
         <!-- No accounts connected -->
         <div class="p-8 text-center">
-          <div class="w-14 h-14 bg-gray-50 rounded-2xl flex items-center justify-center mx-auto mb-4">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-7 h-7 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+          <div class="w-14 h-14 bg-surface-2 rounded-2xl flex items-center justify-center mx-auto mb-4">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-7 h-7 text-ink-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" />
             </svg>
           </div>
-          <p class="text-sm font-medium text-gray-700 mb-1">{$_('social.noProjectAccounts')}</p>
-          <p class="text-xs text-gray-500 mb-4">{$_('social.noProjectAccountsDesc')}</p>
-          <a href="/projects/{projectId}/settings" class="inline-block text-sm px-4 py-2 bg-primary-600 text-white rounded-lg hover:bg-primary-700 transition-colors duration-150">
+          <p class="text-sm font-medium text-ink mb-1">{$_('social.noProjectAccounts')}</p>
+          <p class="text-xs text-ink-muted mb-4">{$_('social.noProjectAccountsDesc')}</p>
+          <a href="/projects/{projectId}/settings" class="inline-block text-sm px-4 py-2 bg-brand text-white rounded-lg hover:brightness-110 transition-colors duration-150">
             {$_('social.goToProjectSettings')}
           </a>
         </div>
       {:else}
         <!-- Account selection -->
         <div class="p-6 space-y-2">
-          <p class="text-sm text-gray-600 mb-3">{$_('social.publishToDesc')}</p>
+          <p class="text-sm text-ink-muted mb-3">{$_('social.publishToDesc')}</p>
           {#each socialAccounts as account}
             <!-- svelte-ignore a11y-click-events-have-key-events -->
             <!-- svelte-ignore a11y-no-static-element-interactions -->
             <div
-              class="flex items-center gap-3 p-3 rounded-xl border cursor-pointer transition-colors duration-150 {selectedAccountIds.includes(account.id) ? 'border-primary-400 bg-primary-50' : 'border-gray-200 hover:bg-gray-50'}"
+              class="flex items-center gap-3 p-3 rounded-xl border cursor-pointer transition-colors duration-150 {selectedAccountIds.includes(account.id) ? 'border-primary-400 bg-brand-subtle/10' : 'border-border hover:bg-surface-2'}"
               on:click={() => toggleAccount(account.id)}
             >
-              <input type="checkbox" checked={selectedAccountIds.includes(account.id)} class="w-4 h-4 text-primary-600 rounded border-gray-300 cursor-pointer" readonly />
+              <input type="checkbox" checked={selectedAccountIds.includes(account.id)} class="w-4 h-4 text-brand rounded border-border cursor-pointer" readonly />
               {#if account.profileImageUrl}
                 <img src={account.profileImageUrl} alt={account.accountName} class="w-8 h-8 rounded-full flex-shrink-0" />
               {:else}
-                <div class="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center flex-shrink-0 text-xs font-bold text-gray-500">
+                <div class="w-8 h-8 rounded-full bg-gray-200 flex items-center justify-center flex-shrink-0 text-xs font-bold text-ink-muted">
                   {account.accountName[0]?.toUpperCase()}
                 </div>
               {/if}
               <div class="flex-1 min-w-0">
-                <div class="text-sm font-medium text-gray-900 truncate" title={account.accountName}>{account.accountName}</div>
-                <div class="text-xs text-gray-500 flex items-center gap-1.5 flex-wrap">
+                <div class="text-sm font-medium text-ink truncate" title={account.accountName}>{account.accountName}</div>
+                <div class="text-xs text-ink-muted flex items-center gap-1.5 flex-wrap">
                   <span>{account.platform}{account.language ? ` - ${account.language.toUpperCase()}` : ''}</span>
                   {#if account.accountId}
-                    <span class="text-gray-300">·</span>
+                    <span class="text-ink-subtle">·</span>
                     <span class="font-mono truncate" title={account.accountId}>{account.accountId}</span>
                   {/if}
                 </div>
@@ -1116,7 +1116,7 @@
                   <select
                     value={accountLanguageMap[account.id] || account.language || publishingContent.language || 'en'}
                     on:change={(e) => { accountLanguageMap[account.id] = (e.target as HTMLSelectElement).value; accountLanguageMap = accountLanguageMap; }}
-                    class="text-xs px-2 py-1 border border-gray-300 rounded-lg bg-white cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-500"
+                    class="text-xs px-2 py-1 border border-border rounded-lg bg-surface cursor-pointer focus:outline-none focus:ring-2 focus:ring-primary-500"
                   >
                     {#each groupSiblings as sibling}
                       <option value={sibling.language}>{(sibling.language || 'en').toUpperCase()}</option>
@@ -1127,7 +1127,7 @@
             </div>
           {/each}
         </div>
-        <div class="p-6 border-t border-gray-100 flex gap-3">
+        <div class="p-6 border-t border-border flex gap-3">
           <button
             on:click={publishContent}
             disabled={publishLoading || selectedAccountIds.length === 0}
@@ -1146,7 +1146,7 @@
               {$_('social.publish')} ({selectedAccountIds.length})
             {/if}
           </button>
-          <button on:click={() => publishingContent = null} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+          <button on:click={() => publishingContent = null} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
             {$_('common.cancel')}
           </button>
         </div>
@@ -1160,15 +1160,15 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => deletingId = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm">
       <div class="p-6">
         <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-4">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900 mb-2">{$_('content.deleteContent')}</h2>
-        <p class="text-sm text-gray-500 mb-6">{$_('content.confirmDelete')}</p>
+        <h2 class="text-lg font-semibold text-ink mb-2">{$_('content.deleteContent')}</h2>
+        <p class="text-sm text-ink-muted mb-6">{$_('content.confirmDelete')}</p>
         <div class="flex gap-3">
           <button
             on:click={() => deleteContent(deletingId!)}
@@ -1176,7 +1176,7 @@
           >
             {$_('common.delete')}
           </button>
-          <button on:click={() => deletingId = null} class="flex-1 px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+          <button on:click={() => deletingId = null} class="flex-1 px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
             {$_('common.cancel')}
           </button>
         </div>
@@ -1190,23 +1190,23 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => repurposingContent = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
         <div class="w-8 h-8 bg-indigo-50 rounded-lg flex items-center justify-center flex-shrink-0">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 12c0-1.232-.046-2.453-.138-3.662a4.006 4.006 0 0 0-3.7-3.7 48.678 48.678 0 0 0-7.324 0 4.006 4.006 0 0 0-3.7 3.7c-.017.22-.032.441-.046.662M19.5 12l3-3m-3 3-3-3m-12 3c0 1.232.046 2.453.138 3.662a4.006 4.006 0 0 0 3.7 3.7 48.656 48.656 0 0 0 7.324 0 4.006 4.006 0 0 0 3.7-3.7c.017-.22.032-.441.046-.662M4.5 12l3 3m-3-3-3 3" />
           </svg>
         </div>
         <div>
-          <h2 class="text-lg font-semibold text-gray-900">{$_('content.repurpose')}</h2>
-          <p class="text-xs text-gray-500 truncate max-w-[300px]">{repurposingContent.title}</p>
+          <h2 class="text-lg font-semibold text-ink">{$_('content.repurpose')}</h2>
+          <p class="text-xs text-ink-muted truncate max-w-[300px]">{repurposingContent.title}</p>
         </div>
       </div>
       <div class="p-6 space-y-4">
-        <p class="text-sm text-gray-600">{$_('content.repurposeDesc')}</p>
+        <p class="text-sm text-ink-muted">{$_('content.repurposeDesc')}</p>
         <div>
-          <label for="repurpose-type" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('content.targetType')}</label>
-          <select id="repurpose-type" bind:value={repurposeTarget} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent">
+          <label for="repurpose-type" class="block text-sm font-medium text-ink mb-1.5">{$_('content.targetType')}</label>
+          <select id="repurpose-type" bind:value={repurposeTarget} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-transparent">
             <option value="SOCIAL_POST">{$_('content.socialPost')}</option>
             <option value="BLOG_ARTICLE">{$_('content.blogArticle')}</option>
             <option value="EMAIL">{$_('content.emailContent')}</option>
@@ -1219,7 +1219,7 @@
           </select>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={repurposeContent}
           disabled={repurposeLoading}
@@ -1233,7 +1233,7 @@
           {/if}
           {$_('content.repurpose')}
         </button>
-        <button on:click={() => repurposingContent = null} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={() => repurposingContent = null} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>
@@ -1246,23 +1246,23 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showCreateModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-[90vw] h-[90vh] flex flex-col">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5 flex-shrink-0">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-[90vw] h-[90vh] flex flex-col">
+      <div class="p-6 border-b border-border flex items-center gap-2.5 flex-shrink-0">
         <div class="w-8 h-8 bg-green-50 rounded-lg flex items-center justify-center flex-shrink-0">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900">{$_('content.createContent')}</h2>
+        <h2 class="text-lg font-semibold text-ink">{$_('content.createContent')}</h2>
       </div>
       <div class="p-6 space-y-4 flex-1 flex flex-col overflow-y-auto">
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1.5">{$_('content.topic')}</label>
-          <input type="text" bind:value={createForm.title} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" placeholder={$_('content.topicPlaceholder')} />
+          <label class="block text-sm font-medium text-ink mb-1.5">{$_('content.topic')}</label>
+          <input type="text" bind:value={createForm.title} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" placeholder={$_('content.topicPlaceholder')} />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1.5">{$_('content.type')}</label>
-          <select bind:value={createForm.type} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+          <label class="block text-sm font-medium text-ink mb-1.5">{$_('content.type')}</label>
+          <select bind:value={createForm.type} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
             <option value="SOCIAL_POST">{$_('content.socialPost')}</option>
             <option value="BLOG_ARTICLE">{$_('content.blogArticle')}</option>
             <option value="EMAIL">{$_('content.emailContent')}</option>
@@ -1275,13 +1275,13 @@
           </select>
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1.5">{$_('content.platform')}</label>
+          <label class="block text-sm font-medium text-ink mb-1.5">{$_('content.platform')}</label>
           <div class="flex flex-wrap gap-2">
             {#each PLATFORM_OPTIONS as opt}
               <button
                 type="button"
                 on:click={() => toggleCreatePlatform(opt.value)}
-                class="px-3 py-1.5 rounded-lg border text-sm cursor-pointer transition-colors duration-150 {createPlatforms.includes(opt.value) ? 'bg-primary-50 border-primary-500 text-primary-700' : 'bg-white border-gray-300 text-gray-700 hover:bg-gray-50'}"
+                class="px-3 py-1.5 rounded-lg border text-sm cursor-pointer transition-colors duration-150 {createPlatforms.includes(opt.value) ? 'bg-brand-subtle/10 border-primary-500 text-brand' : 'bg-surface border-border text-ink hover:bg-surface-2'}"
               >
                 {opt.label}
               </button>
@@ -1290,18 +1290,18 @@
         </div>
 
         <label class="flex items-center gap-2">
-          <input type="checkbox" bind:checked={createAllLanguages} class="rounded border-gray-300 text-primary-600 focus:ring-primary-500" />
-          <span class="text-sm text-gray-700">{$_('content.createAllLanguages')}</span>
+          <input type="checkbox" bind:checked={createAllLanguages} class="rounded border-border text-brand focus:ring-primary-500" />
+          <span class="text-sm text-ink">{$_('content.createAllLanguages')}</span>
         </label>
 
         {#if createAllLanguages}
           <!-- Language tabs -->
           <div class="flex-1 flex flex-col min-h-[400px]">
-            <div class="flex border-b border-gray-200 mb-3 flex-shrink-0">
+            <div class="flex border-b border-border mb-3 flex-shrink-0">
               {#each ['en', 'pl', 'ru'] as lang}
                 <button
                   on:click={() => activeCreateLang = lang}
-                  class="px-4 py-2 text-sm font-medium border-b-2 transition-colors duration-150 cursor-pointer {activeCreateLang === lang ? 'border-primary-500 text-primary-600' : 'border-transparent text-gray-500 hover:text-gray-700'}"
+                  class="px-4 py-2 text-sm font-medium border-b-2 transition-colors duration-150 cursor-pointer {activeCreateLang === lang ? 'border-primary-500 text-brand' : 'border-transparent text-ink-muted hover:text-gray-700'}"
                 >
                   {lang.toUpperCase()}
                 </button>
@@ -1315,7 +1315,7 @@
           </div>
         {:else}
           <div class="flex-1 flex flex-col min-h-[400px]">
-            <label class="block text-sm font-medium text-gray-700 mb-1.5 flex-shrink-0">{$_('content.type')}</label>
+            <label class="block text-sm font-medium text-ink mb-1.5 flex-shrink-0">{$_('content.type')}</label>
             <div class="flex-1 min-h-0">
               <MarkdownEditor bind:value={createForm.body} placeholder={$_('content.bodyPlaceholder')} />
             </div>
@@ -1323,7 +1323,7 @@
         {/if}
 
         <div class="border-t pt-4 mt-4">
-          <label class="flex items-center gap-2 text-sm font-medium text-gray-700">
+          <label class="flex items-center gap-2 text-sm font-medium text-ink">
             <input type="checkbox" bind:checked={scheduleEnabled} />
             {$_('content.schedule.scheduleForLater')}
           </label>
@@ -1331,17 +1331,17 @@
           {#if scheduleEnabled}
             <div class="mt-3 space-y-3">
               <div>
-                <label class="block text-xs font-medium text-gray-600 mb-1">{$_('content.schedule.scheduledAt')}</label>
+                <label class="block text-xs font-medium text-ink-muted mb-1">{$_('content.schedule.scheduledAt')}</label>
                 <input type="datetime-local" bind:value={scheduleAt}
                        class="w-full border rounded-lg px-3 py-2 text-sm" />
               </div>
 
               <div>
-                <label class="block text-xs font-medium text-gray-600 mb-1">{$_('content.schedule.selectAccounts')}</label>
+                <label class="block text-xs font-medium text-ink-muted mb-1">{$_('content.schedule.selectAccounts')}</label>
                 {#if projectAccounts.length === 0}
-                  <p class="text-xs text-gray-500">{$_('content.schedule.noProjectAccounts')}</p>
+                  <p class="text-xs text-ink-muted">{$_('content.schedule.noProjectAccounts')}</p>
                 {:else}
-                  <p class="text-xs text-gray-500 mb-1">{$_('content.schedule.languageRoutingHint')}</p>
+                  <p class="text-xs text-ink-muted mb-1">{$_('content.schedule.languageRoutingHint')}</p>
                   <div class="space-y-1 max-h-40 overflow-y-auto border rounded-lg p-2">
                     {#each projectAccounts as acc}
                       <label class="flex items-center gap-2 text-sm">
@@ -1352,8 +1352,8 @@
                                  else scheduleAccountIds = scheduleAccountIds.filter(id => id !== acc.id);
                                }} />
                         <span class="font-medium">{acc.platform}</span>
-                        <span class="text-gray-500 truncate">{acc.accountName}</span>
-                        {#if acc.language}<span class="text-xs px-1.5 py-0.5 bg-gray-100 rounded">{acc.language.toUpperCase()}</span>{/if}
+                        <span class="text-ink-muted truncate">{acc.accountName}</span>
+                        {#if acc.language}<span class="text-xs px-1.5 py-0.5 bg-surface-2 rounded">{acc.language.toUpperCase()}</span>{/if}
                       </label>
                     {/each}
                   </div>
@@ -1363,14 +1363,14 @@
           {/if}
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3 justify-end flex-shrink-0">
-        <button on:click={() => showCreateModal = false} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+      <div class="p-6 border-t border-border flex gap-3 justify-end flex-shrink-0">
+        <button on:click={() => showCreateModal = false} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
         <button
           on:click={createContent}
           disabled={createSaving || !createForm.title.trim()}
-          class="px-6 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
+          class="px-6 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
         >
           {#if createSaving}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">

--- a/apps/web/src/routes/(app)/projects/[id]/content/[contentId]/edit/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/content/[contentId]/edit/+page.svelte
@@ -117,20 +117,20 @@
       <input
         type="text"
         bind:value={content.title}
-        class="text-2xl font-bold bg-transparent border-none focus:outline-none focus:ring-0 w-full text-gray-900 placeholder-gray-400"
+        class="text-2xl font-bold bg-transparent border-none focus:outline-none focus:ring-0 w-full text-ink placeholder-gray-400"
         placeholder={$_('content.title')}
       />
       <div class="flex gap-2 flex-shrink-0">
         <button
           on:click={() => goto(`/projects/${projectId}/content`)}
-          class="px-4 py-2 text-sm text-gray-600 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 cursor-pointer"
+          class="px-4 py-2 text-sm text-ink-muted bg-surface border border-border rounded-lg hover:bg-surface-2 cursor-pointer"
         >
           {$_('common.cancel')}
         </button>
         <button
           on:click={save}
           disabled={saving}
-          class="px-4 py-2 text-sm text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50 cursor-pointer"
+          class="px-4 py-2 text-sm text-white bg-brand rounded-lg hover:brightness-110 disabled:opacity-50 cursor-pointer"
         >
           {saving ? $_('common.saving') : $_('common.save')}
         </button>
@@ -156,12 +156,12 @@
         type="text"
         bind:value={imagePrompt}
         placeholder={$_('content.imagePrompt')}
-        class="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-primary-500 focus:border-primary-500"
+        class="flex-1 border border-border rounded-lg px-3 py-2 text-sm focus:ring-primary-500 focus:border-primary-500"
       />
       <button
         on:click={() => generateImage(imagePrompt)}
         disabled={generatingImage || !imagePrompt}
-        class="px-4 py-2 text-sm text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50 cursor-pointer whitespace-nowrap"
+        class="px-4 py-2 text-sm text-white bg-brand rounded-lg hover:brightness-110 disabled:opacity-50 cursor-pointer whitespace-nowrap"
       >
         {generatingImage ? $_('content.generating_image') : $_('content.generateImage')}
       </button>
@@ -170,11 +170,11 @@
     <!-- Attached images -->
     {#if content.mediaUrls?.length}
       <div class="mt-3">
-        <p class="text-sm text-gray-500 mb-1">{$_('content.attachedImages')}</p>
+        <p class="text-sm text-ink-muted mb-1">{$_('content.attachedImages')}</p>
         <div class="flex flex-wrap gap-2">
           {#each content.mediaUrls as url, i}
             <div class="relative group">
-              <img src={url} alt="" class="w-20 h-20 object-cover rounded border border-gray-200" />
+              <img src={url} alt="" class="w-20 h-20 object-cover rounded border border-border" />
               <button
                 on:click={() => removeImage(i)}
                 class="absolute -top-1 -right-1 bg-red-500 text-white rounded-full w-5 h-5 text-xs leading-none flex items-center justify-center opacity-0 group-hover:opacity-100 transition-opacity cursor-pointer"
@@ -188,7 +188,7 @@
     <!-- Schedule -->
     {#if content.status !== 'PUBLISHED'}
       <div class="mt-6 border-t pt-4">
-        <label class="flex items-center gap-2 text-sm font-medium text-gray-700">
+        <label class="flex items-center gap-2 text-sm font-medium text-ink">
           <input type="checkbox" bind:checked={scheduleEnabled} />
           {$_('content.schedule.scheduleForLater')}
         </label>
@@ -196,17 +196,17 @@
         {#if scheduleEnabled}
           <div class="mt-3 space-y-3 max-w-2xl">
             <div>
-              <label class="block text-xs font-medium text-gray-600 mb-1">{$_('content.schedule.scheduledAt')}</label>
+              <label class="block text-xs font-medium text-ink-muted mb-1">{$_('content.schedule.scheduledAt')}</label>
               <input type="datetime-local" bind:value={scheduleAt}
                      class="w-full border rounded-lg px-3 py-2 text-sm" />
             </div>
 
             <div>
-              <label class="block text-xs font-medium text-gray-600 mb-1">{$_('content.schedule.selectAccounts')}</label>
+              <label class="block text-xs font-medium text-ink-muted mb-1">{$_('content.schedule.selectAccounts')}</label>
               {#if projectAccounts.length === 0}
-                <p class="text-xs text-gray-500">{$_('content.schedule.noProjectAccounts')}</p>
+                <p class="text-xs text-ink-muted">{$_('content.schedule.noProjectAccounts')}</p>
               {:else}
-                <p class="text-xs text-gray-500 mb-1">{$_('content.schedule.languageRoutingHint')}</p>
+                <p class="text-xs text-ink-muted mb-1">{$_('content.schedule.languageRoutingHint')}</p>
                 <div class="space-y-1 max-h-40 overflow-y-auto border rounded-lg p-2">
                   {#each projectAccounts as acc}
                     <label class="flex items-center gap-2 text-sm">
@@ -217,8 +217,8 @@
                                else scheduleAccountIds = scheduleAccountIds.filter(id => id !== acc.id);
                              }} />
                       <span class="font-medium">{acc.platform}</span>
-                      <span class="text-gray-500 truncate">{acc.accountName}</span>
-                      {#if acc.language}<span class="text-xs px-1.5 py-0.5 bg-gray-100 rounded">{acc.language.toUpperCase()}</span>{/if}
+                      <span class="text-ink-muted truncate">{acc.accountName}</span>
+                      {#if acc.language}<span class="text-xs px-1.5 py-0.5 bg-surface-2 rounded">{acc.language.toUpperCase()}</span>{/if}
                     </label>
                   {/each}
                 </div>
@@ -231,6 +231,6 @@
   </div>
 {:else}
   <div class="flex items-center justify-center h-64">
-    <p class="text-gray-500">Content not found</p>
+    <p class="text-ink-muted">Content not found</p>
   </div>
 {/if}

--- a/apps/web/src/routes/(app)/projects/[id]/documents/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/documents/+page.svelte
@@ -330,11 +330,11 @@
   <SectionHint sectionKey="documents" titleKey="hints.documents.title" descKey="hints.documents.desc" />
   <!-- Header -->
   <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-6">
-    <h1 class="text-2xl font-bold text-gray-900">{$_('documents.title')}</h1>
+    <h1 class="text-2xl font-bold text-ink">{$_('documents.title')}</h1>
     <div class="flex items-center gap-2 flex-wrap">
       <button
         on:click={() => showManageTypesModal = true}
-        class="border border-gray-300 text-gray-700 px-3 sm:px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors duration-150 flex items-center gap-1.5 cursor-pointer"
+        class="border border-border text-ink px-3 sm:px-4 py-2 rounded-lg text-sm font-medium hover:bg-surface-2 transition-colors duration-150 flex items-center gap-1.5 cursor-pointer"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
@@ -344,7 +344,7 @@
       </button>
       <button
         on:click={() => showCreateModal = true}
-        class="border border-gray-300 text-gray-700 px-3 sm:px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors duration-150 flex items-center gap-1.5 cursor-pointer"
+        class="border border-border text-ink px-3 sm:px-4 py-2 rounded-lg text-sm font-medium hover:bg-surface-2 transition-colors duration-150 flex items-center gap-1.5 cursor-pointer"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -353,7 +353,7 @@
       </button>
       <button
         on:click={() => { showUploadModal = true; uploadFile = null; uploadForm = { type: '', title: '' }; }}
-        class="border border-gray-300 text-gray-700 px-3 sm:px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors duration-150 flex items-center gap-1.5 cursor-pointer"
+        class="border border-border text-ink px-3 sm:px-4 py-2 rounded-lg text-sm font-medium hover:bg-surface-2 transition-colors duration-150 flex items-center gap-1.5 cursor-pointer"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
@@ -362,7 +362,7 @@
       </button>
       <button
         on:click={() => showGenerateModal = true}
-        class="bg-primary-600 text-white px-3 sm:px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 flex items-center gap-1.5 cursor-pointer"
+        class="bg-brand text-white px-3 sm:px-4 py-2 rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-1.5 cursor-pointer"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" />
@@ -403,24 +403,24 @@
   {#if loading}
     <div class="space-y-3">
       {#each Array(3) as _}
-        <div class="bg-white rounded-xl border border-gray-200 p-5 animate-pulse h-24"></div>
+        <div class="bg-surface rounded-xl border border-border p-5 animate-pulse h-24"></div>
       {/each}
     </div>
 
   <!-- Empty state -->
   {:else if documents.length === 0}
     <div class="flex flex-col items-center justify-center py-20 text-center">
-      <div class="w-20 h-20 bg-primary-50 rounded-2xl flex items-center justify-center mb-6">
+      <div class="w-20 h-20 bg-brand-subtle/10 rounded-2xl flex items-center justify-center mb-6">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
         </svg>
       </div>
-      <h2 class="text-xl font-semibold text-gray-900 mb-2">{$_('documents.empty')}</h2>
-      <p class="text-gray-500 mb-6">{$_('documents.emptyDesc')}</p>
+      <h2 class="text-xl font-semibold text-ink mb-2">{$_('documents.empty')}</h2>
+      <p class="text-ink-muted mb-6">{$_('documents.emptyDesc')}</p>
       <div class="flex items-center gap-3">
         <button
           on:click={() => showCreateModal = true}
-          class="border border-gray-300 text-gray-700 px-5 py-3 rounded-xl font-medium hover:bg-gray-50 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+          class="border border-border text-ink px-5 py-3 rounded-xl font-medium hover:bg-surface-2 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
         >
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -429,7 +429,7 @@
         </button>
         <button
           on:click={() => { showUploadModal = true; uploadFile = null; uploadForm = { type: '', title: '' }; }}
-          class="border border-gray-300 text-gray-700 px-5 py-3 rounded-xl font-medium hover:bg-gray-50 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+          class="border border-border text-ink px-5 py-3 rounded-xl font-medium hover:bg-surface-2 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
         >
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
@@ -438,7 +438,7 @@
         </button>
         <button
           on:click={() => showGenerateModal = true}
-          class="bg-primary-600 text-white px-5 py-3 rounded-xl font-medium hover:bg-primary-700 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+          class="bg-brand text-white px-5 py-3 rounded-xl font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
         >
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" />
@@ -455,27 +455,27 @@
         <!-- svelte-ignore a11y_click_events_have_key_events -->
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <div
-          class="bg-white rounded-xl border border-gray-200 border-l-4 border-l-primary-400 p-5 hover:shadow-sm transition-shadow duration-150 cursor-pointer"
+          class="bg-surface rounded-xl border border-border border-l-4 border-l-primary-400 p-5 hover:shadow-sm transition-shadow duration-150 cursor-pointer"
           on:click={() => openView(doc)}
         >
           <div class="flex items-start justify-between gap-4">
             <div class="flex items-start gap-4 flex-1 min-w-0">
-              <div class="w-10 h-10 rounded-lg bg-primary-50 flex items-center justify-center flex-shrink-0">
+              <div class="w-10 h-10 rounded-lg bg-brand-subtle/10 flex items-center justify-center flex-shrink-0">
                 {#if doc.fileUrl}
-                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                     <path stroke-linecap="round" stroke-linejoin="round" d="m18.375 12.739-7.693 7.693a4.5 4.5 0 0 1-6.364-6.364l10.94-10.94A3 3 0 1 1 19.5 7.372L8.552 18.32m.009-.01-.01.01m5.699-9.941-7.81 7.81a1.5 1.5 0 0 0 2.112 2.13" />
                   </svg>
                 {:else}
-                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
                   </svg>
                 {/if}
               </div>
               <div class="flex-1 min-w-0">
-                <h3 class="font-medium text-gray-900 truncate">{doc.title}</h3>
+                <h3 class="font-medium text-ink truncate">{doc.title}</h3>
                 <div class="flex flex-wrap items-center gap-1.5 mt-1.5">
-                  <span class="text-xs px-2 py-0.5 bg-gray-100 text-gray-600 rounded font-medium">{getTypeLabel(doc.type)}</span>
-                  <span class="text-xs text-gray-400">{$_('documents.version')} {doc.version}</span>
+                  <span class="text-xs px-2 py-0.5 bg-surface-2 text-ink-muted rounded font-medium">{getTypeLabel(doc.type)}</span>
+                  <span class="text-xs text-ink-subtle">{$_('documents.version')} {doc.version}</span>
                   {#if doc.generatedByAi}
                     <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-purple-50 text-purple-600 rounded">
                       <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -493,16 +493,16 @@
                     </span>
                   {/if}
                   {#if doc.fileSize}
-                    <span class="text-xs text-gray-400">{formatFileSize(doc.fileSize)}</span>
+                    <span class="text-xs text-ink-subtle">{formatFileSize(doc.fileSize)}</span>
                   {/if}
                 </div>
-                <p class="text-xs text-gray-400 mt-1">{new Date(doc.createdAt).toLocaleDateString()}</p>
+                <p class="text-xs text-ink-subtle mt-1">{new Date(doc.createdAt).toLocaleDateString()}</p>
               </div>
             </div>
             <div class="flex items-center gap-2 flex-shrink-0">
               <button
                 on:click|stopPropagation={() => openEdit(doc)}
-                class="text-xs px-3 py-1.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
+                class="text-xs px-3 py-1.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
               >
                 {$_('common.edit')}
               </button>
@@ -512,20 +512,20 @@
                   href="{API_URL.replace('/api', '')}{doc.fileUrl}"
                   download={doc.fileName || doc.title}
                   on:click|stopPropagation
-                  class="text-xs px-2 py-1.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 cursor-pointer inline-flex items-center"
+                  class="text-xs px-2 py-1.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 cursor-pointer inline-flex items-center"
                   title={$_('documents.download')}
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-ink-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
                   </svg>
                 </a>
               {:else if doc.contentMd}
                 <button
                   on:click|stopPropagation={() => downloadMarkdown(doc)}
-                  class="text-xs px-2 py-1.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
+                  class="text-xs px-2 py-1.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
                   title={$_('documents.download')}
                 >
-                  <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-ink-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
                   </svg>
                 </button>
@@ -553,34 +553,34 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showGenerateModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
-        <div class="w-8 h-8 bg-primary-50 rounded-lg flex items-center justify-center flex-shrink-0">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
+        <div class="w-8 h-8 bg-brand-subtle/10 rounded-lg flex items-center justify-center flex-shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904 9 18.75l-.813-2.846a4.5 4.5 0 0 0-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 0 0 3.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 0 0 3.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 0 0-3.09 3.09Z" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900">{$_('documents.generate')}</h2>
+        <h2 class="text-lg font-semibold text-ink">{$_('documents.generate')}</h2>
       </div>
       <div class="p-6 space-y-4">
         <div>
-          <label for="gen-type" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('documents.type')}</label>
-          <select id="gen-type" bind:value={generateForm.type} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+          <label for="gen-type" class="block text-sm font-medium text-ink mb-1.5">{$_('documents.type')}</label>
+          <select id="gen-type" bind:value={generateForm.type} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
             {#each docTypes as t}
               <option value={t.slug}>{t.label}</option>
             {/each}
           </select>
         </div>
         <div>
-          <label for="gen-title" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('documents.customTitle')} <span class="text-gray-400 font-normal">({$_('common.optional')})</span></label>
-          <input id="gen-title" type="text" bind:value={generateForm.title} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" placeholder={$_('documents.customTitlePlaceholder')} />
+          <label for="gen-title" class="block text-sm font-medium text-ink mb-1.5">{$_('documents.customTitle')} <span class="text-ink-subtle font-normal">({$_('common.optional')})</span></label>
+          <input id="gen-title" type="text" bind:value={generateForm.title} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" placeholder={$_('documents.customTitlePlaceholder')} />
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={generateDocument}
           disabled={generating}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
         >
           {#if generating}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -595,7 +595,7 @@
             {$_('documents.generate')}
           {/if}
         </button>
-        <button on:click={() => showGenerateModal = false} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={() => showGenerateModal = false} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>
@@ -608,23 +608,23 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showCreateModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-lg">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-lg">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
         <div class="w-8 h-8 bg-green-50 rounded-lg flex items-center justify-center flex-shrink-0">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900">{$_('documents.create')}</h2>
+        <h2 class="text-lg font-semibold text-ink">{$_('documents.create')}</h2>
       </div>
       <div class="p-6 space-y-4">
         <div>
-          <label for="create-title" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('documents.titleLabel')}</label>
-          <input id="create-title" type="text" bind:value={createForm.title} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" placeholder={$_('documents.titlePlaceholder')} />
+          <label for="create-title" class="block text-sm font-medium text-ink mb-1.5">{$_('documents.titleLabel')}</label>
+          <input id="create-title" type="text" bind:value={createForm.title} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" placeholder={$_('documents.titlePlaceholder')} />
         </div>
         <div>
-          <label for="create-type" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('documents.type')} <span class="text-gray-400 font-normal">({$_('common.optional')})</span></label>
-          <select id="create-type" bind:value={createForm.type} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+          <label for="create-type" class="block text-sm font-medium text-ink mb-1.5">{$_('documents.type')} <span class="text-ink-subtle font-normal">({$_('common.optional')})</span></label>
+          <select id="create-type" bind:value={createForm.type} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
             <option value="">{$_('documents.noType')}</option>
             {#each docTypes as t}
               <option value={t.slug}>{t.label}</option>
@@ -632,21 +632,21 @@
           </select>
         </div>
         <div>
-          <label for="create-content" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('content.title')} <span class="text-gray-400 font-normal">({$_('common.optional')})</span></label>
+          <label for="create-content" class="block text-sm font-medium text-ink mb-1.5">{$_('content.title')} <span class="text-ink-subtle font-normal">({$_('common.optional')})</span></label>
           <textarea
             id="create-content"
             bind:value={createForm.contentMd}
             rows="8"
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"
             placeholder={$_('documents.contentPlaceholder')}
           ></textarea>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={createDocument}
           disabled={creating || !createForm.title.trim()}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
         >
           {#if creating}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -656,7 +656,7 @@
           {/if}
           {$_('documents.create')}
         </button>
-        <button on:click={() => showCreateModal = false} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={() => showCreateModal = false} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>
@@ -669,20 +669,20 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showUploadModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
         <div class="w-8 h-8 bg-blue-50 rounded-lg flex items-center justify-center flex-shrink-0">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900">{$_('documents.uploadDocument')}</h2>
+        <h2 class="text-lg font-semibold text-ink">{$_('documents.uploadDocument')}</h2>
       </div>
       <div class="p-6 space-y-4">
         <!-- Drop zone -->
         <!-- svelte-ignore a11y_no_static_element_interactions -->
         <div
-          class="border-2 border-dashed rounded-xl p-6 text-center transition-colors duration-150 {dragOver ? 'border-primary-400 bg-primary-50' : 'border-gray-300 hover:border-gray-400'}"
+          class="border-2 border-dashed rounded-xl p-6 text-center transition-colors duration-150 {dragOver ? 'border-primary-400 bg-brand-subtle/10' : 'border-border hover:border-gray-400'}"
           on:drop={handleDrop}
           on:dragover={handleDragOver}
           on:dragleave={handleDragLeave}
@@ -693,22 +693,22 @@
                 <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
               </svg>
               <div class="text-left">
-                <p class="text-sm font-medium text-gray-900 truncate max-w-[200px]">{uploadFile.name}</p>
-                <p class="text-xs text-gray-500">{formatFileSize(uploadFile.size)}</p>
+                <p class="text-sm font-medium text-ink truncate max-w-[200px]">{uploadFile.name}</p>
+                <p class="text-xs text-ink-muted">{formatFileSize(uploadFile.size)}</p>
               </div>
-              <button on:click|stopPropagation={() => uploadFile = null} class="text-gray-400 hover:text-gray-600 cursor-pointer">
+              <button on:click|stopPropagation={() => uploadFile = null} class="text-ink-subtle hover:text-gray-600 cursor-pointer">
                 <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                   <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
                 </svg>
               </button>
             </div>
           {:else}
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-gray-300 mx-auto mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-ink-subtle mx-auto mb-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5m-13.5-9L12 3m0 0 4.5 4.5M12 3v13.5" />
             </svg>
-            <p class="text-sm text-gray-600 mb-1">{$_('documents.dragDrop')}</p>
-            <p class="text-xs text-gray-400 mb-3">{$_('documents.maxFileSize')}</p>
-            <label class="inline-flex items-center gap-2 px-4 py-2 bg-primary-50 text-primary-600 rounded-lg text-sm font-medium cursor-pointer hover:bg-primary-100 transition-colors duration-150">
+            <p class="text-sm text-ink-muted mb-1">{$_('documents.dragDrop')}</p>
+            <p class="text-xs text-ink-subtle mb-3">{$_('documents.maxFileSize')}</p>
+            <label class="inline-flex items-center gap-2 px-4 py-2 bg-brand-subtle/10 text-brand rounded-lg text-sm font-medium cursor-pointer hover:bg-primary-100 transition-colors duration-150">
               <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
               </svg>
@@ -719,8 +719,8 @@
         </div>
 
         <div>
-          <label for="upload-type" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('documents.type')} <span class="text-gray-400 font-normal">({$_('common.optional')})</span></label>
-          <select id="upload-type" bind:value={uploadForm.type} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+          <label for="upload-type" class="block text-sm font-medium text-ink mb-1.5">{$_('documents.type')} <span class="text-ink-subtle font-normal">({$_('common.optional')})</span></label>
+          <select id="upload-type" bind:value={uploadForm.type} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
             <option value="">{$_('documents.noType')}</option>
             {#each docTypes as t}
               <option value={t.slug}>{t.label}</option>
@@ -728,16 +728,16 @@
           </select>
         </div>
         <div>
-          <label for="upload-title" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('documents.titleLabel')} <span class="text-gray-400 font-normal">({$_('common.optional')})</span></label>
-          <input id="upload-title" type="text" bind:value={uploadForm.title} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" placeholder={$_('documents.titlePlaceholder')} />
+          <label for="upload-title" class="block text-sm font-medium text-ink mb-1.5">{$_('documents.titleLabel')} <span class="text-ink-subtle font-normal">({$_('common.optional')})</span></label>
+          <input id="upload-title" type="text" bind:value={uploadForm.title} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" placeholder={$_('documents.titlePlaceholder')} />
         </div>
-        <p class="text-xs text-gray-400">{$_('documents.allowedTypes')}</p>
+        <p class="text-xs text-ink-subtle">{$_('documents.allowedTypes')}</p>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={uploadDocument}
           disabled={uploading || !uploadFile}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
         >
           {#if uploading}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -752,7 +752,7 @@
             {$_('documents.upload')}
           {/if}
         </button>
-        <button on:click={() => showUploadModal = false} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={() => showUploadModal = false} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>
@@ -765,19 +765,19 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => viewingDocument = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-4xl max-h-[90vh] flex flex-col">
-      <div class="p-6 border-b border-gray-100 flex items-start justify-between flex-shrink-0">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-4xl max-h-[90vh] flex flex-col">
+      <div class="p-6 border-b border-border flex items-start justify-between flex-shrink-0">
         <div class="flex items-start gap-3 flex-1 min-w-0">
-          <div class="w-10 h-10 rounded-lg bg-primary-50 flex items-center justify-center flex-shrink-0 mt-0.5">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+          <div class="w-10 h-10 rounded-lg bg-brand-subtle/10 flex items-center justify-center flex-shrink-0 mt-0.5">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
             </svg>
           </div>
           <div class="flex-1 min-w-0">
-            <h2 class="text-lg font-semibold text-gray-900 truncate">{viewingDocument.title}</h2>
+            <h2 class="text-lg font-semibold text-ink truncate">{viewingDocument.title}</h2>
             <div class="flex flex-wrap items-center gap-1.5 mt-1">
-              <span class="text-xs px-2 py-0.5 bg-gray-100 text-gray-600 rounded font-medium">{getTypeLabel(viewingDocument.type)}</span>
-              <span class="text-xs text-gray-400">{$_('documents.version')} {viewingDocument.version}</span>
+              <span class="text-xs px-2 py-0.5 bg-surface-2 text-ink-muted rounded font-medium">{getTypeLabel(viewingDocument.type)}</span>
+              <span class="text-xs text-ink-subtle">{$_('documents.version')} {viewingDocument.version}</span>
               {#if viewingDocument.generatedByAi}
                 <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 bg-purple-50 text-purple-600 rounded">
                   <svg xmlns="http://www.w3.org/2000/svg" class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -787,13 +787,13 @@
                 </span>
               {/if}
               {#if viewingDocument.fileSize}
-                <span class="text-xs text-gray-400">{formatFileSize(viewingDocument.fileSize)}</span>
+                <span class="text-xs text-ink-subtle">{formatFileSize(viewingDocument.fileSize)}</span>
               {/if}
-              <span class="text-xs text-gray-400">{new Date(viewingDocument.createdAt).toLocaleDateString()}</span>
+              <span class="text-xs text-ink-subtle">{new Date(viewingDocument.createdAt).toLocaleDateString()}</span>
             </div>
           </div>
         </div>
-        <button on:click={() => viewingDocument = null} class="p-1.5 rounded-lg text-gray-400 hover:text-gray-600 hover:bg-gray-100 transition-colors duration-150 cursor-pointer flex-shrink-0 ml-4">
+        <button on:click={() => viewingDocument = null} class="p-1.5 rounded-lg text-ink-subtle hover:text-gray-600 hover:bg-surface-2 transition-colors duration-150 cursor-pointer flex-shrink-0 ml-4">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
           </svg>
@@ -801,7 +801,7 @@
       </div>
       <div class="flex-1 overflow-y-auto p-6">
         {#if viewingDocument.contentMd}
-          <div class="prose prose-sm max-w-none prose-headings:text-gray-900 prose-p:text-gray-700 prose-strong:text-gray-900 prose-ul:text-gray-700 prose-ol:text-gray-700 prose-li:text-gray-700 prose-headings:mt-4 prose-headings:mb-2 prose-p:my-1.5 prose-ul:my-1.5 prose-ol:my-1.5 prose-li:my-0.5 prose-pre:bg-gray-50 prose-pre:text-gray-800 prose-pre:border prose-pre:border-gray-200 prose-pre:my-2 prose-code:text-primary-700 prose-code:bg-primary-50 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:before:content-[''] prose-code:after:content-[''] prose-a:text-primary-600 prose-blockquote:text-gray-600 prose-blockquote:border-primary-300">
+          <div class="prose prose-sm max-w-none prose-headings:text-gray-900 prose-p:text-gray-700 prose-strong:text-gray-900 prose-ul:text-gray-700 prose-ol:text-gray-700 prose-li:text-gray-700 prose-headings:mt-4 prose-headings:mb-2 prose-p:my-1.5 prose-ul:my-1.5 prose-ol:my-1.5 prose-li:my-0.5 prose-pre:bg-gray-50 prose-pre:text-gray-800 prose-pre:border prose-pre:border-gray-200 prose-pre:my-2 prose-code:text-primary-700 prose-code:bg-brand-subtle/10 prose-code:px-1 prose-code:py-0.5 prose-code:rounded prose-code:text-sm prose-code:before:content-[''] prose-code:after:content-[''] prose-a:text-primary-600 prose-blockquote:text-gray-600 prose-blockquote:border-primary-300">
             {@html renderMarkdown(viewingDocument.contentMd)}
           </div>
         {:else if viewingDocument.fileUrl && viewingDocument.mimeType && isImageMime(viewingDocument.mimeType)}
@@ -811,28 +811,28 @@
           </div>
         {:else if viewingDocument.fileUrl}
           <!-- File document — no inline preview -->
-          <div class="text-center py-12 text-gray-400">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-16 h-16 mx-auto mb-4 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1">
+          <div class="text-center py-12 text-ink-subtle">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-16 h-16 mx-auto mb-4 text-ink-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1">
               <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
             </svg>
-            <p class="text-gray-500 mb-1">{viewingDocument.fileName || viewingDocument.title}</p>
-            <p class="text-sm text-gray-400">{$_('documents.noPreview')}</p>
+            <p class="text-ink-muted mb-1">{viewingDocument.fileName || viewingDocument.title}</p>
+            <p class="text-sm text-ink-subtle">{$_('documents.noPreview')}</p>
           </div>
         {:else}
-          <div class="text-center py-12 text-gray-400">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-12 h-12 mx-auto mb-3 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+          <div class="text-center py-12 text-ink-subtle">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-12 h-12 mx-auto mb-3 text-ink-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
             </svg>
             <p>{$_('documents.emptyDesc')}</p>
           </div>
         {/if}
       </div>
-      <div class="p-4 border-t border-gray-100 flex items-center justify-end gap-2 flex-shrink-0">
+      <div class="p-4 border-t border-border flex items-center justify-end gap-2 flex-shrink-0">
         {#if viewingDocument.fileUrl}
           <a
             href="{API_URL.replace('/api', '')}{viewingDocument.fileUrl}"
             download={viewingDocument.fileName || viewingDocument.title}
-            class="px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors duration-150 flex items-center gap-2"
+            class="px-4 py-2 border border-border rounded-lg text-sm font-medium text-ink hover:bg-surface-2 transition-colors duration-150 flex items-center gap-2"
             on:click|stopPropagation
           >
             <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -843,7 +843,7 @@
         {:else if viewingDocument.contentMd}
           <button
             on:click={() => downloadMarkdown(viewingDocument)}
-            class="px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors duration-150 cursor-pointer flex items-center gap-2"
+            class="px-4 py-2 border border-border rounded-lg text-sm font-medium text-ink hover:bg-surface-2 transition-colors duration-150 cursor-pointer flex items-center gap-2"
           >
             <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 0 0 5.25 21h13.5A2.25 2.25 0 0 0 21 18.75V16.5M16.5 12 12 16.5m0 0L7.5 12m4.5 4.5V3" />
@@ -853,7 +853,7 @@
         {/if}
         <button
           on:click={() => openEdit(viewingDocument)}
-          class="px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 hover:bg-gray-50 transition-colors duration-150 cursor-pointer flex items-center gap-2"
+          class="px-4 py-2 border border-border rounded-lg text-sm font-medium text-ink hover:bg-surface-2 transition-colors duration-150 cursor-pointer flex items-center gap-2"
         >
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
@@ -879,23 +879,23 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => editingDocument = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-3xl">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-3xl">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
         <div class="w-8 h-8 bg-blue-50 rounded-lg flex items-center justify-center flex-shrink-0">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900">{$_('documents.editDocument')}</h2>
+        <h2 class="text-lg font-semibold text-ink">{$_('documents.editDocument')}</h2>
       </div>
       <div class="p-6 space-y-4">
         <div>
-          <label for="edit-title" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('documents.titleLabel')}</label>
-          <input id="edit-title" type="text" bind:value={editForm.title} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
+          <label for="edit-title" class="block text-sm font-medium text-ink mb-1.5">{$_('documents.titleLabel')}</label>
+          <input id="edit-title" type="text" bind:value={editForm.title} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
         </div>
         <div>
-          <label for="edit-type" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('documents.type')}</label>
-          <select id="edit-type" bind:value={editForm.type} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+          <label for="edit-type" class="block text-sm font-medium text-ink mb-1.5">{$_('documents.type')}</label>
+          <select id="edit-type" bind:value={editForm.type} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
             <option value="">{$_('documents.noType')}</option>
             {#each docTypes as t}
               <option value={t.slug}>{t.label}</option>
@@ -904,22 +904,22 @@
         </div>
         {#if !editingDocument?.fileUrl}
           <div>
-            <label for="edit-content" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('content.title')}</label>
+            <label for="edit-content" class="block text-sm font-medium text-ink mb-1.5">{$_('content.title')}</label>
             <textarea
               id="edit-content"
               bind:value={editForm.contentMd}
               rows="16"
-              class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"
+              class="w-full px-3 py-2 border border-border rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"
               placeholder={$_('documents.contentPlaceholder')}
             ></textarea>
           </div>
         {/if}
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={saveEdit}
           disabled={editSaving}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
         >
           {#if editSaving}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -929,7 +929,7 @@
           {/if}
           {$_('common.save')}
         </button>
-        <button on:click={() => editingDocument = null} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={() => editingDocument = null} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>
@@ -942,30 +942,30 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showManageTypesModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
-        <div class="w-8 h-8 bg-gray-100 rounded-lg flex items-center justify-center flex-shrink-0">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
+        <div class="w-8 h-8 bg-surface-2 rounded-lg flex items-center justify-center flex-shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-ink-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
             <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900">{$_('documents.manageTypes')}</h2>
+        <h2 class="text-lg font-semibold text-ink">{$_('documents.manageTypes')}</h2>
       </div>
       <div class="p-6 space-y-4">
         <!-- Existing types -->
         <div class="space-y-2 max-h-64 overflow-y-auto">
           {#each docTypes as t}
-            <div class="flex items-center justify-between px-3 py-2 bg-gray-50 rounded-lg">
+            <div class="flex items-center justify-between px-3 py-2 bg-surface-2 rounded-lg">
               <div class="flex items-center gap-2 min-w-0">
-                <span class="text-sm font-medium text-gray-900 truncate">{t.label}</span>
-                <span class="text-xs text-gray-400 font-mono">{t.slug}</span>
+                <span class="text-sm font-medium text-ink truncate">{t.label}</span>
+                <span class="text-xs text-ink-subtle font-mono">{t.slug}</span>
                 {#if t.isDefault}
                   <span class="text-xs px-1.5 py-0.5 bg-blue-50 text-blue-600 rounded">default</span>
                 {/if}
               </div>
               {#if isTypeInUse(t.slug)}
-                <span class="text-xs text-gray-400 flex-shrink-0" title={$_('documents.typeInUse')}>in use</span>
+                <span class="text-xs text-ink-subtle flex-shrink-0" title={$_('documents.typeInUse')}>in use</span>
               {:else}
                 <button
                   on:click={() => deletingTypeId = t.id}
@@ -994,7 +994,7 @@
               </button>
               <button
                 on:click={() => deletingTypeId = null}
-                class="text-xs px-3 py-1.5 border border-gray-300 rounded-lg hover:bg-gray-50 cursor-pointer"
+                class="text-xs px-3 py-1.5 border border-border rounded-lg hover:bg-surface-2 cursor-pointer"
               >
                 {$_('common.cancel')}
               </button>
@@ -1007,21 +1007,21 @@
           <input
             type="text"
             bind:value={newTypeLabel}
-            class="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            class="flex-1 px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             placeholder={$_('documents.typeLabelPlaceholder')}
             on:keydown={(e) => e.key === 'Enter' && addDocumentType()}
           />
           <button
             on:click={addDocumentType}
             disabled={addingType || !newTypeLabel.trim()}
-            class="px-4 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 cursor-pointer flex-shrink-0"
+            class="px-4 py-2 bg-brand text-white rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 cursor-pointer flex-shrink-0"
           >
             {$_('documents.addType')}
           </button>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex justify-end">
-        <button on:click={() => showManageTypesModal = false} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+      <div class="p-6 border-t border-border flex justify-end">
+        <button on:click={() => showManageTypesModal = false} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.close')}
         </button>
       </div>
@@ -1034,15 +1034,15 @@
   <!-- svelte-ignore a11y_click_events_have_key_events -->
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => deletingId = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm">
       <div class="p-6">
         <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-4">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900 mb-2">{$_('documents.deleteDocument')}</h2>
-        <p class="text-sm text-gray-500 mb-6">{$_('documents.confirmDelete')}</p>
+        <h2 class="text-lg font-semibold text-ink mb-2">{$_('documents.deleteDocument')}</h2>
+        <p class="text-sm text-ink-muted mb-6">{$_('documents.confirmDelete')}</p>
         <div class="flex gap-3">
           <button
             on:click={() => deleteDocument(deletingId!)}
@@ -1050,7 +1050,7 @@
           >
             {$_('common.delete')}
           </button>
-          <button on:click={() => deletingId = null} class="flex-1 px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+          <button on:click={() => deletingId = null} class="flex-1 px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
             {$_('common.cancel')}
           </button>
         </div>

--- a/apps/web/src/routes/(app)/projects/[id]/email/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/email/+page.svelte
@@ -290,12 +290,12 @@
   const statusColors: Record<string, string> = {
     sent: 'bg-green-100 text-green-700',
     sending: 'bg-yellow-100 text-yellow-700',
-    draft: 'bg-gray-100 text-gray-600',
+    draft: 'bg-surface-2 text-ink-muted',
   };
 
   const subStatusColors: Record<string, string> = {
     ACTIVE: 'bg-green-100 text-green-700',
-    UNSUBSCRIBED: 'bg-gray-100 text-gray-500',
+    UNSUBSCRIBED: 'bg-surface-2 text-ink-muted',
     BOUNCED: 'bg-red-100 text-red-700',
   };
 </script>
@@ -305,7 +305,7 @@
   <!-- Header -->
   <div class="flex items-center justify-between mb-6">
     <div>
-      <h1 class="text-2xl font-bold text-gray-900">{$_('email.title')}</h1>
+      <h1 class="text-2xl font-bold text-ink">{$_('email.title')}</h1>
     </div>
     {#if activeTab === 'lists'}
       <button
@@ -332,16 +332,16 @@
   </div>
 
   <!-- Tabs -->
-  <div class="flex gap-1 mb-6 bg-gray-100 p-1 rounded-xl w-fit">
+  <div class="flex gap-1 mb-6 bg-surface-2 p-1 rounded-xl w-fit">
     <button
       on:click={() => (activeTab = 'lists')}
-      class="px-4 py-2 text-sm font-medium rounded-lg transition-colors {activeTab === 'lists' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'}"
+      class="px-4 py-2 text-sm font-medium rounded-lg transition-colors {activeTab === 'lists' ? 'bg-surface text-ink shadow-sm' : 'text-ink-muted hover:text-gray-700'}"
     >
       {$_('email.tabLists')}
     </button>
     <button
       on:click={() => (activeTab = 'campaigns')}
-      class="px-4 py-2 text-sm font-medium rounded-lg transition-colors {activeTab === 'campaigns' ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-500 hover:text-gray-700'}"
+      class="px-4 py-2 text-sm font-medium rounded-lg transition-colors {activeTab === 'campaigns' ? 'bg-surface text-ink shadow-sm' : 'text-ink-muted hover:text-gray-700'}"
     >
       {$_('email.tabCampaigns')}
     </button>
@@ -358,14 +358,14 @@
         <div class="w-6 h-6 border-2 border-indigo-600 border-t-transparent rounded-full animate-spin"></div>
       </div>
     {:else if lists.length === 0}
-      <div class="text-center py-16 bg-gray-50 rounded-xl border border-dashed border-gray-200">
+      <div class="text-center py-16 bg-surface-2 rounded-xl border border-dashed border-border">
         <div class="w-12 h-12 bg-indigo-50 rounded-full flex items-center justify-center mx-auto mb-3">
           <svg class="w-6 h-6 text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
               d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
           </svg>
         </div>
-        <p class="text-gray-700 font-medium text-sm">{$_('email.noLists')}</p>
+        <p class="text-ink font-medium text-sm">{$_('email.noLists')}</p>
         <button
           on:click={() => (showCreateListModal = true)}
           class="mt-3 bg-indigo-600 text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors"
@@ -376,17 +376,17 @@
     {:else}
       <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {#each lists as list (list.id)}
-          <div class="bg-white border border-gray-200 rounded-xl p-5 flex flex-col gap-3 hover:border-indigo-200 transition-colors">
+          <div class="bg-surface border border-border rounded-xl p-5 flex flex-col gap-3 hover:border-indigo-200 transition-colors">
             <div class="flex items-start justify-between gap-2">
               <div class="min-w-0">
-                <h3 class="font-semibold text-gray-900 text-sm truncate">{list.name}</h3>
+                <h3 class="font-semibold text-ink text-sm truncate">{list.name}</h3>
                 {#if list.description}
-                  <p class="text-xs text-gray-400 mt-0.5 line-clamp-2">{list.description}</p>
+                  <p class="text-xs text-ink-subtle mt-0.5 line-clamp-2">{list.description}</p>
                 {/if}
               </div>
               <button
                 on:click={() => deleteList(list)}
-                class="text-gray-300 hover:text-red-500 transition-colors shrink-0"
+                class="text-ink-subtle hover:text-red-500 transition-colors shrink-0"
                 title={$_('email.deleteList')}
               >
                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -402,10 +402,10 @@
                   d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z" />
               </svg>
               <span class="text-sm font-medium">{list.subscriberCount}</span>
-              <span class="text-xs text-gray-400">{$_('email.subscribers').toLowerCase()}</span>
+              <span class="text-xs text-ink-subtle">{$_('email.subscribers').toLowerCase()}</span>
             </div>
 
-            <div class="text-xs text-gray-400">{formatDate(list.createdAt)}</div>
+            <div class="text-xs text-ink-subtle">{formatDate(list.createdAt)}</div>
 
             <button
               on:click={() => openSubscribers(list)}
@@ -430,14 +430,14 @@
         <div class="w-6 h-6 border-2 border-indigo-600 border-t-transparent rounded-full animate-spin"></div>
       </div>
     {:else if campaigns.length === 0}
-      <div class="text-center py-16 bg-gray-50 rounded-xl border border-dashed border-gray-200">
+      <div class="text-center py-16 bg-surface-2 rounded-xl border border-dashed border-border">
         <div class="w-12 h-12 bg-indigo-50 rounded-full flex items-center justify-center mx-auto mb-3">
           <svg class="w-6 h-6 text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
               d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8" />
           </svg>
         </div>
-        <p class="text-gray-700 font-medium text-sm">{$_('email.noCampaigns')}</p>
+        <p class="text-ink font-medium text-sm">{$_('email.noCampaigns')}</p>
         <button
           on:click={openSendModal}
           class="mt-3 bg-indigo-600 text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors"
@@ -448,20 +448,20 @@
     {:else}
       <div class="space-y-3">
         {#each campaigns as campaign (campaign.id)}
-          <div class="bg-white border border-gray-200 rounded-xl p-5">
+          <div class="bg-surface border border-border rounded-xl p-5">
             <div class="flex items-start justify-between gap-3 mb-3">
               <div class="min-w-0">
-                <h3 class="font-semibold text-gray-900 text-sm">{campaign.subject}</h3>
+                <h3 class="font-semibold text-ink text-sm">{campaign.subject}</h3>
                 {#if campaign.previewText}
-                  <p class="text-xs text-gray-400 mt-0.5">{campaign.previewText}</p>
+                  <p class="text-xs text-ink-subtle mt-0.5">{campaign.previewText}</p>
                 {/if}
               </div>
-              <span class="text-xs px-2.5 py-1 rounded-full font-medium shrink-0 {statusColors[campaign.status] ?? 'bg-gray-100 text-gray-600'}">
+              <span class="text-xs px-2.5 py-1 rounded-full font-medium shrink-0 {statusColors[campaign.status] ?? 'bg-surface-2 text-ink-muted'}">
                 {campaign.status}
               </span>
             </div>
 
-            <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-gray-500 mb-3">
+            <div class="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-ink-muted mb-3">
               {#if campaign.list}
                 <span class="flex items-center gap-1">
                   <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -488,26 +488,26 @@
             </div>
 
             {#if campaign.stats && campaign.stats.sent > 0}
-              <div class="flex flex-wrap gap-4 pt-3 border-t border-gray-100">
+              <div class="flex flex-wrap gap-4 pt-3 border-t border-border">
                 <div class="text-center">
-                  <div class="text-sm font-bold text-gray-900">{campaign.stats.sent}</div>
-                  <div class="text-xs text-gray-400">{$_('email.sent')}</div>
+                  <div class="text-sm font-bold text-ink">{campaign.stats.sent}</div>
+                  <div class="text-xs text-ink-subtle">{$_('email.sent')}</div>
                 </div>
                 <div class="text-center">
-                  <div class="text-sm font-bold text-gray-900">{pct(campaign.stats.opens, campaign.stats.sent)}</div>
-                  <div class="text-xs text-gray-400">{$_('email.openRate')}</div>
+                  <div class="text-sm font-bold text-ink">{pct(campaign.stats.opens, campaign.stats.sent)}</div>
+                  <div class="text-xs text-ink-subtle">{$_('email.openRate')}</div>
                 </div>
                 <div class="text-center">
-                  <div class="text-sm font-bold text-gray-900">{pct(campaign.stats.clicks, campaign.stats.sent)}</div>
-                  <div class="text-xs text-gray-400">{$_('email.clickRate')}</div>
+                  <div class="text-sm font-bold text-ink">{pct(campaign.stats.clicks, campaign.stats.sent)}</div>
+                  <div class="text-xs text-ink-subtle">{$_('email.clickRate')}</div>
                 </div>
                 <div class="text-center">
-                  <div class="text-sm font-bold text-gray-900">{campaign.stats.bounces}</div>
-                  <div class="text-xs text-gray-400">{$_('email.bounces')}</div>
+                  <div class="text-sm font-bold text-ink">{campaign.stats.bounces}</div>
+                  <div class="text-xs text-ink-subtle">{$_('email.bounces')}</div>
                 </div>
                 <div class="text-center">
-                  <div class="text-sm font-bold text-gray-900">{campaign.stats.unsubscribes}</div>
-                  <div class="text-xs text-gray-400">{$_('email.unsubscribes')}</div>
+                  <div class="text-sm font-bold text-ink">{campaign.stats.unsubscribes}</div>
+                  <div class="text-xs text-ink-subtle">{$_('email.unsubscribes')}</div>
                 </div>
               </div>
             {/if}
@@ -528,11 +528,11 @@
     on:click|self={() => (showCreateListModal = false)}
     on:keydown={(e) => e.key === 'Escape' && (showCreateListModal = false)}
   >
-    <div class="bg-white rounded-2xl shadow-xl w-full max-w-sm">
+    <div class="bg-surface rounded-2xl shadow-xl w-full max-w-sm">
       <div class="p-6">
         <div class="flex items-center justify-between mb-5">
-          <h2 class="text-lg font-semibold text-gray-900">{$_('email.createListTitle')}</h2>
-          <button on:click={() => (showCreateListModal = false)} class="text-gray-400 hover:text-gray-600 transition-colors">
+          <h2 class="text-lg font-semibold text-ink">{$_('email.createListTitle')}</h2>
+          <button on:click={() => (showCreateListModal = false)} class="text-ink-subtle hover:text-gray-600 transition-colors">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -545,31 +545,31 @@
 
         <form on:submit|preventDefault={createList} class="space-y-4">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">{$_('email.listName')} *</label>
+            <label class="block text-sm font-medium text-ink mb-1">{$_('email.listName')} *</label>
             <input
               type="text"
               bind:value={newListName}
               required
               placeholder={$_('email.placeholderListName')}
-              class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              class="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
             />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">
-              {$_('common.description')} <span class="text-gray-400 font-normal">({$_('common.optional')})</span>
+            <label class="block text-sm font-medium text-ink mb-1">
+              {$_('common.description')} <span class="text-ink-subtle font-normal">({$_('common.optional')})</span>
             </label>
             <input
               type="text"
               bind:value={newListDesc}
               placeholder={$_('email.placeholderListDesc')}
-              class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              class="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
             />
           </div>
           <div class="flex gap-3 pt-1">
             <button
               type="button"
               on:click={() => (showCreateListModal = false)}
-              class="flex-1 border border-gray-200 text-gray-700 text-sm font-medium py-2.5 rounded-xl hover:bg-gray-50 transition-colors"
+              class="flex-1 border border-border text-ink text-sm font-medium py-2.5 rounded-xl hover:bg-surface-2 transition-colors"
             >
               {$_('common.cancel')}
             </button>
@@ -597,14 +597,14 @@
     on:click|self={() => (selectedList = null)}
     on:keydown={(e) => e.key === 'Escape' && (selectedList = null)}
   >
-    <div class="bg-white rounded-2xl shadow-xl w-full max-w-2xl max-h-[85vh] flex flex-col">
-      <div class="p-6 border-b border-gray-100 shrink-0">
+    <div class="bg-surface rounded-2xl shadow-xl w-full max-w-2xl max-h-[85vh] flex flex-col">
+      <div class="p-6 border-b border-border shrink-0">
         <div class="flex items-center justify-between">
           <div>
-            <h2 class="text-lg font-semibold text-gray-900">{selectedList.name}</h2>
-            <p class="text-sm text-gray-400 mt-0.5">{$_('email.subscribers')}</p>
+            <h2 class="text-lg font-semibold text-ink">{selectedList.name}</h2>
+            <p class="text-sm text-ink-subtle mt-0.5">{$_('email.subscribers')}</p>
           </div>
-          <button on:click={() => (selectedList = null)} class="text-gray-400 hover:text-gray-600 transition-colors">
+          <button on:click={() => (selectedList = null)} class="text-ink-subtle hover:text-gray-600 transition-colors">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -618,13 +618,13 @@
             bind:value={newSubEmail}
             required
             placeholder={$_('email.subscriberEmail')}
-            class="flex-1 border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            class="flex-1 border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
           <input
             type="text"
             bind:value={newSubName}
             placeholder={$_('email.subscriberName')}
-            class="w-36 border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+            class="w-36 border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
           />
           <button
             type="submit"
@@ -648,33 +648,33 @@
         {:else if subscribersError}
           <div class="px-6 py-4 text-sm text-red-600">{subscribersError}</div>
         {:else if subscribers.length === 0}
-          <div class="text-center py-10 text-gray-400 text-sm">{$_('email.noSubscribers')}</div>
+          <div class="text-center py-10 text-ink-subtle text-sm">{$_('email.noSubscribers')}</div>
         {:else}
           <table class="w-full text-sm">
-            <thead class="bg-gray-50 sticky top-0">
+            <thead class="bg-surface-2 sticky top-0">
               <tr>
-                <th class="text-left px-6 py-3 text-xs font-medium text-gray-500 uppercase tracking-wide">{$_('email.subscriberEmail')}</th>
-                <th class="text-left px-3 py-3 text-xs font-medium text-gray-500 uppercase tracking-wide">{$_('email.subscriberName')}</th>
-                <th class="text-left px-3 py-3 text-xs font-medium text-gray-500 uppercase tracking-wide">{$_('common.status')}</th>
-                <th class="text-left px-3 py-3 text-xs font-medium text-gray-500 uppercase tracking-wide">{$_('common.date')}</th>
+                <th class="text-left px-6 py-3 text-xs font-medium text-ink-muted uppercase tracking-wide">{$_('email.subscriberEmail')}</th>
+                <th class="text-left px-3 py-3 text-xs font-medium text-ink-muted uppercase tracking-wide">{$_('email.subscriberName')}</th>
+                <th class="text-left px-3 py-3 text-xs font-medium text-ink-muted uppercase tracking-wide">{$_('common.status')}</th>
+                <th class="text-left px-3 py-3 text-xs font-medium text-ink-muted uppercase tracking-wide">{$_('common.date')}</th>
                 <th class="px-3 py-3"></th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-50">
               {#each subscribers as sub (sub.id)}
-                <tr class="hover:bg-gray-50 transition-colors">
-                  <td class="px-6 py-3 text-gray-900 font-medium">{sub.email}</td>
-                  <td class="px-3 py-3 text-gray-500">{sub.name ?? '—'}</td>
+                <tr class="hover:bg-surface-2 transition-colors">
+                  <td class="px-6 py-3 text-ink font-medium">{sub.email}</td>
+                  <td class="px-3 py-3 text-ink-muted">{sub.name ?? '—'}</td>
                   <td class="px-3 py-3">
-                    <span class="text-xs px-2 py-0.5 rounded-full font-medium {subStatusColors[sub.status] ?? 'bg-gray-100 text-gray-600'}">
+                    <span class="text-xs px-2 py-0.5 rounded-full font-medium {subStatusColors[sub.status] ?? 'bg-surface-2 text-ink-muted'}">
                       {$_(`email.${sub.status.toLowerCase()}`) || sub.status}
                     </span>
                   </td>
-                  <td class="px-3 py-3 text-gray-400 text-xs">{formatDate(sub.subscribedAt)}</td>
+                  <td class="px-3 py-3 text-ink-subtle text-xs">{formatDate(sub.subscribedAt)}</td>
                   <td class="px-3 py-3">
                     <button
                       on:click={() => removeSubscriber(sub)}
-                      class="text-gray-300 hover:text-red-500 transition-colors"
+                      class="text-ink-subtle hover:text-red-500 transition-colors"
                       title={$_('email.removeSubscriber')}
                     >
                       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -703,11 +703,11 @@
     on:click|self={() => (showSendModal = false)}
     on:keydown={(e) => e.key === 'Escape' && (showSendModal = false)}
   >
-    <div class="bg-white rounded-2xl shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
+    <div class="bg-surface rounded-2xl shadow-xl w-full max-w-lg max-h-[90vh] overflow-y-auto">
       <div class="p-6">
         <div class="flex items-center justify-between mb-5">
-          <h2 class="text-lg font-semibold text-gray-900">{$_('email.sendCampaignTitle')}</h2>
-          <button on:click={() => (showSendModal = false)} class="text-gray-400 hover:text-gray-600 transition-colors">
+          <h2 class="text-lg font-semibold text-ink">{$_('email.sendCampaignTitle')}</h2>
+          <button on:click={() => (showSendModal = false)} class="text-ink-subtle hover:text-gray-600 transition-colors">
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -729,7 +729,7 @@
           </div>
         {:else if emailAccounts.length === 0}
           <div class="text-center py-8">
-            <p class="text-gray-500 text-sm mb-3">{$_('email.noAccounts')}</p>
+            <p class="text-ink-muted text-sm mb-3">{$_('email.noAccounts')}</p>
             <a
               href="/settings/email-accounts"
               class="text-indigo-600 text-sm font-medium hover:underline"
@@ -740,11 +740,11 @@
         {:else}
           <form on:submit|preventDefault={sendCampaign} class="space-y-4">
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">{$_('email.selectAccount')} *</label>
+              <label class="block text-sm font-medium text-ink mb-1">{$_('email.selectAccount')} *</label>
               <select
                 bind:value={campaignForm.emailAccountId}
                 required
-                class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                class="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
               >
                 <option value="">— {$_('email.selectAccount')} —</option>
                 {#each emailAccounts as acc}
@@ -754,11 +754,11 @@
             </div>
 
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">{$_('email.selectList')} *</label>
+              <label class="block text-sm font-medium text-ink mb-1">{$_('email.selectList')} *</label>
               <select
                 bind:value={campaignForm.listId}
                 required
-                class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                class="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
               >
                 <option value="">— {$_('email.selectList')} —</option>
                 {#each lists as l}
@@ -768,31 +768,31 @@
             </div>
 
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">{$_('email.subject')} *</label>
+              <label class="block text-sm font-medium text-ink mb-1">{$_('email.subject')} *</label>
               <input
                 type="text"
                 bind:value={campaignForm.subject}
                 required
                 placeholder={$_('email.placeholderSubject')}
-                class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                class="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
               />
             </div>
 
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">
-                {$_('email.previewText')} <span class="text-gray-400 font-normal">({$_('common.optional')})</span>
+              <label class="block text-sm font-medium text-ink mb-1">
+                {$_('email.previewText')} <span class="text-ink-subtle font-normal">({$_('common.optional')})</span>
               </label>
               <input
                 type="text"
                 bind:value={campaignForm.previewText}
                 placeholder={$_('email.placeholderPreviewText')}
-                class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                class="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
               />
             </div>
 
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">{$_('email.htmlContent')} *</label>
-              <p class="text-xs text-gray-400 mb-1.5">
+              <label class="block text-sm font-medium text-ink mb-1">{$_('email.htmlContent')} *</label>
+              <p class="text-xs text-ink-subtle mb-1.5">
                 {$_('email.placeholderHint')}
               </p>
               <textarea
@@ -800,7 +800,7 @@
                 required
                 rows="8"
                 placeholder={$_('email.placeholderHtml')}
-                class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-y"
+                class="w-full border border-border rounded-lg px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-indigo-500 resize-y"
               ></textarea>
             </div>
 
@@ -808,7 +808,7 @@
               <button
                 type="button"
                 on:click={() => (showSendModal = false)}
-                class="flex-1 border border-gray-200 text-gray-700 text-sm font-medium py-2.5 rounded-xl hover:bg-gray-50 transition-colors"
+                class="flex-1 border border-border text-ink text-sm font-medium py-2.5 rounded-xl hover:bg-surface-2 transition-colors"
               >
                 {$_('common.cancel')}
               </button>

--- a/apps/web/src/routes/(app)/projects/[id]/experiments/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/experiments/+page.svelte
@@ -61,7 +61,7 @@
   const EXPERIMENT_STATUSES = ['DRAFT', 'RUNNING', 'PAUSED', 'COMPLETED'];
 
   const statusBadge: Record<string, string> = {
-    DRAFT: 'bg-gray-100 text-gray-600',
+    DRAFT: 'bg-surface-2 text-ink-muted',
     RUNNING: 'bg-green-100 text-green-700',
     PAUSED: 'bg-yellow-100 text-yellow-700',
     COMPLETED: 'bg-blue-100 text-blue-700',
@@ -222,12 +222,12 @@
   <SectionHint sectionKey="experiments" titleKey="hints.experiments.title" descKey="hints.experiments.desc" />
   <div class="flex items-center justify-between mb-6">
     <div>
-      <h1 class="text-2xl font-bold text-gray-900">{$_('experiments.title')}</h1>
-      <p class="text-sm text-gray-500 mt-1">{$_('experiments.subtitle')}</p>
+      <h1 class="text-2xl font-bold text-ink">{$_('experiments.title')}</h1>
+      <p class="text-sm text-ink-muted mt-1">{$_('experiments.subtitle')}</p>
     </div>
     <button
       on:click={() => showCreateModal = true}
-      class="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+      class="bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
     >
       <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -239,21 +239,21 @@
   {#if loading}
     <div class="space-y-4">
       {#each Array(3) as _}
-        <div class="bg-white rounded-xl border border-gray-200 p-5 animate-pulse h-40"></div>
+        <div class="bg-surface rounded-xl border border-border p-5 animate-pulse h-40"></div>
       {/each}
     </div>
   {:else if experiments.length === 0}
     <div class="flex flex-col items-center justify-center py-20 text-center">
-      <div class="w-20 h-20 bg-primary-50 rounded-2xl flex items-center justify-center mb-6">
+      <div class="w-20 h-20 bg-brand-subtle/10 rounded-2xl flex items-center justify-center mb-6">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
         </svg>
       </div>
-      <h2 class="text-xl font-semibold text-gray-900 mb-2">{$_('experiments.empty')}</h2>
-      <p class="text-gray-500 mb-6">{$_('experiments.emptyDesc')}</p>
+      <h2 class="text-xl font-semibold text-ink mb-2">{$_('experiments.empty')}</h2>
+      <p class="text-ink-muted mb-6">{$_('experiments.emptyDesc')}</p>
       <button
         on:click={() => showCreateModal = true}
-        class="bg-primary-600 text-white px-6 py-3 rounded-xl font-medium hover:bg-primary-700 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+        class="bg-brand text-white px-6 py-3 rounded-xl font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -266,15 +266,15 @@
       {#each experiments as experiment}
         {@const expVariants = experiment.variants || []}
         {@const maxRate = maxConversionRate(expVariants)}
-        <div class="bg-white rounded-xl border border-gray-200 border-l-4 {statusBorderAccent[experiment.status] || 'border-l-gray-300'} p-5 hover:shadow-sm transition-shadow duration-150">
+        <div class="bg-surface rounded-xl border border-border border-l-4 {statusBorderAccent[experiment.status] || 'border-l-gray-300'} p-5 hover:shadow-sm transition-shadow duration-150">
           <!-- Header row -->
           <div class="flex items-start justify-between gap-4 mb-4">
             <div class="flex-1 min-w-0">
               <div class="flex flex-wrap items-center gap-1.5 mb-2">
-                <span class="text-xs px-2 py-0.5 rounded font-medium {typeBadge[experiment.type] || 'bg-gray-100 text-gray-600'}">
+                <span class="text-xs px-2 py-0.5 rounded font-medium {typeBadge[experiment.type] || 'bg-surface-2 text-ink-muted'}">
                   {$_(typeLabel[experiment.type] || 'experiments.typeEmailSubject')}
                 </span>
-                <span class="text-xs px-2 py-0.5 rounded {statusBadge[experiment.status] || 'bg-gray-100 text-gray-600'}">
+                <span class="text-xs px-2 py-0.5 rounded {statusBadge[experiment.status] || 'bg-surface-2 text-ink-muted'}">
                   {$_(statusLabel[experiment.status] || 'experiments.statusDraft')}
                 </span>
                 {#if experiment.winnerId}
@@ -286,8 +286,8 @@
                   </span>
                 {/if}
               </div>
-              <h3 class="font-medium text-gray-900">{experiment.name}</h3>
-              <div class="flex flex-wrap items-center gap-3 mt-1.5 text-xs text-gray-500">
+              <h3 class="font-medium text-ink">{experiment.name}</h3>
+              <div class="flex flex-wrap items-center gap-3 mt-1.5 text-xs text-ink-muted">
                 {#if experiment.startDate || experiment.endDate}
                   <span class="flex items-center gap-1">
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -348,7 +348,7 @@
               {#if experiment.status === 'RUNNING' || experiment.status === 'COMPLETED'}
                 <button
                   on:click={() => viewResults(experiment)}
-                  class="text-xs px-3 py-1.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
+                  class="text-xs px-3 py-1.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
                 >
                   {$_('experiments.viewResults')}
                 </button>
@@ -367,10 +367,10 @@
 
           <!-- Variants table -->
           {#if expVariants.length > 0}
-            <div class="border border-gray-100 rounded-lg overflow-hidden">
+            <div class="border border-border rounded-lg overflow-hidden">
               <table class="w-full text-sm">
                 <thead>
-                  <tr class="bg-gray-50 text-left text-xs text-gray-500 uppercase tracking-wider">
+                  <tr class="bg-surface-2 text-left text-xs text-ink-muted uppercase tracking-wider">
                     <th class="px-4 py-2.5 font-medium">{$_('experiments.variant')}</th>
                     <th class="px-4 py-2.5 font-medium text-right">{$_('experiments.impressions')}</th>
                     <th class="px-4 py-2.5 font-medium text-right">{$_('experiments.clicks')}</th>
@@ -378,17 +378,17 @@
                     <th class="px-4 py-2.5 font-medium">{$_('experiments.conversionRate')}</th>
                   </tr>
                 </thead>
-                <tbody class="divide-y divide-gray-100">
+                <tbody class="divide-y divide-border">
                   {#each expVariants as variant}
                     {@const rate = conversionRate(variant)}
                     {@const barWidth = maxRate > 0 ? (rate / maxRate) * 100 : 0}
                     {@const isWinner = experiment.winnerId === variant.id}
-                    <tr class="{isWinner ? 'bg-emerald-50/50' : 'bg-white'} hover:bg-gray-50/50 transition-colors">
+                    <tr class="{isWinner ? 'bg-emerald-50/50' : 'bg-surface'} hover:bg-surface-2/50 transition-colors">
                       <td class="px-4 py-3">
                         <div class="flex items-center gap-2">
-                          <span class="font-medium text-gray-900">{variant.name}</span>
+                          <span class="font-medium text-ink">{variant.name}</span>
                           {#if variant.isControl}
-                            <span class="text-[10px] px-1.5 py-0.5 bg-gray-200 text-gray-600 rounded font-medium uppercase">{$_('experiments.control')}</span>
+                            <span class="text-[10px] px-1.5 py-0.5 bg-gray-200 text-ink-muted rounded font-medium uppercase">{$_('experiments.control')}</span>
                           {/if}
                           {#if isWinner}
                             <span class="text-[10px] px-1.5 py-0.5 bg-emerald-200 text-emerald-700 rounded font-medium uppercase flex items-center gap-0.5">
@@ -400,18 +400,18 @@
                           {/if}
                         </div>
                       </td>
-                      <td class="px-4 py-3 text-right text-gray-700 tabular-nums">{formatNumber(variant.impressions || 0)}</td>
-                      <td class="px-4 py-3 text-right text-gray-700 tabular-nums">{formatNumber(variant.clicks || 0)}</td>
-                      <td class="px-4 py-3 text-right text-gray-700 tabular-nums">{formatNumber(variant.conversions || 0)}</td>
+                      <td class="px-4 py-3 text-right text-ink tabular-nums">{formatNumber(variant.impressions || 0)}</td>
+                      <td class="px-4 py-3 text-right text-ink tabular-nums">{formatNumber(variant.clicks || 0)}</td>
+                      <td class="px-4 py-3 text-right text-ink tabular-nums">{formatNumber(variant.conversions || 0)}</td>
                       <td class="px-4 py-3">
                         <div class="flex items-center gap-2.5">
-                          <div class="flex-1 bg-gray-100 rounded-full h-2 min-w-[60px]">
+                          <div class="flex-1 bg-surface-2 rounded-full h-2 min-w-[60px]">
                             <div
                               class="h-2 rounded-full transition-all duration-500 {isWinner ? 'bg-emerald-500' : 'bg-primary-500'}"
                               style="width: {barWidth}%"
                             ></div>
                           </div>
-                          <span class="text-xs font-medium text-gray-700 tabular-nums w-12 text-right">{rate.toFixed(1)}%</span>
+                          <span class="text-xs font-medium text-ink tabular-nums w-12 text-right">{rate.toFixed(1)}%</span>
                         </div>
                       </td>
                     </tr>
@@ -433,11 +433,11 @@
                   <span class="text-yellow-700 font-medium">{$_('experiments.approaching')}</span>
                 {:else}
                   <div class="w-2 h-2 rounded-full bg-gray-400"></div>
-                  <span class="text-gray-500 font-medium">{$_('experiments.notSignificant')}</span>
+                  <span class="text-ink-muted font-medium">{$_('experiments.notSignificant')}</span>
                 {/if}
               </div>
-              <span class="text-gray-400">|</span>
-              <span class="text-gray-500">{$_('experiments.confidence', { values: { value: experiment.significance.toFixed(1) } })}</span>
+              <span class="text-ink-subtle">|</span>
+              <span class="text-ink-muted">{$_('experiments.confidence', { values: { value: experiment.significance.toFixed(1) } })}</span>
             </div>
           {/if}
         </div>
@@ -451,23 +451,23 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showCreateModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
-        <div class="w-8 h-8 bg-primary-50 rounded-lg flex items-center justify-center flex-shrink-0">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
+        <div class="w-8 h-8 bg-brand-subtle/10 rounded-lg flex items-center justify-center flex-shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900">{$_('experiments.create')}</h2>
+        <h2 class="text-lg font-semibold text-ink">{$_('experiments.create')}</h2>
       </div>
       <div class="p-6 space-y-4">
         <div>
-          <label for="exp-name" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('experiments.name')} *</label>
-          <input id="exp-name" type="text" bind:value={createForm.name} placeholder={$_('experiments.namePlaceholder')} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
+          <label for="exp-name" class="block text-sm font-medium text-ink mb-1.5">{$_('experiments.name')} *</label>
+          <input id="exp-name" type="text" bind:value={createForm.name} placeholder={$_('experiments.namePlaceholder')} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
         </div>
         <div>
-          <label for="exp-type" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('experiments.type')}</label>
-          <select id="exp-type" bind:value={createForm.type} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+          <label for="exp-type" class="block text-sm font-medium text-ink mb-1.5">{$_('experiments.type')}</label>
+          <select id="exp-type" bind:value={createForm.type} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
             {#each EXPERIMENT_TYPES as t}
               <option value={t}>{$_(typeLabel[t])}</option>
             {/each}
@@ -477,10 +477,10 @@
         <!-- Variants -->
         <div>
           <div class="flex items-center justify-between mb-2">
-            <label class="block text-sm font-medium text-gray-700">{$_('experiments.variants')} *</label>
+            <label class="block text-sm font-medium text-ink">{$_('experiments.variants')} *</label>
             <button
               on:click={addVariant}
-              class="text-xs text-primary-600 hover:text-primary-700 font-medium cursor-pointer"
+              class="text-xs text-brand hover:text-primary-700 font-medium cursor-pointer"
             >
               + {$_('experiments.addVariant')}
             </button>
@@ -491,26 +491,26 @@
                 <button
                   type="button"
                   on:click={() => setControl(i)}
-                  class="w-5 h-5 rounded-full border-2 flex-shrink-0 flex items-center justify-center transition-all cursor-pointer {variant.isControl ? 'border-primary-600 bg-primary-600' : 'border-gray-300 hover:border-primary-400'}"
+                  class="w-5 h-5 rounded-full border-2 flex-shrink-0 flex items-center justify-center transition-all cursor-pointer {variant.isControl ? 'border-primary-600 bg-brand' : 'border-border hover:border-primary-400'}"
                   title={$_('experiments.setAsControl')}
                 >
                   {#if variant.isControl}
-                    <div class="w-2 h-2 rounded-full bg-white"></div>
+                    <div class="w-2 h-2 rounded-full bg-surface"></div>
                   {/if}
                 </button>
                 <input
                   type="text"
                   bind:value={variant.name}
                   placeholder={variant.isControl ? $_('experiments.controlPlaceholder') : $_('experiments.variantPlaceholder', { values: { index: i } })}
-                  class="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                  class="flex-1 px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
                 />
                 {#if variant.isControl}
-                  <span class="text-[10px] px-1.5 py-0.5 bg-gray-200 text-gray-600 rounded font-medium uppercase flex-shrink-0">{$_('experiments.control')}</span>
+                  <span class="text-[10px] px-1.5 py-0.5 bg-gray-200 text-ink-muted rounded font-medium uppercase flex-shrink-0">{$_('experiments.control')}</span>
                 {/if}
                 {#if variants.length > 2}
                   <button
                     on:click={() => removeVariant(i)}
-                    class="text-gray-400 hover:text-red-500 transition-colors cursor-pointer flex-shrink-0"
+                    class="text-ink-subtle hover:text-red-500 transition-colors cursor-pointer flex-shrink-0"
                   >
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                       <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
@@ -520,14 +520,14 @@
               </div>
             {/each}
           </div>
-          <p class="text-xs text-gray-400 mt-1.5">{$_('experiments.controlHint')}</p>
+          <p class="text-xs text-ink-subtle mt-1.5">{$_('experiments.controlHint')}</p>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={createExperiment}
           disabled={creating || !createForm.name.trim() || variants.filter(v => v.name.trim()).length < 2}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
         >
           {#if creating}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -539,7 +539,7 @@
             {$_('experiments.create')}
           {/if}
         </button>
-        <button on:click={() => showCreateModal = false} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={() => showCreateModal = false} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>
@@ -552,15 +552,15 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => deletingId = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm">
       <div class="p-6">
         <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-4">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900 mb-2">{$_('experiments.deleteExperiment')}</h2>
-        <p class="text-sm text-gray-500 mb-6">{$_('experiments.confirmDelete')}</p>
+        <h2 class="text-lg font-semibold text-ink mb-2">{$_('experiments.deleteExperiment')}</h2>
+        <p class="text-sm text-ink-muted mb-6">{$_('experiments.confirmDelete')}</p>
         <div class="flex gap-3">
           <button
             on:click={() => deleteExperiment(deletingId)}
@@ -568,7 +568,7 @@
           >
             {$_('common.delete')}
           </button>
-          <button on:click={() => deletingId = null} class="flex-1 px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+          <button on:click={() => deletingId = null} class="flex-1 px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
             {$_('common.cancel')}
           </button>
         </div>
@@ -582,8 +582,8 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => resultsFor = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-2xl max-h-[80vh] flex flex-col">
-      <div class="p-6 border-b border-gray-100 flex items-center justify-between">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-2xl max-h-[80vh] flex flex-col">
+      <div class="p-6 border-b border-border flex items-center justify-between">
         <div class="flex items-center gap-2.5">
           <div class="w-8 h-8 bg-blue-50 rounded-lg flex items-center justify-center flex-shrink-0">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-blue-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -591,11 +591,11 @@
             </svg>
           </div>
           <div>
-            <h2 class="text-lg font-semibold text-gray-900">{$_('experiments.results')}</h2>
-            <p class="text-sm text-gray-500">{resultsFor.name}</p>
+            <h2 class="text-lg font-semibold text-ink">{$_('experiments.results')}</h2>
+            <p class="text-sm text-ink-muted">{resultsFor.name}</p>
           </div>
         </div>
-        <button on:click={() => resultsFor = null} class="text-gray-400 hover:text-gray-600 transition-colors cursor-pointer">
+        <button on:click={() => resultsFor = null} class="text-ink-subtle hover:text-gray-600 transition-colors cursor-pointer">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M6 18 18 6M6 6l12 12" />
           </svg>
@@ -611,7 +611,7 @@
         {:else if resultsData}
           <!-- Statistical significance banner -->
           {#if resultsData.significance !== undefined}
-            <div class="mb-5 p-4 rounded-lg border {resultsData.significance >= 95 ? 'bg-green-50 border-green-200' : resultsData.significance >= 80 ? 'bg-yellow-50 border-yellow-200' : 'bg-gray-50 border-gray-200'}">
+            <div class="mb-5 p-4 rounded-lg border {resultsData.significance >= 95 ? 'bg-green-50 border-green-200' : resultsData.significance >= 80 ? 'bg-yellow-50 border-yellow-200' : 'bg-surface-2 border-border'}">
               <div class="flex items-center gap-3">
                 <div class="flex-shrink-0">
                   {#if resultsData.significance >= 95}
@@ -627,15 +627,15 @@
                       </svg>
                     </div>
                   {:else}
-                    <div class="w-10 h-10 bg-gray-100 rounded-lg flex items-center justify-center">
-                      <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                    <div class="w-10 h-10 bg-surface-2 rounded-lg flex items-center justify-center">
+                      <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-ink-muted" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                         <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                       </svg>
                     </div>
                   {/if}
                 </div>
                 <div>
-                  <p class="text-sm font-medium {resultsData.significance >= 95 ? 'text-green-800' : resultsData.significance >= 80 ? 'text-yellow-800' : 'text-gray-700'}">
+                  <p class="text-sm font-medium {resultsData.significance >= 95 ? 'text-green-800' : resultsData.significance >= 80 ? 'text-yellow-800' : 'text-ink'}">
                     {#if resultsData.significance >= 95}
                       {$_('experiments.significantResult')}
                     {:else if resultsData.significance >= 80}
@@ -644,7 +644,7 @@
                       {$_('experiments.notSignificantResult')}
                     {/if}
                   </p>
-                  <p class="text-xs mt-0.5 {resultsData.significance >= 95 ? 'text-green-600' : resultsData.significance >= 80 ? 'text-yellow-600' : 'text-gray-500'}">
+                  <p class="text-xs mt-0.5 {resultsData.significance >= 95 ? 'text-green-600' : resultsData.significance >= 80 ? 'text-yellow-600' : 'text-ink-muted'}">
                     {$_('experiments.confidence', { values: { value: resultsData.significance.toFixed(1) } })}
                   </p>
                 </div>
@@ -660,20 +660,20 @@
               {@const maxRate2 = maxConversionRate(allVariants)}
               {@const barWidth = maxRate2 > 0 ? (rate / maxRate2) * 100 : 0}
               {@const isWinner = resultsData.winnerId === variant.id}
-              <div class="border rounded-lg p-4 {isWinner ? 'border-emerald-300 bg-emerald-50/50' : 'border-gray-200'}">
+              <div class="border rounded-lg p-4 {isWinner ? 'border-emerald-300 bg-emerald-50/50' : 'border-border'}">
                 <div class="flex items-center justify-between mb-3">
                   <div class="flex items-center gap-2">
-                    <span class="font-medium text-gray-900">{variant.name}</span>
+                    <span class="font-medium text-ink">{variant.name}</span>
                     {#if variant.isControl}
-                      <span class="text-[10px] px-1.5 py-0.5 bg-gray-200 text-gray-600 rounded font-medium uppercase">{$_('experiments.control')}</span>
+                      <span class="text-[10px] px-1.5 py-0.5 bg-gray-200 text-ink-muted rounded font-medium uppercase">{$_('experiments.control')}</span>
                     {/if}
                     {#if isWinner}
                       <span class="text-[10px] px-1.5 py-0.5 bg-emerald-200 text-emerald-700 rounded font-medium uppercase">{$_('experiments.winner')}</span>
                     {/if}
                   </div>
-                  <span class="text-lg font-bold {isWinner ? 'text-emerald-700' : 'text-gray-900'}">{rate.toFixed(2)}%</span>
+                  <span class="text-lg font-bold {isWinner ? 'text-emerald-700' : 'text-ink'}">{rate.toFixed(2)}%</span>
                 </div>
-                <div class="bg-gray-100 rounded-full h-3 mb-3">
+                <div class="bg-surface-2 rounded-full h-3 mb-3">
                   <div
                     class="h-3 rounded-full transition-all duration-700 {isWinner ? 'bg-emerald-500' : 'bg-primary-500'}"
                     style="width: {barWidth}%"
@@ -681,16 +681,16 @@
                 </div>
                 <div class="grid grid-cols-3 gap-4 text-center">
                   <div>
-                    <div class="text-lg font-semibold text-gray-900">{formatNumber(variant.impressions || 0)}</div>
-                    <div class="text-xs text-gray-500">{$_('experiments.impressions')}</div>
+                    <div class="text-lg font-semibold text-ink">{formatNumber(variant.impressions || 0)}</div>
+                    <div class="text-xs text-ink-muted">{$_('experiments.impressions')}</div>
                   </div>
                   <div>
-                    <div class="text-lg font-semibold text-gray-900">{formatNumber(variant.clicks || 0)}</div>
-                    <div class="text-xs text-gray-500">{$_('experiments.clicks')}</div>
+                    <div class="text-lg font-semibold text-ink">{formatNumber(variant.clicks || 0)}</div>
+                    <div class="text-xs text-ink-muted">{$_('experiments.clicks')}</div>
                   </div>
                   <div>
-                    <div class="text-lg font-semibold text-gray-900">{formatNumber(variant.conversions || 0)}</div>
-                    <div class="text-xs text-gray-500">{$_('experiments.conversions')}</div>
+                    <div class="text-lg font-semibold text-ink">{formatNumber(variant.conversions || 0)}</div>
+                    <div class="text-xs text-ink-muted">{$_('experiments.conversions')}</div>
                   </div>
                 </div>
               </div>
@@ -699,8 +699,8 @@
         {/if}
       </div>
 
-      <div class="p-6 border-t border-gray-100">
-        <button on:click={() => resultsFor = null} class="w-full px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+      <div class="p-6 border-t border-border">
+        <button on:click={() => resultsFor = null} class="w-full px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.close')}
         </button>
       </div>

--- a/apps/web/src/routes/(app)/projects/[id]/finances/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/finances/+page.svelte
@@ -444,17 +444,17 @@
   <!-- Header -->
   <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 mb-6">
     <div>
-      <h1 class="text-2xl font-bold text-gray-900">{$_('finances.title')}</h1>
-      <p class="text-sm text-gray-500 mt-0.5">{$_('finances.subtitle')}</p>
+      <h1 class="text-2xl font-bold text-ink">{$_('finances.title')}</h1>
+      <p class="text-sm text-ink-muted mt-0.5">{$_('finances.subtitle')}</p>
     </div>
     <div class="flex items-center gap-3 flex-wrap">
       <!-- Period selector -->
-      <div class="flex bg-gray-100 rounded-lg p-0.5">
+      <div class="flex bg-surface-2 rounded-lg p-0.5">
         {#each [['month', $_('finances.month')], ['quarter', $_('finances.quarter')], ['year', $_('finances.year')], ['custom', $_('finances.custom')]] as [mode, label]}
           <button
             on:click={() => setPeriod(mode as any)}
             class="px-3 py-1.5 text-xs font-medium rounded-md transition-colors duration-150 cursor-pointer
-              {periodMode === mode ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-600 hover:text-gray-900'}"
+              {periodMode === mode ? 'bg-surface text-ink shadow-sm' : 'text-ink-muted hover:text-gray-900'}"
           >
             {label}
           </button>
@@ -462,15 +462,15 @@
       </div>
       {#if periodMode === 'custom'}
         <div class="flex items-center gap-2">
-          <input type="date" bind:value={customDateFrom} class="px-2 py-1.5 border border-gray-300 rounded-lg text-xs focus:outline-none focus:ring-2 focus:ring-primary-500" />
-          <span class="text-gray-400 text-xs">-</span>
-          <input type="date" bind:value={customDateTo} class="px-2 py-1.5 border border-gray-300 rounded-lg text-xs focus:outline-none focus:ring-2 focus:ring-primary-500" />
-          <button on:click={applyCustomDates} class="px-3 py-1.5 bg-primary-600 text-white rounded-lg text-xs font-medium hover:bg-primary-700 cursor-pointer">OK</button>
+          <input type="date" bind:value={customDateFrom} class="px-2 py-1.5 border border-border rounded-lg text-xs focus:outline-none focus:ring-2 focus:ring-primary-500" />
+          <span class="text-ink-subtle text-xs">-</span>
+          <input type="date" bind:value={customDateTo} class="px-2 py-1.5 border border-border rounded-lg text-xs focus:outline-none focus:ring-2 focus:ring-primary-500" />
+          <button on:click={applyCustomDates} class="px-3 py-1.5 bg-brand text-white rounded-lg text-xs font-medium hover:brightness-110 cursor-pointer">OK</button>
         </div>
       {/if}
       <button
         on:click={openCreateRecord}
-        class="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+        class="bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -484,20 +484,20 @@
     <div class="space-y-4">
       <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
         {#each Array(3) as _}
-          <div class="bg-white rounded-xl border border-gray-200 p-5 animate-pulse h-24"></div>
+          <div class="bg-surface rounded-xl border border-border p-5 animate-pulse h-24"></div>
         {/each}
       </div>
       <div class="grid grid-cols-1 lg:grid-cols-5 gap-4">
-        <div class="lg:col-span-3 bg-white rounded-xl border border-gray-200 p-5 animate-pulse h-64"></div>
-        <div class="lg:col-span-2 bg-white rounded-xl border border-gray-200 p-5 animate-pulse h-64"></div>
+        <div class="lg:col-span-3 bg-surface rounded-xl border border-border p-5 animate-pulse h-64"></div>
+        <div class="lg:col-span-2 bg-surface rounded-xl border border-border p-5 animate-pulse h-64"></div>
       </div>
-      <div class="bg-white rounded-xl border border-gray-200 animate-pulse h-48"></div>
+      <div class="bg-surface rounded-xl border border-border animate-pulse h-48"></div>
     </div>
   {:else}
     <!-- Summary Cards -->
     <div class="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
       <!-- Income -->
-      <div class="bg-white rounded-xl border border-gray-200 p-5">
+      <div class="bg-surface rounded-xl border border-border p-5">
         <div class="flex items-center gap-3">
           <div class="w-10 h-10 bg-green-50 rounded-lg flex items-center justify-center flex-shrink-0">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-green-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -505,13 +505,13 @@
             </svg>
           </div>
           <div>
-            <p class="text-sm text-gray-500">{$_('finances.income')}</p>
+            <p class="text-sm text-ink-muted">{$_('finances.income')}</p>
             <p class="text-xl font-bold text-green-600">{formatCurrency(summary?.totalIncome || 0)}</p>
           </div>
         </div>
       </div>
       <!-- Expenses -->
-      <div class="bg-white rounded-xl border border-gray-200 p-5">
+      <div class="bg-surface rounded-xl border border-border p-5">
         <div class="flex items-center gap-3">
           <div class="w-10 h-10 bg-red-50 rounded-lg flex items-center justify-center flex-shrink-0">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -519,13 +519,13 @@
             </svg>
           </div>
           <div>
-            <p class="text-sm text-gray-500">{$_('finances.expenses')}</p>
+            <p class="text-sm text-ink-muted">{$_('finances.expenses')}</p>
             <p class="text-xl font-bold text-red-600">{formatCurrency(summary?.totalExpense || 0)}</p>
           </div>
         </div>
       </div>
       <!-- Profit -->
-      <div class="bg-white rounded-xl border border-gray-200 p-5">
+      <div class="bg-surface rounded-xl border border-border p-5">
         <div class="flex items-center gap-3">
           <div class="w-10 h-10 bg-indigo-50 rounded-lg flex items-center justify-center flex-shrink-0">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -533,7 +533,7 @@
             </svg>
           </div>
           <div>
-            <p class="text-sm text-gray-500">{$_('finances.profit')}</p>
+            <p class="text-sm text-ink-muted">{$_('finances.profit')}</p>
             <p class="text-xl font-bold {(summary?.profit || 0) >= 0 ? 'text-indigo-600' : 'text-red-600'}">{formatCurrency(summary?.profit || 0)}</p>
           </div>
         </div>
@@ -544,19 +544,19 @@
     {#if summary?.monthly?.length > 0 || summary?.byCategory?.length > 0}
       <div class="grid grid-cols-1 lg:grid-cols-5 gap-4 mb-6">
         <!-- Bar chart -->
-        <div class="lg:col-span-3 bg-white rounded-xl border border-gray-200 p-5">
-          <h3 class="text-sm font-semibold text-gray-900 mb-3">{$_('finances.incomeVsExpenses')}</h3>
+        <div class="lg:col-span-3 bg-surface rounded-xl border border-border p-5">
+          <h3 class="text-sm font-semibold text-ink mb-3">{$_('finances.incomeVsExpenses')}</h3>
           <div class="h-64">
             <canvas bind:this={barCanvas}></canvas>
           </div>
         </div>
         <!-- Doughnut chart -->
-        <div class="lg:col-span-2 bg-white rounded-xl border border-gray-200 p-5">
+        <div class="lg:col-span-2 bg-surface rounded-xl border border-border p-5">
           <div class="flex items-center justify-between mb-3">
-            <h3 class="text-sm font-semibold text-gray-900">{$_('finances.byCategory')}</h3>
+            <h3 class="text-sm font-semibold text-ink">{$_('finances.byCategory')}</h3>
             <button
               on:click={toggleDoughnutMode}
-              class="text-xs px-2.5 py-1 rounded-md border border-gray-200 hover:bg-gray-50 transition-colors cursor-pointer
+              class="text-xs px-2.5 py-1 rounded-md border border-border hover:bg-surface-2 transition-colors cursor-pointer
                 {doughnutMode === 'EXPENSE' ? 'text-red-600' : 'text-green-600'}"
             >
               {doughnutMode === 'EXPENSE' ? $_('finances.expenses') : $_('finances.income')}
@@ -571,12 +571,12 @@
 
     <!-- Table filters -->
     <div class="flex flex-col sm:flex-row items-start sm:items-center gap-3 mb-4">
-      <div class="flex bg-gray-100 rounded-lg p-0.5">
+      <div class="flex bg-surface-2 rounded-lg p-0.5">
         {#each [['ALL', $_('finances.all')], ['INCOME', $_('finances.income')], ['EXPENSE', $_('finances.expenses')]] as [type, label]}
           <button
             on:click={() => setFilterType(type as any)}
             class="px-3 py-1.5 text-xs font-medium rounded-md transition-colors duration-150 cursor-pointer
-              {filterType === type ? 'bg-white text-gray-900 shadow-sm' : 'text-gray-600 hover:text-gray-900'}"
+              {filterType === type ? 'bg-surface text-ink shadow-sm' : 'text-ink-muted hover:text-gray-900'}"
           >
             {label}
           </button>
@@ -585,7 +585,7 @@
       <select
         value={filterCategoryId}
         on:change={e => setFilterCategory((e.target as HTMLSelectElement).value)}
-        class="px-3 py-1.5 border border-gray-300 rounded-lg text-xs bg-white focus:outline-none focus:ring-2 focus:ring-primary-500 cursor-pointer"
+        class="px-3 py-1.5 border border-border rounded-lg text-xs bg-surface focus:outline-none focus:ring-2 focus:ring-primary-500 cursor-pointer"
       >
         <option value="">{$_('finances.filterByCategory')}</option>
         {#each categories as cat}
@@ -594,7 +594,7 @@
       </select>
       <button
         on:click={() => showCategoriesModal = true}
-        class="text-xs text-primary-600 hover:text-primary-700 font-medium cursor-pointer"
+        class="text-xs text-brand hover:text-primary-700 font-medium cursor-pointer"
       >
         {$_('finances.manageCategories')}
       </button>
@@ -603,16 +603,16 @@
     <!-- Records table -->
     {#if records.length === 0}
       <div class="flex flex-col items-center justify-center py-20 text-center">
-        <div class="w-20 h-20 bg-primary-50 rounded-2xl flex items-center justify-center mb-6">
+        <div class="w-20 h-20 bg-brand-subtle/10 rounded-2xl flex items-center justify-center mb-6">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v12m-3-2.818l.879.659c1.171.879 3.07.879 4.242 0 1.172-.879 1.172-2.303 0-3.182C13.536 12.219 12.768 12 12 12c-.725 0-1.45-.22-2.003-.659-1.106-.879-1.106-2.303 0-3.182s2.9-.879 4.006 0l.415.33M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
           </svg>
         </div>
-        <h2 class="text-xl font-semibold text-gray-900 mb-2">{$_('finances.title')}</h2>
-        <p class="text-gray-500 mb-6">{$_('finances.emptyState')}</p>
+        <h2 class="text-xl font-semibold text-ink mb-2">{$_('finances.title')}</h2>
+        <p class="text-ink-muted mb-6">{$_('finances.emptyState')}</p>
         <button
           on:click={openCreateRecord}
-          class="bg-primary-600 text-white px-6 py-3 rounded-xl font-medium hover:bg-primary-700 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+          class="bg-brand text-white px-6 py-3 rounded-xl font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
         >
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -621,30 +621,30 @@
         </button>
       </div>
     {:else}
-      <div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
+      <div class="bg-surface rounded-xl border border-border overflow-hidden">
         <div class="overflow-x-auto">
           <table class="w-full text-sm">
             <thead>
-              <tr class="border-b border-gray-100 bg-gray-50">
-                <th class="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase">{$_('finances.date')}</th>
-                <th class="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase">{$_('finances.type')}</th>
-                <th class="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase">{$_('finances.category')}</th>
-                <th class="text-left px-4 py-3 text-xs font-medium text-gray-500 uppercase">{$_('finances.description')}</th>
-                <th class="text-right px-4 py-3 text-xs font-medium text-gray-500 uppercase">{$_('finances.amount')}</th>
-                <th class="text-right px-4 py-3 text-xs font-medium text-gray-500 uppercase">{$_('finances.amountInBase', { values: { currency: baseCurrency } })}</th>
-                <th class="text-right px-4 py-3 text-xs font-medium text-gray-500 uppercase"></th>
+              <tr class="border-b border-border bg-surface-2">
+                <th class="text-left px-4 py-3 text-xs font-medium text-ink-muted uppercase">{$_('finances.date')}</th>
+                <th class="text-left px-4 py-3 text-xs font-medium text-ink-muted uppercase">{$_('finances.type')}</th>
+                <th class="text-left px-4 py-3 text-xs font-medium text-ink-muted uppercase">{$_('finances.category')}</th>
+                <th class="text-left px-4 py-3 text-xs font-medium text-ink-muted uppercase">{$_('finances.description')}</th>
+                <th class="text-right px-4 py-3 text-xs font-medium text-ink-muted uppercase">{$_('finances.amount')}</th>
+                <th class="text-right px-4 py-3 text-xs font-medium text-ink-muted uppercase">{$_('finances.amountInBase', { values: { currency: baseCurrency } })}</th>
+                <th class="text-right px-4 py-3 text-xs font-medium text-ink-muted uppercase"></th>
               </tr>
             </thead>
             <tbody>
               {#each records as record}
-                <tr class="border-b border-gray-50 hover:bg-gray-50 transition-colors">
-                  <td class="px-4 py-3 text-gray-700 whitespace-nowrap">{formatDate(record.date)}</td>
+                <tr class="border-b border-gray-50 hover:bg-surface-2 transition-colors">
+                  <td class="px-4 py-3 text-ink whitespace-nowrap">{formatDate(record.date)}</td>
                   <td class="px-4 py-3">
                     <span class="text-xs px-2 py-0.5 rounded font-medium {record.type === 'INCOME' ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700'}">
                       {record.type === 'INCOME' ? $_('finances.income') : $_('finances.expense')}
                     </span>
                   </td>
-                  <td class="px-4 py-3 text-gray-700">
+                  <td class="px-4 py-3 text-ink">
                     {#if record.category}
                       <span class="flex items-center gap-1.5">
                         <span class="w-2.5 h-2.5 rounded-full flex-shrink-0" style="background-color: {record.category.color || '#6366F1'}"></span>
@@ -652,22 +652,22 @@
                       </span>
                     {/if}
                   </td>
-                  <td class="px-4 py-3 text-gray-500 max-w-[200px] truncate">{record.description || ''}</td>
+                  <td class="px-4 py-3 text-ink-muted max-w-[200px] truncate">{record.description || ''}</td>
                   <td class="px-4 py-3 text-right font-medium whitespace-nowrap {record.type === 'INCOME' ? 'text-green-600' : 'text-red-600'}">
                     {record.type === 'INCOME' ? '+' : '-'}{formatCurrency(record.amount, record.currency)}
                   </td>
-                  <td class="px-4 py-3 text-right text-gray-500 whitespace-nowrap">
+                  <td class="px-4 py-3 text-right text-ink-muted whitespace-nowrap">
                     {#if record.currency !== baseCurrency && record.amountInBaseCurrency != null}
                       {formatCurrency(record.amountInBaseCurrency)}
                     {:else if record.currency === baseCurrency}
-                      <span class="text-gray-300">-</span>
+                      <span class="text-ink-subtle">-</span>
                     {/if}
                   </td>
                   <td class="px-4 py-3 text-right">
                     <div class="flex items-center justify-end gap-1">
                       <button
                         on:click={() => openEditRecord(record)}
-                        class="p-1.5 text-gray-400 hover:text-gray-600 rounded-md hover:bg-gray-100 transition-colors cursor-pointer"
+                        class="p-1.5 text-ink-subtle hover:text-gray-600 rounded-md hover:bg-surface-2 transition-colors cursor-pointer"
                         title={$_('common.edit')}
                       >
                         <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -676,7 +676,7 @@
                       </button>
                       <button
                         on:click={() => deletingId = record.id}
-                        class="p-1.5 text-gray-400 hover:text-red-500 rounded-md hover:bg-red-50 transition-colors cursor-pointer"
+                        class="p-1.5 text-ink-subtle hover:text-red-500 rounded-md hover:bg-red-50 transition-colors cursor-pointer"
                         title={$_('common.delete')}
                       >
                         <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -692,29 +692,29 @@
         </div>
         <!-- Pagination -->
         {#if totalPages > 1}
-          <div class="flex items-center justify-between px-4 py-3 border-t border-gray-100">
-            <p class="text-xs text-gray-500">{totalRecords} {$_('finances.all').toLowerCase()}</p>
+          <div class="flex items-center justify-between px-4 py-3 border-t border-border">
+            <p class="text-xs text-ink-muted">{totalRecords} {$_('finances.all').toLowerCase()}</p>
             <div class="flex items-center gap-1">
               <button
                 on:click={() => goToPage(currentPage - 1)}
                 disabled={currentPage <= 1}
-                class="px-2 py-1 text-xs border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-40 cursor-pointer"
+                class="px-2 py-1 text-xs border border-border rounded hover:bg-surface-2 disabled:opacity-40 cursor-pointer"
               >&laquo;</button>
               {#each Array(totalPages) as _, i}
                 {#if totalPages <= 7 || i === 0 || i === totalPages - 1 || Math.abs(i + 1 - currentPage) <= 1}
                   <button
                     on:click={() => goToPage(i + 1)}
                     class="px-2.5 py-1 text-xs rounded cursor-pointer
-                      {currentPage === i + 1 ? 'bg-primary-600 text-white' : 'border border-gray-300 hover:bg-gray-50'}"
+                      {currentPage === i + 1 ? 'bg-brand text-white' : 'border border-border hover:bg-surface-2'}"
                   >{i + 1}</button>
                 {:else if Math.abs(i + 1 - currentPage) === 2}
-                  <span class="px-1 text-gray-400 text-xs">...</span>
+                  <span class="px-1 text-ink-subtle text-xs">...</span>
                 {/if}
               {/each}
               <button
                 on:click={() => goToPage(currentPage + 1)}
                 disabled={currentPage >= totalPages}
-                class="px-2 py-1 text-xs border border-gray-300 rounded hover:bg-gray-50 disabled:opacity-40 cursor-pointer"
+                class="px-2 py-1 text-xs border border-border rounded hover:bg-surface-2 disabled:opacity-40 cursor-pointer"
               >&raquo;</button>
             </div>
           </div>
@@ -729,36 +729,36 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showRecordModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
-        <div class="w-8 h-8 bg-primary-50 rounded-lg flex items-center justify-center flex-shrink-0">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md max-h-[90vh] overflow-y-auto">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
+        <div class="w-8 h-8 bg-brand-subtle/10 rounded-lg flex items-center justify-center flex-shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900">{editingRecord ? $_('finances.editRecord') : $_('finances.addRecord')}</h2>
+        <h2 class="text-lg font-semibold text-ink">{editingRecord ? $_('finances.editRecord') : $_('finances.addRecord')}</h2>
       </div>
       <div class="p-6 space-y-4">
         <!-- Type toggle -->
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1.5">{$_('finances.type')} *</label>
-          <div class="flex bg-gray-100 rounded-lg p-0.5">
+          <label class="block text-sm font-medium text-ink mb-1.5">{$_('finances.type')} *</label>
+          <div class="flex bg-surface-2 rounded-lg p-0.5">
             <button
               on:click={() => { recordForm.type = 'EXPENSE'; onRecordTypeChange(); }}
               class="flex-1 px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 cursor-pointer
-                {recordForm.type === 'EXPENSE' ? 'bg-white text-red-600 shadow-sm' : 'text-gray-600 hover:text-gray-900'}"
+                {recordForm.type === 'EXPENSE' ? 'bg-surface text-red-600 shadow-sm' : 'text-ink-muted hover:text-gray-900'}"
             >{$_('finances.expense')}</button>
             <button
               on:click={() => { recordForm.type = 'INCOME'; onRecordTypeChange(); }}
               class="flex-1 px-3 py-2 text-sm font-medium rounded-md transition-colors duration-150 cursor-pointer
-                {recordForm.type === 'INCOME' ? 'bg-white text-green-600 shadow-sm' : 'text-gray-600 hover:text-gray-900'}"
+                {recordForm.type === 'INCOME' ? 'bg-surface text-green-600 shadow-sm' : 'text-ink-muted hover:text-gray-900'}"
             >{$_('finances.income')}</button>
           </div>
         </div>
         <!-- Category -->
         <div>
-          <label for="r-cat" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('finances.category')} *</label>
-          <select id="r-cat" bind:value={recordForm.categoryId} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+          <label for="r-cat" class="block text-sm font-medium text-ink mb-1.5">{$_('finances.category')} *</label>
+          <select id="r-cat" bind:value={recordForm.categoryId} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
             <option value="">-- {$_('finances.category')} --</option>
             {#each filteredCategories as cat}
               <option value={cat.id}>{getCategoryName(cat)}</option>
@@ -768,12 +768,12 @@
         <!-- Amount + Currency -->
         <div class="grid grid-cols-5 gap-3">
           <div class="col-span-3">
-            <label for="r-amount" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('finances.amount')} *</label>
-            <input id="r-amount" type="number" step="0.01" min="0" bind:value={recordForm.amount} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
+            <label for="r-amount" class="block text-sm font-medium text-ink mb-1.5">{$_('finances.amount')} *</label>
+            <input id="r-amount" type="number" step="0.01" min="0" bind:value={recordForm.amount} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
           </div>
           <div class="col-span-2">
-            <label for="r-currency" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('finances.currency')}</label>
-            <select id="r-currency" bind:value={recordForm.currency} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
+            <label for="r-currency" class="block text-sm font-medium text-ink mb-1.5">{$_('finances.currency')}</label>
+            <select id="r-currency" bind:value={recordForm.currency} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent">
               {#each SUPPORTED_CURRENCIES as cur}
                 <option value={cur}>{cur}</option>
               {/each}
@@ -782,36 +782,36 @@
         </div>
         <!-- Exchange rate preview -->
         {#if recordForm.currency !== baseCurrency}
-          <div class="bg-gray-50 rounded-lg px-3 py-2.5 text-xs text-gray-600">
+          <div class="bg-surface-2 rounded-lg px-3 py-2.5 text-xs text-ink-muted">
             {#if exchangeRateLoading}
-              <span class="text-gray-400">{$_('finances.exchangeRate')}...</span>
+              <span class="text-ink-subtle">{$_('finances.exchangeRate')}...</span>
             {:else if exchangeRate}
               <div>{$_('finances.exchangeRateInfo', { values: { from: recordForm.currency, to: baseCurrency } })}: <span class="font-medium">{exchangeRate.rate.toFixed(4)}</span></div>
               {#if recordForm.amount}
                 <div class="mt-1">{$_('finances.amountInBase', { values: { currency: baseCurrency } })}: <span class="font-semibold">{formatCurrency(Number(recordForm.amount) * exchangeRate.rate)}</span></div>
               {/if}
               {#if exchangeRate.date}
-                <div class="mt-1 text-gray-400">{$_('finances.exchangeRateSource', { values: { date: exchangeRate.date } })}</div>
+                <div class="mt-1 text-ink-subtle">{$_('finances.exchangeRateSource', { values: { date: exchangeRate.date } })}</div>
               {/if}
             {/if}
           </div>
         {/if}
         <!-- Date -->
         <div>
-          <label for="r-date" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('finances.date')} *</label>
-          <input id="r-date" type="date" bind:value={recordForm.date} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
+          <label for="r-date" class="block text-sm font-medium text-ink mb-1.5">{$_('finances.date')} *</label>
+          <input id="r-date" type="date" bind:value={recordForm.date} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent" />
         </div>
         <!-- Description -->
         <div>
-          <label for="r-desc" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('finances.description')}</label>
-          <textarea id="r-desc" bind:value={recordForm.description} rows="2" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"></textarea>
+          <label for="r-desc" class="block text-sm font-medium text-ink mb-1.5">{$_('finances.description')}</label>
+          <textarea id="r-desc" bind:value={recordForm.description} rows="2" class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"></textarea>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={saveRecord}
           disabled={recordSaving || !recordForm.amount || !recordForm.categoryId}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
         >
           {#if recordSaving}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -821,7 +821,7 @@
           {/if}
           {$_('finances.save')}
         </button>
-        <button on:click={() => showRecordModal = false} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={() => showRecordModal = false} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('finances.cancel')}
         </button>
       </div>
@@ -834,10 +834,10 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showCategoriesModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-lg max-h-[80vh] overflow-y-auto">
-      <div class="p-6 border-b border-gray-100 flex items-center justify-between">
-        <h2 class="text-lg font-semibold text-gray-900">{$_('finances.categories.title')}</h2>
-        <button on:click={() => showCategoriesModal = false} class="p-1 text-gray-400 hover:text-gray-600 cursor-pointer">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-lg max-h-[80vh] overflow-y-auto">
+      <div class="p-6 border-b border-border flex items-center justify-between">
+        <h2 class="text-lg font-semibold text-ink">{$_('finances.categories.title')}</h2>
+        <button on:click={() => showCategoriesModal = false} class="p-1 text-ink-subtle hover:text-gray-600 cursor-pointer">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
           </svg>
@@ -846,21 +846,21 @@
       <div class="p-6 space-y-6">
         <!-- Expense categories -->
         <div>
-          <h3 class="text-sm font-semibold text-gray-900 mb-2">{$_('finances.categories.expenseCategories')}</h3>
+          <h3 class="text-sm font-semibold text-ink mb-2">{$_('finances.categories.expenseCategories')}</h3>
           <div class="space-y-1.5">
             {#each categories.filter(c => c.type === 'EXPENSE' || c.type === 'BOTH') as cat}
-              <div class="flex items-center justify-between px-3 py-2 rounded-lg hover:bg-gray-50">
+              <div class="flex items-center justify-between px-3 py-2 rounded-lg hover:bg-surface-2">
                 <span class="flex items-center gap-2 text-sm">
                   <span class="w-3 h-3 rounded-full" style="background-color: {cat.color || '#6366F1'}"></span>
                   {getCategoryName(cat)}
                   {#if cat.isDefault}
-                    <span class="text-xs text-gray-400">({$_('finances.categories.default')})</span>
+                    <span class="text-xs text-ink-subtle">({$_('finances.categories.default')})</span>
                   {/if}
                 </span>
                 {#if !cat.isDefault}
                   <button
                     on:click={() => deleteCategory(cat.id)}
-                    class="p-1 text-gray-400 hover:text-red-500 cursor-pointer"
+                    class="p-1 text-ink-subtle hover:text-red-500 cursor-pointer"
                     title={$_('common.delete')}
                   >
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -874,21 +874,21 @@
         </div>
         <!-- Income categories -->
         <div>
-          <h3 class="text-sm font-semibold text-gray-900 mb-2">{$_('finances.categories.incomeCategories')}</h3>
+          <h3 class="text-sm font-semibold text-ink mb-2">{$_('finances.categories.incomeCategories')}</h3>
           <div class="space-y-1.5">
             {#each categories.filter(c => c.type === 'INCOME' || c.type === 'BOTH') as cat}
-              <div class="flex items-center justify-between px-3 py-2 rounded-lg hover:bg-gray-50">
+              <div class="flex items-center justify-between px-3 py-2 rounded-lg hover:bg-surface-2">
                 <span class="flex items-center gap-2 text-sm">
                   <span class="w-3 h-3 rounded-full" style="background-color: {cat.color || '#6366F1'}"></span>
                   {getCategoryName(cat)}
                   {#if cat.isDefault}
-                    <span class="text-xs text-gray-400">({$_('finances.categories.default')})</span>
+                    <span class="text-xs text-ink-subtle">({$_('finances.categories.default')})</span>
                   {/if}
                 </span>
                 {#if !cat.isDefault}
                   <button
                     on:click={() => deleteCategory(cat.id)}
-                    class="p-1 text-gray-400 hover:text-red-500 cursor-pointer"
+                    class="p-1 text-ink-subtle hover:text-red-500 cursor-pointer"
                     title={$_('common.delete')}
                   >
                     <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -901,26 +901,26 @@
           </div>
         </div>
         <!-- Add new category -->
-        <div class="border-t border-gray-100 pt-4">
-          <h3 class="text-sm font-semibold text-gray-900 mb-2">{$_('finances.categories.addCategory')}</h3>
+        <div class="border-t border-border pt-4">
+          <h3 class="text-sm font-semibold text-ink mb-2">{$_('finances.categories.addCategory')}</h3>
           <div class="flex items-end gap-2">
             <div class="flex-1">
               <input
                 type="text"
                 bind:value={newCatName}
                 placeholder={$_('finances.categories.newCategory')}
-                class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+                class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
               />
             </div>
-            <select bind:value={newCatType} class="px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500">
+            <select bind:value={newCatType} class="px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500">
               <option value="EXPENSE">{$_('finances.expense')}</option>
               <option value="INCOME">{$_('finances.income')}</option>
             </select>
-            <input type="color" bind:value={newCatColor} class="w-10 h-9 rounded border border-gray-300 cursor-pointer" />
+            <input type="color" bind:value={newCatColor} class="w-10 h-9 rounded border border-border cursor-pointer" />
             <button
               on:click={addCategory}
               disabled={catSaving || !newCatName.trim()}
-              class="px-4 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 disabled:opacity-50 cursor-pointer"
+              class="px-4 py-2 bg-brand text-white rounded-lg text-sm font-medium hover:brightness-110 disabled:opacity-50 cursor-pointer"
             >
               {#if catSaving}
                 <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -943,15 +943,15 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => deletingId = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm">
       <div class="p-6">
         <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-4">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900 mb-2">{$_('finances.deleteRecord')}</h2>
-        <p class="text-sm text-gray-500 mb-6">{$_('finances.deleteRecordConfirm')}</p>
+        <h2 class="text-lg font-semibold text-ink mb-2">{$_('finances.deleteRecord')}</h2>
+        <p class="text-sm text-ink-muted mb-6">{$_('finances.deleteRecordConfirm')}</p>
         <div class="flex gap-3">
           <button
             on:click={() => deleteRecord(deletingId!)}
@@ -959,7 +959,7 @@
           >
             {$_('common.delete')}
           </button>
-          <button on:click={() => deletingId = null} class="flex-1 px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+          <button on:click={() => deletingId = null} class="flex-1 px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
             {$_('common.cancel')}
           </button>
         </div>

--- a/apps/web/src/routes/(app)/projects/[id]/overview/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/overview/+page.svelte
@@ -272,7 +272,7 @@
     <div class="bg-gradient-to-r from-iris-600 to-iris-400 rounded-xl p-5 mb-8 text-white">
       <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 sm:gap-4">
         <div class="flex items-center gap-3">
-          <div class="w-10 h-10 bg-surface/20 rounded-xl flex items-center justify-center flex-shrink-0">
+          <div class="w-10 h-10 bg-white/20 rounded-xl flex items-center justify-center flex-shrink-0">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z" />
             </svg>
@@ -282,7 +282,7 @@
             <p class="text-white/80 text-sm mt-0.5">{$_('projects.askAIDesc')}</p>
           </div>
         </div>
-        <a href="/ai-chat" class="bg-surface/20 hover:bg-white/30 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150 backdrop-blur-sm whitespace-nowrap flex-shrink-0 cursor-pointer">
+        <a href="/ai-chat" class="bg-white/20 hover:bg-white/30 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150 backdrop-blur-sm whitespace-nowrap flex-shrink-0 cursor-pointer">
           {$_('projects.openChat')}
         </a>
       </div>
@@ -298,7 +298,7 @@
               {$_('projects.gs.progress', { values: { done: completedCount, total: gettingStartedItems.length } })}
             </p>
           </div>
-          <button on:click={dismissGuide} class="text-xs text-ink-subtle hover:text-gray-600 cursor-pointer transition-colors duration-150">
+          <button on:click={dismissGuide} class="text-xs text-ink-subtle hover:text-ink-muted cursor-pointer transition-colors duration-150">
             {$_('projects.gs.dismiss')}
           </button>
         </div>

--- a/apps/web/src/routes/(app)/projects/[id]/overview/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/overview/+page.svelte
@@ -175,32 +175,32 @@
     {
       href: 'content', title: 'content.title', descKey: 'projects.quickActionDescs.content',
       icon: `<svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10" /></svg>`,
-      color: 'text-violet-600 bg-violet-50',
+      color: 'text-violet-500 bg-violet-500/12',
     },
     {
       href: 'campaigns', title: 'projects.campaigns', descKey: 'projects.quickActionDescs.campaigns',
       icon: `<svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M15.59 14.37a6 6 0 01-5.84 7.38v-4.8m5.84-2.58a14.98 14.98 0 006.16-12.12A14.98 14.98 0 009.631 8.41m5.96 5.96a14.926 14.926 0 01-5.841 2.58m-.119-8.54a6 6 0 00-7.381 5.84h4.8m2.581-5.84a14.927 14.927 0 00-2.58 5.84m2.699 2.7c-.103.021-.207.041-.311.06a15.09 15.09 0 01-2.448-2.448 14.9 14.9 0 01.06-.312m-2.24 2.39a4.493 4.493 0 00-1.757 4.306 4.493 4.493 0 004.306-1.758M16.5 9a1.5 1.5 0 11-3 0 1.5 1.5 0 013 0z" /></svg>`,
-      color: 'text-green-600 bg-green-50',
+      color: 'text-green-500 bg-green-500/12',
     },
     {
       href: 'email', title: 'projects.email', descKey: 'projects.quickActionDescs.email',
       icon: `<svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" /></svg>`,
-      color: 'text-blue-600 bg-blue-50',
+      color: 'text-blue-500 bg-blue-500/12',
     },
     {
       href: 'checklists', title: 'projects.checklists', descKey: 'projects.quickActionDescs.checklists',
       icon: `<svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>`,
-      color: 'text-orange-600 bg-orange-50',
+      color: 'text-orange-500 bg-orange-500/12',
     },
     {
       href: 'documents', title: 'projects.documents', descKey: 'projects.quickActionDescs.documents',
       icon: `<svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" /></svg>`,
-      color: 'text-slate-600 bg-slate-50',
+      color: 'text-slate-500 bg-slate-500/12',
     },
     {
       href: 'analytics', title: 'projects.analytics', descKey: 'projects.quickActionDescs.analytics',
       icon: `<svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" /></svg>`,
-      color: 'text-pink-600 bg-pink-50',
+      color: 'text-pink-500 bg-pink-500/12',
     },
   ];
 
@@ -216,7 +216,7 @@
   {#if $currentProjectStore}
     <div class="flex flex-col sm:flex-row items-start justify-between gap-4 mb-6">
       <div class="flex items-center gap-4">
-        <div class="w-14 h-14 bg-gradient-to-br from-primary-400 to-primary-700 rounded-2xl flex items-center justify-center text-white font-bold text-2xl flex-shrink-0">
+        <div class="w-14 h-14 bg-gradient-to-br from-iris-400 to-iris-700 rounded-2xl flex items-center justify-center text-white font-bold text-2xl flex-shrink-0">
           {$currentProjectStore.name.charAt(0)}
         </div>
         <div>
@@ -241,26 +241,35 @@
       </div>
     </div>
 
-    <!-- Stats -->
+    <!-- Stats — lead metric as a confident color block, rest as token KPIs -->
     <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
-      {#each stats as stat}
-        <div class="bg-surface rounded-xl border border-border p-4 border-t-4
-          {stat.color.includes('blue') ? 'border-t-blue-400' :
-           stat.color.includes('green') ? 'border-t-green-400' :
-           stat.color.includes('purple') ? 'border-t-purple-400' : 'border-t-orange-400'}">
-          <div class="flex items-center justify-between mb-3">
-            <div class="w-9 h-9 {stat.color} rounded-lg flex items-center justify-center flex-shrink-0">
-              {@html stat.icon}
+      {#each stats as stat, i}
+        {#if i === 0}
+          <div class="kpi-feature relative overflow-hidden">
+            <div class="absolute -right-7 -top-7 w-28 h-28 rounded-full bg-white/10 blur-xl"></div>
+            <div class="relative">
+              <div class="w-9 h-9 bg-white/20 rounded-lg flex items-center justify-center flex-shrink-0 text-white mb-3">
+                {@html stat.icon}
+              </div>
+              <div class="text-3xl font-bold leading-none">{loading ? '...' : stat.value}</div>
+              <div class="text-xs text-white/80 mt-1.5">{$_(stat.labelKey)}</div>
             </div>
           </div>
-          <div class="text-2xl font-bold text-ink">{loading ? '...' : stat.value}</div>
-          <div class="text-xs text-ink-muted mt-1">{$_(stat.labelKey)}</div>
-        </div>
+        {:else}
+          <div class="kpi flex flex-col">
+            <div class="w-9 h-9 rounded-lg flex items-center justify-center flex-shrink-0 mb-3
+              {i === 1 ? 'bg-ok/12 text-ok' : i === 2 ? 'bg-brand-subtle/12 text-brand' : 'bg-warn/12 text-warn'}">
+              {@html stat.icon}
+            </div>
+            <div class="text-2xl font-bold text-ink">{loading ? '...' : stat.value}</div>
+            <div class="text-xs text-ink-muted mt-1">{$_(stat.labelKey)}</div>
+          </div>
+        {/if}
       {/each}
     </div>
 
     <!-- AI Chat CTA -->
-    <div class="bg-gradient-to-r from-primary-600 to-violet-600 rounded-xl p-5 mb-8 text-white">
+    <div class="bg-gradient-to-r from-iris-600 to-iris-400 rounded-xl p-5 mb-8 text-white">
       <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 sm:gap-4">
         <div class="flex items-center gap-3">
           <div class="w-10 h-10 bg-surface/20 rounded-xl flex items-center justify-center flex-shrink-0">
@@ -270,7 +279,7 @@
           </div>
           <div>
             <h3 class="font-semibold text-base">{$_('projects.askAI')}</h3>
-            <p class="text-primary-100 text-sm mt-0.5">{$_('projects.askAIDesc')}</p>
+            <p class="text-white/80 text-sm mt-0.5">{$_('projects.askAIDesc')}</p>
           </div>
         </div>
         <a href="/ai-chat" class="bg-surface/20 hover:bg-white/30 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150 backdrop-blur-sm whitespace-nowrap flex-shrink-0 cursor-pointer">
@@ -305,7 +314,7 @@
             <div class="flex items-center gap-3 p-3 rounded-lg {item.done ? 'bg-surface-2' : 'border border-border'}">
               <!-- Circle check indicator -->
               <div class="w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0
-                {item.done ? 'bg-green-100 text-green-600' : 'border-2 border-border'}">
+                {item.done ? 'bg-ok/15 text-ok' : 'border-2 border-border'}">
                 {#if item.done}
                   <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
@@ -323,7 +332,7 @@
               {#if !item.done}
                 <a
                   href={item.external ? item.href : `/projects/${projectId}/${item.href}`}
-                  class="text-xs font-medium text-brand hover:text-primary-700 whitespace-nowrap cursor-pointer transition-colors duration-150"
+                  class="text-xs font-medium text-brand hover:text-brand whitespace-nowrap cursor-pointer transition-colors duration-150"
                 >
                   {$_('projects.gs.doItNow')} →
                 </a>
@@ -340,12 +349,12 @@
       {#each quickActions as action}
         <a
           href="/projects/{projectId}/{action.href}"
-          class="bg-surface rounded-xl border border-border p-5 hover:shadow-md hover:border-primary-200 transition-all duration-150 group cursor-pointer"
+          class="bg-surface rounded-xl border border-border p-5 hover:border-brand/40 hover:shadow-glow transition-all duration-150 group cursor-pointer"
         >
           <div class="w-11 h-11 {action.color} rounded-xl flex items-center justify-center mb-3 transition-colors duration-150">
             {@html action.icon}
           </div>
-          <h3 class="font-semibold text-ink group-hover:text-primary-700 transition-colors duration-150">{$_(action.title)}</h3>
+          <h3 class="font-semibold text-ink group-hover:text-brand transition-colors duration-150">{$_(action.title)}</h3>
           <p class="text-sm text-ink-muted mt-1">{$_(action.descKey)}</p>
         </a>
       {/each}
@@ -389,16 +398,16 @@
       <div class="p-6">
         <div class="flex items-center justify-between mb-3">
           <p class="text-sm font-medium text-ink">{$_('projectExport.selectSections')}</p>
-          <button on:click={toggleAllExportSections} class="text-xs text-brand hover:text-primary-700 cursor-pointer">
+          <button on:click={toggleAllExportSections} class="text-xs text-brand hover:text-brand cursor-pointer">
             {selectedExportSections.size === exportSections.length ? $_('projectExport.deselectAll') : $_('projectExport.selectAll')}
           </button>
         </div>
         <div class="space-y-2">
           {#each exportSections as section}
             <label class="flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors duration-150
-              {selectedExportSections.has(section.key) ? 'border-primary-200 bg-brand-subtle/10' : 'border-border hover:bg-surface-2'}">
+              {selectedExportSections.has(section.key) ? 'border-brand/40 bg-brand-subtle/10' : 'border-border hover:bg-surface-2'}">
               <input type="checkbox" checked={selectedExportSections.has(section.key)} on:change={() => toggleExportSection(section.key)}
-                class="w-4 h-4 text-brand rounded border-border focus:ring-primary-500" />
+                class="w-4 h-4 text-brand rounded border-border focus:ring-ring" />
               <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-ink-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                 <path stroke-linecap="round" stroke-linejoin="round" d={section.iconPath} />
               </svg>

--- a/apps/web/src/routes/(app)/projects/[id]/overview/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/overview/+page.svelte
@@ -220,18 +220,18 @@
           {$currentProjectStore.name.charAt(0)}
         </div>
         <div>
-          <h1 class="text-2xl font-bold text-gray-900">{$currentProjectStore.name}</h1>
-          <p class="text-sm text-gray-500 mt-0.5">{$currentProjectStore.projectType ? $_(`projects.types.${$currentProjectStore.projectType}`) : ''}{$currentProjectStore.industry ? ' · ' + $currentProjectStore.industry : ''}{$currentProjectStore.websiteUrl ? ' · ' + $currentProjectStore.websiteUrl : ''}</p>
+          <h1 class="text-2xl font-bold text-ink">{$currentProjectStore.name}</h1>
+          <p class="text-sm text-ink-muted mt-0.5">{$currentProjectStore.projectType ? $_(`projects.types.${$currentProjectStore.projectType}`) : ''}{$currentProjectStore.industry ? ' · ' + $currentProjectStore.industry : ''}{$currentProjectStore.websiteUrl ? ' · ' + $currentProjectStore.websiteUrl : ''}</p>
         </div>
       </div>
       <div class="flex items-center gap-2 w-full sm:w-auto">
-        <button on:click={() => showExportModal = true} class="flex-1 sm:flex-initial px-3 py-2 text-sm text-gray-600 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors duration-150 flex items-center justify-center gap-1.5 cursor-pointer">
+        <button on:click={() => showExportModal = true} class="flex-1 sm:flex-initial px-3 py-2 text-sm text-ink-muted border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 flex items-center justify-center gap-1.5 cursor-pointer">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
           </svg>
           {$_('common.export')}
         </button>
-        <a href="/projects/{projectId}/settings" class="flex-1 sm:flex-initial px-3 py-2 text-sm text-gray-600 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors duration-150 flex items-center justify-center gap-1.5 cursor-pointer">
+        <a href="/projects/{projectId}/settings" class="flex-1 sm:flex-initial px-3 py-2 text-sm text-ink-muted border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 flex items-center justify-center gap-1.5 cursor-pointer">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z" />
             <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -244,7 +244,7 @@
     <!-- Stats -->
     <div class="grid grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
       {#each stats as stat}
-        <div class="bg-white rounded-xl border border-gray-200 p-4 border-t-4
+        <div class="bg-surface rounded-xl border border-border p-4 border-t-4
           {stat.color.includes('blue') ? 'border-t-blue-400' :
            stat.color.includes('green') ? 'border-t-green-400' :
            stat.color.includes('purple') ? 'border-t-purple-400' : 'border-t-orange-400'}">
@@ -253,8 +253,8 @@
               {@html stat.icon}
             </div>
           </div>
-          <div class="text-2xl font-bold text-gray-900">{loading ? '...' : stat.value}</div>
-          <div class="text-xs text-gray-500 mt-1">{$_(stat.labelKey)}</div>
+          <div class="text-2xl font-bold text-ink">{loading ? '...' : stat.value}</div>
+          <div class="text-xs text-ink-muted mt-1">{$_(stat.labelKey)}</div>
         </div>
       {/each}
     </div>
@@ -263,7 +263,7 @@
     <div class="bg-gradient-to-r from-primary-600 to-violet-600 rounded-xl p-5 mb-8 text-white">
       <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 sm:gap-4">
         <div class="flex items-center gap-3">
-          <div class="w-10 h-10 bg-white/20 rounded-xl flex items-center justify-center flex-shrink-0">
+          <div class="w-10 h-10 bg-surface/20 rounded-xl flex items-center justify-center flex-shrink-0">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456zM16.894 20.567L16.5 21.75l-.394-1.183a2.25 2.25 0 00-1.423-1.423L13.5 18.75l1.183-.394a2.25 2.25 0 001.423-1.423l.394-1.183.394 1.183a2.25 2.25 0 001.423 1.423l1.183.394-1.183.394a2.25 2.25 0 00-1.423 1.423z" />
             </svg>
@@ -273,7 +273,7 @@
             <p class="text-primary-100 text-sm mt-0.5">{$_('projects.askAIDesc')}</p>
           </div>
         </div>
-        <a href="/ai-chat" class="bg-white/20 hover:bg-white/30 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150 backdrop-blur-sm whitespace-nowrap flex-shrink-0 cursor-pointer">
+        <a href="/ai-chat" class="bg-surface/20 hover:bg-white/30 text-white px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-150 backdrop-blur-sm whitespace-nowrap flex-shrink-0 cursor-pointer">
           {$_('projects.openChat')}
         </a>
       </div>
@@ -281,31 +281,31 @@
 
     <!-- Getting Started guide — shown until dismissed or all items done -->
     {#if !dismissed && !allDone}
-      <div class="bg-white rounded-xl border border-gray-200 p-5 mb-8">
+      <div class="bg-surface rounded-xl border border-border p-5 mb-8">
         <div class="flex items-center justify-between mb-3">
           <div>
-            <h2 class="text-base font-semibold text-gray-900">{$_('projects.gs.title')}</h2>
-            <p class="text-xs text-gray-500 mt-0.5">
+            <h2 class="text-base font-semibold text-ink">{$_('projects.gs.title')}</h2>
+            <p class="text-xs text-ink-muted mt-0.5">
               {$_('projects.gs.progress', { values: { done: completedCount, total: gettingStartedItems.length } })}
             </p>
           </div>
-          <button on:click={dismissGuide} class="text-xs text-gray-400 hover:text-gray-600 cursor-pointer transition-colors duration-150">
+          <button on:click={dismissGuide} class="text-xs text-ink-subtle hover:text-gray-600 cursor-pointer transition-colors duration-150">
             {$_('projects.gs.dismiss')}
           </button>
         </div>
         <!-- Progress bar -->
-        <div class="w-full bg-gray-100 rounded-full h-1.5 mb-4">
+        <div class="w-full bg-surface-2 rounded-full h-1.5 mb-4">
           <div
-            class="bg-primary-600 h-1.5 rounded-full transition-all duration-500"
+            class="bg-brand h-1.5 rounded-full transition-all duration-500"
             style="width: {(completedCount / gettingStartedItems.length) * 100}%"
           ></div>
         </div>
         <div class="space-y-2">
           {#each gettingStartedItems as item}
-            <div class="flex items-center gap-3 p-3 rounded-lg {item.done ? 'bg-gray-50' : 'border border-gray-100'}">
+            <div class="flex items-center gap-3 p-3 rounded-lg {item.done ? 'bg-surface-2' : 'border border-border'}">
               <!-- Circle check indicator -->
               <div class="w-5 h-5 rounded-full flex items-center justify-center flex-shrink-0
-                {item.done ? 'bg-green-100 text-green-600' : 'border-2 border-gray-300'}">
+                {item.done ? 'bg-green-100 text-green-600' : 'border-2 border-border'}">
                 {#if item.done}
                   <svg class="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="3">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
@@ -313,17 +313,17 @@
                 {/if}
               </div>
               <div class="flex-1 min-w-0">
-                <p class="text-sm font-medium {item.done ? 'line-through text-gray-400' : 'text-gray-900'}">
+                <p class="text-sm font-medium {item.done ? 'line-through text-ink-subtle' : 'text-ink'}">
                   {$_(item.labelKey)}
                 </p>
                 {#if !item.done}
-                  <p class="text-xs text-gray-500 mt-0.5">{$_(item.descKey)}</p>
+                  <p class="text-xs text-ink-muted mt-0.5">{$_(item.descKey)}</p>
                 {/if}
               </div>
               {#if !item.done}
                 <a
                   href={item.external ? item.href : `/projects/${projectId}/${item.href}`}
-                  class="text-xs font-medium text-primary-600 hover:text-primary-700 whitespace-nowrap cursor-pointer transition-colors duration-150"
+                  class="text-xs font-medium text-brand hover:text-primary-700 whitespace-nowrap cursor-pointer transition-colors duration-150"
                 >
                   {$_('projects.gs.doItNow')} →
                 </a>
@@ -335,18 +335,18 @@
     {/if}
 
     <!-- Quick actions grid -->
-    <h2 class="text-lg font-semibold text-gray-900 mb-4">{$_('projects.quickActions')}</h2>
+    <h2 class="text-lg font-semibold text-ink mb-4">{$_('projects.quickActions')}</h2>
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
       {#each quickActions as action}
         <a
           href="/projects/{projectId}/{action.href}"
-          class="bg-white rounded-xl border border-gray-200 p-5 hover:shadow-md hover:border-primary-200 transition-all duration-150 group cursor-pointer"
+          class="bg-surface rounded-xl border border-border p-5 hover:shadow-md hover:border-primary-200 transition-all duration-150 group cursor-pointer"
         >
           <div class="w-11 h-11 {action.color} rounded-xl flex items-center justify-center mb-3 transition-colors duration-150">
             {@html action.icon}
           </div>
-          <h3 class="font-semibold text-gray-900 group-hover:text-primary-700 transition-colors duration-150">{$_(action.title)}</h3>
-          <p class="text-sm text-gray-500 mt-1">{$_(action.descKey)}</p>
+          <h3 class="font-semibold text-ink group-hover:text-primary-700 transition-colors duration-150">{$_(action.title)}</h3>
+          <p class="text-sm text-ink-muted mt-1">{$_(action.descKey)}</p>
         </a>
       {/each}
     </div>
@@ -371,49 +371,49 @@
 <!-- Export Modal -->
 {#if showExportModal}
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showExportModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border">
         <div class="flex items-center gap-3">
-          <div class="w-10 h-10 bg-primary-50 rounded-xl flex items-center justify-center">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+          <div class="w-10 h-10 bg-brand-subtle/10 rounded-xl flex items-center justify-center">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M3 16.5v2.25A2.25 2.25 0 005.25 21h13.5A2.25 2.25 0 0021 18.75V16.5M16.5 12L12 16.5m0 0L7.5 12m4.5 4.5V3" />
             </svg>
           </div>
           <div>
-            <h3 class="text-lg font-semibold text-gray-900">{$_('projectExport.title')}</h3>
-            <p class="text-sm text-gray-500">{$_('projectExport.description')}</p>
+            <h3 class="text-lg font-semibold text-ink">{$_('projectExport.title')}</h3>
+            <p class="text-sm text-ink-muted">{$_('projectExport.description')}</p>
           </div>
         </div>
       </div>
 
       <div class="p-6">
         <div class="flex items-center justify-between mb-3">
-          <p class="text-sm font-medium text-gray-700">{$_('projectExport.selectSections')}</p>
-          <button on:click={toggleAllExportSections} class="text-xs text-primary-600 hover:text-primary-700 cursor-pointer">
+          <p class="text-sm font-medium text-ink">{$_('projectExport.selectSections')}</p>
+          <button on:click={toggleAllExportSections} class="text-xs text-brand hover:text-primary-700 cursor-pointer">
             {selectedExportSections.size === exportSections.length ? $_('projectExport.deselectAll') : $_('projectExport.selectAll')}
           </button>
         </div>
         <div class="space-y-2">
           {#each exportSections as section}
             <label class="flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors duration-150
-              {selectedExportSections.has(section.key) ? 'border-primary-200 bg-primary-50/50' : 'border-gray-200 hover:bg-gray-50'}">
+              {selectedExportSections.has(section.key) ? 'border-primary-200 bg-brand-subtle/10' : 'border-border hover:bg-surface-2'}">
               <input type="checkbox" checked={selectedExportSections.has(section.key)} on:change={() => toggleExportSection(section.key)}
-                class="w-4 h-4 text-primary-600 rounded border-gray-300 focus:ring-primary-500" />
-              <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                class="w-4 h-4 text-brand rounded border-border focus:ring-primary-500" />
+              <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-ink-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
                 <path stroke-linecap="round" stroke-linejoin="round" d={section.iconPath} />
               </svg>
-              <span class="text-sm text-gray-700">{$_(section.labelKey)}</span>
+              <span class="text-sm text-ink">{$_(section.labelKey)}</span>
             </label>
           {/each}
         </div>
       </div>
 
-      <div class="p-6 border-t border-gray-100 flex justify-end gap-3">
-        <button on:click={() => showExportModal = false} class="px-4 py-2 text-sm text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 cursor-pointer transition-colors duration-150">
+      <div class="p-6 border-t border-border flex justify-end gap-3">
+        <button on:click={() => showExportModal = false} class="px-4 py-2 text-sm text-ink border border-border rounded-lg hover:bg-surface-2 cursor-pointer transition-colors duration-150">
           {$_('common.cancel')}
         </button>
         <button on:click={doExport} disabled={exporting || selectedExportSections.size === 0}
-          class="px-4 py-2 text-sm text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50 cursor-pointer transition-colors duration-150 flex items-center gap-2">
+          class="px-4 py-2 text-sm text-white bg-brand rounded-lg hover:brightness-110 disabled:opacity-50 cursor-pointer transition-colors duration-150 flex items-center gap-2">
           {#if exporting}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24"><circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle><path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path></svg>
             {$_('projectExport.downloading')}

--- a/apps/web/src/routes/(app)/projects/[id]/search-console/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/search-console/+page.svelte
@@ -139,28 +139,28 @@
 <div class="p-6 max-w-7xl mx-auto">
   <!-- Page header -->
   <div class="mb-6">
-    <a href={`/projects/${projectId}/analytics`} class="inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-2">
+    <a href={`/projects/${projectId}/analytics`} class="inline-flex items-center gap-1 text-sm text-ink-muted hover:text-gray-700 mb-2">
       <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15 19l-7-7 7-7" /></svg>
       {$_('gscDetail.back')}
     </a>
-    <h1 class="text-2xl font-semibold text-gray-900">{$_('gscDetail.title')}</h1>
-    <p class="text-sm text-gray-500 mt-1">{$_('gscDetail.subtitle')}</p>
+    <h1 class="text-2xl font-semibold text-ink">{$_('gscDetail.title')}</h1>
+    <p class="text-sm text-ink-muted mt-1">{$_('gscDetail.subtitle')}</p>
   </div>
 
   <!-- Not connected state -->
   {#if notConnected}
-    <div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
+    <div class="bg-surface rounded-xl border border-border overflow-hidden">
       <div class="flex flex-col items-center justify-center py-14 px-5 text-center">
         <div class="w-16 h-16 bg-blue-50 rounded-2xl flex items-center justify-center mb-4">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 text-blue-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-4.35-4.35M17 11A6 6 0 115 11a6 6 0 0112 0z" />
           </svg>
         </div>
-        <h3 class="text-base font-semibold text-gray-900 mb-1">{$_('seo.searchConsolePanel.notConnectedTitle')}</h3>
-        <p class="text-sm text-gray-500 max-w-sm mb-4">{$_('seo.searchConsolePanel.notConnectedDescription')}</p>
+        <h3 class="text-base font-semibold text-ink mb-1">{$_('seo.searchConsolePanel.notConnectedTitle')}</h3>
+        <p class="text-sm text-ink-muted max-w-sm mb-4">{$_('seo.searchConsolePanel.notConnectedDescription')}</p>
         <a
           href={settingsUrl}
-          class="inline-flex items-center gap-1.5 px-4 py-2 bg-primary-600 hover:bg-primary-700 text-white text-sm font-medium rounded-lg transition-colors">
+          class="inline-flex items-center gap-1.5 px-4 py-2 bg-brand hover:brightness-110 text-white text-sm font-medium rounded-lg transition-colors">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M10.343 3.94c.09-.542.56-.94 1.11-.94h1.093c.55 0 1.02.398 1.11.94l.149.894c.07.424.384.764.78.93.398.164.855.142 1.205-.108l.737-.527a1.125 1.125 0 011.45.12l.773.774c.39.389.44 1.002.12 1.45l-.527.737c-.25.35-.272.806-.107 1.204.165.397.505.71.93.78l.893.15c.543.09.94.56.94 1.109v1.094c0 .55-.397 1.02-.94 1.11l-.893.149c-.425.07-.765.383-.93.78-.165.398-.143.854.107 1.204l.527.738c.32.447.269 1.06-.12 1.45l-.774.773a1.125 1.125 0 01-1.449.12l-.738-.527c-.35-.25-.806-.272-1.203-.107-.397.165-.71.505-.781.929l-.149.894c-.09.542-.56.94-1.11.94h-1.094c-.55 0-1.019-.398-1.11-.94l-.148-.894c-.071-.424-.384-.764-.781-.93-.398-.164-.854-.142-1.204.108l-.738.527c-.447.32-1.06.269-1.45-.12l-.773-.774a1.125 1.125 0 01-.12-1.45l.527-.737c.25-.35.273-.806.108-1.204-.165-.397-.505-.71-.93-.78l-.894-.15c-.542-.09-.94-.56-.94-1.109v-1.094c0-.55.398-1.02.94-1.11l.894-.149c.424-.07.765-.383.93-.78.165-.398.143-.854-.107-1.204l-.527-.738a1.125 1.125 0 01.12-1.45l.773-.773a1.125 1.125 0 011.45-.12l.737.527c.35.25.807.272 1.204.107.397-.165.71-.505.78-.929l.15-.894z" />
             <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
@@ -172,17 +172,17 @@
 
   <!-- Error state -->
   {:else if error}
-    <div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
+    <div class="bg-surface rounded-xl border border-border overflow-hidden">
       <div class="flex flex-col items-center justify-center py-14 px-5 text-center">
         <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-3">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z" />
           </svg>
         </div>
-        <p class="text-sm text-gray-700 mb-3">{error}</p>
+        <p class="text-sm text-ink mb-3">{error}</p>
         <button
           on:click={reload}
-          class="px-4 py-1.5 text-sm font-medium bg-gray-100 hover:bg-gray-200 text-gray-700 rounded-lg transition-colors">
+          class="px-4 py-1.5 text-sm font-medium bg-surface-2 hover:bg-gray-200 text-ink rounded-lg transition-colors">
           {$_('seo.searchConsolePanel.retry')}
         </button>
       </div>
@@ -190,13 +190,13 @@
 
   <!-- Loading skeleton -->
   {:else if loading}
-    <div class="bg-white rounded-xl border border-gray-200 p-5 space-y-6 animate-pulse">
+    <div class="bg-surface rounded-xl border border-border p-5 space-y-6 animate-pulse">
       <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
         {#each Array(4) as _}
-          <div class="bg-gray-100 rounded-xl h-24"></div>
+          <div class="bg-surface-2 rounded-xl h-24"></div>
         {/each}
       </div>
-      <div class="bg-gray-100 rounded-xl h-56"></div>
+      <div class="bg-surface-2 rounded-xl h-56"></div>
     </div>
 
   <!-- Overview content -->
@@ -213,21 +213,21 @@
     <GscOverview totals={totalsRow} {byDate} {compare} />
 
     <!-- Queries / Pages tab switch -->
-    <div class="flex gap-1 bg-gray-100 rounded-lg p-1 w-fit mt-6 mb-3">
+    <div class="flex gap-1 bg-surface-2 rounded-lg p-1 w-fit mt-6 mb-3">
       <button
         on:click={() => (activeTableDim = 'query')}
         class="px-4 py-1.5 text-sm font-medium rounded-md transition-colors duration-150
           {activeTableDim === 'query'
-            ? 'bg-white text-gray-900 shadow-sm'
-            : 'text-gray-500 hover:text-gray-700'}">
+            ? 'bg-surface text-ink shadow-sm'
+            : 'text-ink-muted hover:text-gray-700'}">
         {$_('gscDetail.tabQueries')}
       </button>
       <button
         on:click={() => (activeTableDim = 'page')}
         class="px-4 py-1.5 text-sm font-medium rounded-md transition-colors duration-150
           {activeTableDim === 'page'
-            ? 'bg-white text-gray-900 shadow-sm'
-            : 'text-gray-500 hover:text-gray-700'}">
+            ? 'bg-surface text-ink shadow-sm'
+            : 'text-ink-muted hover:text-gray-700'}">
         {$_('gscDetail.tabPages')}
       </button>
     </div>
@@ -242,7 +242,7 @@
 
     <!-- Insights section -->
     <div class="mt-10">
-      <h2 class="text-lg font-semibold text-gray-900 mb-4">{$_('gscDetail.insights')}</h2>
+      <h2 class="text-lg font-semibold text-ink mb-4">{$_('gscDetail.insights')}</h2>
       <GscInsights
         projectId={projectId ?? ''}
         {days}
@@ -251,25 +251,25 @@
     </div>
 
     <!-- AI Advice card -->
-    <div class="bg-white rounded-xl border border-gray-200 p-5 mt-6">
+    <div class="bg-surface rounded-xl border border-border p-5 mt-6">
       <div class="flex items-center justify-between mb-3">
-        <h3 class="text-sm font-semibold text-gray-700">{$_('gscDetail.adviceTitle')}</h3>
+        <h3 class="text-sm font-semibold text-ink">{$_('gscDetail.adviceTitle')}</h3>
         {#if !advice}
           <button on:click={getAdvice} disabled={adviceLoading}
-            class="px-3 py-1.5 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50 cursor-pointer">
+            class="px-3 py-1.5 text-sm font-medium text-white bg-brand rounded-lg hover:brightness-110 disabled:opacity-50 cursor-pointer">
             {adviceLoading ? $_('gscDetail.generating') : $_('gscDetail.getAdvice')}
           </button>
         {/if}
       </div>
       {#if adviceError}<p class="text-sm text-red-600">{adviceError}</p>{/if}
       {#if advice}
-        <div class="prose prose-sm max-w-none text-gray-700">{@html DOMPurify.sanitize(marked.parse(advice, { async: false }) as string)}</div>
+        <div class="prose prose-sm max-w-none text-ink">{@html DOMPurify.sanitize(marked.parse(advice, { async: false }) as string)}</div>
         <div class="flex items-center gap-2 mt-4">
           <button on:click={continueInChat} disabled={openingChat}
-            class="px-3 py-1.5 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 disabled:opacity-50 cursor-pointer">
+            class="px-3 py-1.5 text-sm font-medium text-white bg-brand rounded-lg hover:brightness-110 disabled:opacity-50 cursor-pointer">
             {$_('gscDetail.continueInChat')}
           </button>
-          <button on:click={getAdvice} disabled={adviceLoading} class="px-3 py-1.5 text-sm text-gray-600 border border-gray-300 rounded-lg hover:bg-gray-50 cursor-pointer">
+          <button on:click={getAdvice} disabled={adviceLoading} class="px-3 py-1.5 text-sm text-ink-muted border border-border rounded-lg hover:bg-surface-2 cursor-pointer">
             {adviceLoading ? $_('gscDetail.generating') : $_('gscDetail.regenerate')}
           </button>
         </div>

--- a/apps/web/src/routes/(app)/projects/[id]/seo/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/seo/+page.svelte
@@ -286,7 +286,7 @@
 
   function rankDelta(now: number | null, prev: number | null): { text: string; color: string } | null {
     if (now === null || prev === null) return null;
-    if (now === prev) return { text: '=', color: 'text-gray-500' };
+    if (now === prev) return { text: '=', color: 'text-ink-muted' };
     const diff = prev - now; // lower rank is better; positive diff = improvement
     if (diff > 0) return { text: `↑ ${diff}`, color: 'text-green-600' };
     return { text: `↓ ${Math.abs(diff)}`, color: 'text-red-600' };
@@ -351,7 +351,7 @@
 
   const intentBadge: Record<string, string> = {
     INFORMATIONAL: 'bg-blue-100 text-blue-700',
-    NAVIGATIONAL: 'bg-gray-100 text-gray-700',
+    NAVIGATIONAL: 'bg-surface-2 text-ink',
     COMMERCIAL: 'bg-amber-100 text-amber-700',
     TRANSACTIONAL: 'bg-green-100 text-green-700',
   };
@@ -370,13 +370,13 @@
   }
 
   function trendIndicator(history: number[]): { icon: 'up' | 'down' | 'stable'; color: string } {
-    if (!history || history.length < 2) return { icon: 'stable', color: 'text-gray-400' };
+    if (!history || history.length < 2) return { icon: 'stable', color: 'text-ink-subtle' };
     const recent = history[history.length - 1];
     const prev = history[history.length - 2];
     // Lower rank = better position
     if (recent < prev) return { icon: 'up', color: 'text-green-600' };
     if (recent > prev) return { icon: 'down', color: 'text-red-500' };
-    return { icon: 'stable', color: 'text-gray-400' };
+    return { icon: 'stable', color: 'text-ink-subtle' };
   }
 
   function sparklinePath(history: number[]): string {
@@ -417,15 +417,15 @@
   <!-- Header -->
   <div class="flex items-center justify-between mb-6">
     <div>
-      <h1 class="text-2xl font-bold text-gray-900">{$_('seo.title')}</h1>
-      <p class="text-sm text-gray-500 mt-1">{$_('seo.subtitle')}</p>
+      <h1 class="text-2xl font-bold text-ink">{$_('seo.title')}</h1>
+      <p class="text-sm text-ink-muted mt-1">{$_('seo.subtitle')}</p>
     </div>
     <div class="flex items-center gap-3">
       <!-- Sync from GSC button -->
       <button
         on:click={syncFromGsc}
         disabled={syncing}
-        class="border border-gray-300 text-gray-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors duration-150 flex items-center gap-2 cursor-pointer disabled:opacity-50"
+        class="border border-border text-ink px-4 py-2 rounded-lg text-sm font-medium hover:bg-surface-2 transition-colors duration-150 flex items-center gap-2 cursor-pointer disabled:opacity-50"
         title={$_('seo.syncFromGsc')}
       >
         {#if syncing}
@@ -447,7 +447,7 @@
       <button
         on:click={runSeoAudit}
         disabled={auditing}
-        class="border border-gray-300 text-gray-700 px-4 py-2 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors duration-150 flex items-center gap-2 cursor-pointer disabled:opacity-50"
+        class="border border-border text-ink px-4 py-2 rounded-lg text-sm font-medium hover:bg-surface-2 transition-colors duration-150 flex items-center gap-2 cursor-pointer disabled:opacity-50"
       >
         {#if auditing}
           <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -464,7 +464,7 @@
       </button>
       <button
         on:click={() => { form = { ...form, searchLocale: defaultSearchLocale }; showModal = true; }}
-        class="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+        class="bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -476,17 +476,17 @@
 
   <!-- GSC sync result panel -->
   {#if lastSyncResult}
-    <div class="bg-white rounded-xl border border-primary-200 p-5 mb-4 shadow-sm">
+    <div class="bg-surface rounded-xl border border-primary-200 p-5 mb-4 shadow-sm">
       <div class="flex items-start justify-between mb-3">
         <div>
-          <h3 class="text-sm font-semibold text-gray-900 flex items-center gap-2">
-            <svg class="w-5 h-5 text-primary-600" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <h3 class="text-sm font-semibold text-ink flex items-center gap-2">
+            <svg class="w-5 h-5 text-brand" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
             </svg>
             Sync complete — pulled Google Search Console data for {lastSyncResult.date}
           </h3>
-          <p class="text-xs text-gray-500 mt-1">
-            Site: <span class="font-mono text-gray-700">{lastSyncResult.siteUrl}</span>
+          <p class="text-xs text-ink-muted mt-1">
+            Site: <span class="font-mono text-ink">{lastSyncResult.siteUrl}</span>
             &nbsp;·&nbsp;
             {lastSyncResult.matched} of {lastSyncResult.synced} keywords matched in GSC
             {#if lastSyncResult.synced - lastSyncResult.matched > 0}
@@ -496,7 +496,7 @@
         </div>
         <button
           on:click={dismissSyncResult}
-          class="text-gray-400 hover:text-gray-600 p-1"
+          class="text-ink-subtle hover:text-gray-600 p-1"
           title="Dismiss"
         >
           <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -506,10 +506,10 @@
       </div>
 
       {#if lastSyncResult.details.length > 0}
-        <div class="overflow-hidden border border-gray-100 rounded-lg">
+        <div class="overflow-hidden border border-border rounded-lg">
           <table class="w-full text-sm">
-            <thead class="bg-gray-50">
-              <tr class="text-left text-xs text-gray-500 uppercase">
+            <thead class="bg-surface-2">
+              <tr class="text-left text-xs text-ink-muted uppercase">
                 <th class="px-3 py-2 font-medium">Keyword</th>
                 <th class="px-3 py-2 font-medium">Previous</th>
                 <th class="px-3 py-2 font-medium">New rank</th>
@@ -518,16 +518,16 @@
             </thead>
             <tbody class="divide-y divide-gray-50">
               {#each lastSyncResult.details as d}
-                <tr class="hover:bg-gray-50">
-                  <td class="px-3 py-2 text-gray-900">{d.keyword}</td>
-                  <td class="px-3 py-2 text-gray-500">
+                <tr class="hover:bg-surface-2">
+                  <td class="px-3 py-2 text-ink">{d.keyword}</td>
+                  <td class="px-3 py-2 text-ink-muted">
                     {d.previousRank ?? '—'}
                   </td>
                   <td class="px-3 py-2">
                     {#if d.rank !== null}
-                      <span class="font-semibold text-gray-900">#{d.rank}</span>
+                      <span class="font-semibold text-ink">#{d.rank}</span>
                     {:else if d.reason === 'NO_MATCH_IN_GSC'}
-                      <span class="text-gray-400 italic">not ranked in GSC</span>
+                      <span class="text-ink-subtle italic">not ranked in GSC</span>
                     {:else if d.reason === 'NO_URL'}
                       <span class="text-amber-600 italic">no target URL</span>
                     {/if}
@@ -538,10 +538,10 @@
                       {#if delta}
                         <span class={delta.color + ' font-medium text-xs'}>{delta.text}</span>
                       {:else}
-                        <span class="text-gray-400 text-xs">new</span>
+                        <span class="text-ink-subtle text-xs">new</span>
                       {/if}
                     {:else}
-                      <span class="text-gray-300">—</span>
+                      <span class="text-ink-subtle">—</span>
                     {/if}
                   </td>
                 </tr>
@@ -551,7 +551,7 @@
         </div>
       {/if}
 
-      <div class="text-xs text-gray-400 mt-3 space-y-1">
+      <div class="text-xs text-ink-subtle mt-3 space-y-1">
         <p>GSC data lags by 2–3 days. Positions shown are an average for {lastSyncResult.date}. For same-day feedback use <strong>Record position</strong> on individual keywords.</p>
         {#if lastSyncResult.matched === 0 && lastSyncResult.synced > 0}
           <p class="text-amber-700">
@@ -567,29 +567,29 @@
 
   {#if loading}
     <!-- Loading skeleton -->
-    <div class="bg-white rounded-xl border border-gray-200 animate-pulse">
-      <div class="p-4 border-b border-gray-100">
+    <div class="bg-surface rounded-xl border border-border animate-pulse">
+      <div class="p-4 border-b border-border">
         <div class="h-4 bg-gray-200 rounded w-1/3"></div>
       </div>
       {#each Array(5) as _}
         <div class="p-4 border-b border-gray-50">
-          <div class="h-4 bg-gray-100 rounded w-full"></div>
+          <div class="h-4 bg-surface-2 rounded w-full"></div>
         </div>
       {/each}
     </div>
   {:else if keywords.length === 0}
     <!-- Empty state -->
     <div class="flex flex-col items-center justify-center py-20 text-center">
-      <div class="w-20 h-20 bg-primary-50 rounded-2xl flex items-center justify-center mb-6">
+      <div class="w-20 h-20 bg-brand-subtle/10 rounded-2xl flex items-center justify-center mb-6">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 21a9.004 9.004 0 0 0 8.716-6.747M12 21a9.004 9.004 0 0 1-8.716-6.747M12 21c2.485 0 4.5-4.03 4.5-9S14.485 3 12 3m0 18c-2.485 0-4.5-4.03-4.5-9S9.515 3 12 3m0 0a8.997 8.997 0 0 1 7.843 4.582M12 3a8.997 8.997 0 0 0-7.843 4.582m15.686 0A11.953 11.953 0 0 1 12 10.5c-2.998 0-5.74-1.1-7.843-2.918m15.686 0A8.959 8.959 0 0 1 21 12c0 .778-.099 1.533-.284 2.253m0 0A17.919 17.919 0 0 1 12 16.5c-3.162 0-6.133-.815-8.716-2.247m0 0A9.015 9.015 0 0 1 3 12c0-1.605.42-3.113 1.157-4.418" />
         </svg>
       </div>
-      <h2 class="text-xl font-semibold text-gray-900 mb-2">{$_('seo.empty')}</h2>
-      <p class="text-gray-500 mb-6 max-w-sm">{$_('seo.emptyDesc')}</p>
+      <h2 class="text-xl font-semibold text-ink mb-2">{$_('seo.empty')}</h2>
+      <p class="text-ink-muted mb-6 max-w-sm">{$_('seo.emptyDesc')}</p>
       <button
         on:click={() => { form = { ...form, searchLocale: defaultSearchLocale }; showModal = true; }}
-        class="bg-primary-600 text-white px-6 py-3 rounded-xl font-medium hover:bg-primary-700 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+        class="bg-brand text-white px-6 py-3 rounded-xl font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -599,21 +599,21 @@
     </div>
   {:else}
     <!-- Keywords table -->
-    <div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
+    <div class="bg-surface rounded-xl border border-border overflow-hidden">
       <div class="overflow-x-auto">
         <table class="w-full">
           <thead>
-            <tr class="border-b border-gray-100 bg-gray-50/50">
-              <th class="text-left text-xs font-medium text-gray-500 uppercase tracking-wider px-5 py-3">{$_('seo.keyword')}</th>
-              <th class="text-left text-xs font-medium text-gray-500 uppercase tracking-wider px-5 py-3">{$_('seo.targetUrl')}</th>
-              <th class="text-right text-xs font-medium text-gray-500 uppercase tracking-wider px-5 py-3">{$_('seo.searchVolume')}</th>
-              <th class="text-left text-xs font-medium text-gray-500 uppercase tracking-wider px-5 py-3">{$_('seo.difficulty')}</th>
-              <th class="text-right text-xs font-medium text-gray-500 uppercase tracking-wider px-5 py-3">{$_('seo.currentRank')}</th>
-              <th class="text-right text-xs font-medium text-gray-500 uppercase tracking-wider px-5 py-3">{$_('seo.targetRank')}</th>
-              <th class="text-left text-xs font-medium text-gray-500 uppercase tracking-wider px-5 py-3">{$_('seo.intent')}</th>
-              <th class="text-center text-xs font-medium text-gray-500 uppercase tracking-wider px-5 py-3">{$_('seo.trend')}</th>
-              <th class="text-center text-xs font-medium text-gray-500 uppercase tracking-wider px-5 py-3">{$_('seo.tracking')}</th>
-              <th class="text-right text-xs font-medium text-gray-500 uppercase tracking-wider px-5 py-3"></th>
+            <tr class="border-b border-border bg-surface-2/50">
+              <th class="text-left text-xs font-medium text-ink-muted uppercase tracking-wider px-5 py-3">{$_('seo.keyword')}</th>
+              <th class="text-left text-xs font-medium text-ink-muted uppercase tracking-wider px-5 py-3">{$_('seo.targetUrl')}</th>
+              <th class="text-right text-xs font-medium text-ink-muted uppercase tracking-wider px-5 py-3">{$_('seo.searchVolume')}</th>
+              <th class="text-left text-xs font-medium text-ink-muted uppercase tracking-wider px-5 py-3">{$_('seo.difficulty')}</th>
+              <th class="text-right text-xs font-medium text-ink-muted uppercase tracking-wider px-5 py-3">{$_('seo.currentRank')}</th>
+              <th class="text-right text-xs font-medium text-ink-muted uppercase tracking-wider px-5 py-3">{$_('seo.targetRank')}</th>
+              <th class="text-left text-xs font-medium text-ink-muted uppercase tracking-wider px-5 py-3">{$_('seo.intent')}</th>
+              <th class="text-center text-xs font-medium text-ink-muted uppercase tracking-wider px-5 py-3">{$_('seo.trend')}</th>
+              <th class="text-center text-xs font-medium text-ink-muted uppercase tracking-wider px-5 py-3">{$_('seo.tracking')}</th>
+              <th class="text-right text-xs font-medium text-ink-muted uppercase tracking-wider px-5 py-3"></th>
             </tr>
           </thead>
           <tbody class="divide-y divide-gray-50">
@@ -621,65 +621,65 @@
               {@const history = historyMap[kw.id] || []}
               {@const trend = trendIndicator(history)}
               {@const urlHost = getTargetUrlHost(kw.url)}
-              <tr class="hover:bg-gray-50/50 transition-colors duration-100">
+              <tr class="hover:bg-surface-2/50 transition-colors duration-100">
                 <!-- Keyword -->
                 <td class="px-5 py-3.5">
-                  <span class="text-sm font-medium text-gray-900">{kw.keyword}</span>
+                  <span class="text-sm font-medium text-ink">{kw.keyword}</span>
                 </td>
 
                 <!-- Target URL -->
                 <td class="px-5 py-3.5 max-w-[140px]">
                   {#if urlHost}
                     {#if projectWebsite && kw.url === projectWebsite}
-                      <span class="text-xs text-gray-500 italic" title={kw.url}>Homepage</span>
+                      <span class="text-xs text-ink-muted italic" title={kw.url}>Homepage</span>
                     {:else}
                       {@const pathOnly = getTargetUrlPath(kw.url)}
-                      <span class="text-sm text-gray-600 truncate block" title={kw.url}>{pathOnly || urlHost}</span>
+                      <span class="text-sm text-ink-muted truncate block" title={kw.url}>{pathOnly || urlHost}</span>
                     {/if}
                   {:else}
-                    <span class="text-sm text-gray-400">—</span>
+                    <span class="text-sm text-ink-subtle">—</span>
                   {/if}
                 </td>
 
                 <!-- Search Volume -->
                 <td class="px-5 py-3.5 text-right">
-                  <span class="text-sm text-gray-600">{kw.searchVolume != null ? kw.searchVolume.toLocaleString() : '—'}</span>
+                  <span class="text-sm text-ink-muted">{kw.searchVolume != null ? kw.searchVolume.toLocaleString() : '—'}</span>
                 </td>
 
                 <!-- Difficulty -->
                 <td class="px-5 py-3.5">
                   {#if kw.difficulty != null}
                     <div class="flex items-center gap-2">
-                      <div class="w-16 bg-gray-100 rounded-full h-1.5">
+                      <div class="w-16 bg-surface-2 rounded-full h-1.5">
                         <div class="{difficultyColor(kw.difficulty)} h-1.5 rounded-full" style="width: {kw.difficulty}%"></div>
                       </div>
-                      <span class="text-xs text-gray-500 w-7 text-right">{kw.difficulty}</span>
+                      <span class="text-xs text-ink-muted w-7 text-right">{kw.difficulty}</span>
                     </div>
                   {:else}
-                    <span class="text-sm text-gray-400">—</span>
+                    <span class="text-sm text-ink-subtle">—</span>
                   {/if}
                 </td>
 
                 <!-- Current Rank -->
                 <td class="px-5 py-3.5 text-right">
-                  <span class="text-sm font-medium {kw.currentRank != null && kw.currentRank <= 10 ? 'text-green-600' : kw.currentRank != null && kw.currentRank <= 30 ? 'text-amber-600' : 'text-gray-600'}">
+                  <span class="text-sm font-medium {kw.currentRank != null && kw.currentRank <= 10 ? 'text-green-600' : kw.currentRank != null && kw.currentRank <= 30 ? 'text-amber-600' : 'text-ink-muted'}">
                     {kw.currentRank != null ? '#' + kw.currentRank : '—'}
                   </span>
                 </td>
 
                 <!-- Target Rank -->
                 <td class="px-5 py-3.5 text-right">
-                  <span class="text-sm text-gray-500">{kw.targetRank != null ? '#' + kw.targetRank : '—'}</span>
+                  <span class="text-sm text-ink-muted">{kw.targetRank != null ? '#' + kw.targetRank : '—'}</span>
                 </td>
 
                 <!-- Intent -->
                 <td class="px-5 py-3.5">
                   {#if kw.intent}
-                    <span class="text-xs px-2 py-0.5 rounded-full font-medium {intentBadge[kw.intent] || 'bg-gray-100 text-gray-600'}">
+                    <span class="text-xs px-2 py-0.5 rounded-full font-medium {intentBadge[kw.intent] || 'bg-surface-2 text-ink-muted'}">
                       {$_(intentLabel[kw.intent] || 'seo.intentInformational')}
                     </span>
                   {:else}
-                    <span class="text-sm text-gray-400">—</span>
+                    <span class="text-sm text-ink-subtle">—</span>
                   {/if}
                 </td>
 
@@ -706,7 +706,7 @@
                         {/if}
                       </span>
                     {:else}
-                      <span class="text-xs text-gray-400">{$_('seo.noHistory')}</span>
+                      <span class="text-xs text-ink-subtle">{$_('seo.noHistory')}</span>
                     {/if}
                   </div>
                 </td>
@@ -719,7 +719,7 @@
                       {$_('seo.active')}
                     </span>
                   {:else}
-                    <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-500 font-medium">
+                    <span class="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-surface-2 text-ink-muted font-medium">
                       <span class="w-1.5 h-1.5 bg-gray-400 rounded-full"></span>
                       {$_('seo.paused')}
                     </span>
@@ -732,7 +732,7 @@
                     <!-- View history link -->
                     <a
                       href="/projects/{projectId}/seo/keywords/{kw.id}"
-                      class="text-gray-400 hover:text-primary-600 transition-colors duration-150 p-1 inline-flex items-center"
+                      class="text-ink-subtle hover:text-primary-600 transition-colors duration-150 p-1 inline-flex items-center"
                       title={$_('seo.history.viewHistory')}
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -742,7 +742,7 @@
                     <!-- Record position button -->
                     <button
                       on:click={() => openRecordModal(kw)}
-                      class="text-gray-400 hover:text-primary-600 transition-colors duration-150 cursor-pointer p-1"
+                      class="text-ink-subtle hover:text-primary-600 transition-colors duration-150 cursor-pointer p-1"
                       title={$_('seo.recordPosition.title')}
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -752,7 +752,7 @@
                     <!-- Delete button -->
                     <button
                       on:click={() => deletingId = kw.id}
-                      class="text-gray-400 hover:text-red-500 transition-colors duration-150 cursor-pointer p-1"
+                      class="text-ink-subtle hover:text-red-500 transition-colors duration-150 cursor-pointer p-1"
                       title={$_('seo.deleteKeyword')}
                     >
                       <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -768,20 +768,20 @@
       </div>
 
       <!-- Summary footer -->
-      <div class="px-5 py-3 border-t border-gray-100 bg-gray-50/30 flex items-center justify-between">
-        <span class="text-xs text-gray-500">
+      <div class="px-5 py-3 border-t border-border bg-surface-2/30 flex items-center justify-between">
+        <span class="text-xs text-ink-muted">
           {$_('seo.totalKeywords', { values: { count: keywords.length } })}
         </span>
         <div class="flex items-center gap-4">
           {#if lastSyncedAt}
-            <span class="text-xs text-gray-400 flex items-center gap-1">
+            <span class="text-xs text-ink-subtle flex items-center gap-1">
               <svg class="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <path stroke-linecap="round" stroke-linejoin="round" d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0l3.181 3.183a8.25 8.25 0 0013.803-3.7M4.031 9.865a8.25 8.25 0 0113.803-3.7l3.181 3.182" />
               </svg>
               {$_('seo.lastSyncedAt', { values: { when: lastSyncedAt } })}
             </span>
           {/if}
-          <span class="text-xs text-gray-400">
+          <span class="text-xs text-ink-subtle">
             {$_('seo.avgDifficulty', { values: { avg: keywords.filter(k => k.difficulty != null).length > 0 ? Math.round(keywords.filter(k => k.difficulty != null).reduce((sum, k) => sum + k.difficulty, 0) / keywords.filter(k => k.difficulty != null).length) : 0 } })}
           </span>
         </div>
@@ -829,102 +829,102 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
-        <div class="w-8 h-8 bg-primary-50 rounded-lg flex items-center justify-center flex-shrink-0">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
+        <div class="w-8 h-8 bg-brand-subtle/10 rounded-lg flex items-center justify-center flex-shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900">{$_('seo.addKeyword')}</h2>
+        <h2 class="text-lg font-semibold text-ink">{$_('seo.addKeyword')}</h2>
       </div>
       <div class="p-6 space-y-4">
         <!-- Keyword -->
         <div>
-          <label for="seo-keyword" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('seo.keyword')}</label>
+          <label for="seo-keyword" class="block text-sm font-medium text-ink mb-1.5">{$_('seo.keyword')}</label>
           <input
             id="seo-keyword"
             type="text"
             bind:value={form.keyword}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             placeholder={$_('seo.keywordPlaceholder')}
           />
         </div>
 
         <!-- Target URL -->
         <div>
-          <label for="seo-url" class="block text-sm font-medium text-gray-700 mb-1.5">
+          <label for="seo-url" class="block text-sm font-medium text-ink mb-1.5">
             {$_('seo.targetUrl')}
-            <span class="font-normal text-gray-400 text-xs ml-1">— {$_('common.optional')}</span>
+            <span class="font-normal text-ink-subtle text-xs ml-1">— {$_('common.optional')}</span>
           </label>
           <input
             id="seo-url"
             type="text"
             bind:value={form.url}
             class="w-full px-3 py-2 border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent
-              {urlError ? 'border-red-400 focus:ring-red-400' : 'border-gray-300'}"
+              {urlError ? 'border-red-400 focus:ring-red-400' : 'border-border'}"
             placeholder={projectWebsite || 'https://your-page.com/path'}
           />
           {#if urlError}
             <p class="mt-1 text-xs text-red-500">Must start with https:// or http://</p>
           {:else if projectWebsite && form.url === projectWebsite}
-            <p class="mt-1 text-xs text-gray-400">Defaulted to your project website. Change only if you want to rank a specific page for this keyword.</p>
+            <p class="mt-1 text-xs text-ink-subtle">Defaulted to your project website. Change only if you want to rank a specific page for this keyword.</p>
           {:else}
-            <p class="mt-1 text-xs text-gray-400">{$_('seo.targetUrlHelper')}</p>
+            <p class="mt-1 text-xs text-ink-subtle">{$_('seo.targetUrlHelper')}</p>
           {/if}
         </div>
 
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <!-- Target Rank -->
           <div>
-            <label for="seo-target" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('seo.targetRank')}</label>
+            <label for="seo-target" class="block text-sm font-medium text-ink mb-1.5">{$_('seo.targetRank')}</label>
             <input
               id="seo-target"
               type="number"
               min="1"
               max="100"
               bind:value={form.targetRank}
-              class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             />
           </div>
 
           <!-- Intent -->
           <div>
-            <label for="seo-intent" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('seo.intent')}</label>
+            <label for="seo-intent" class="block text-sm font-medium text-ink mb-1.5">{$_('seo.intent')}</label>
             <select
               id="seo-intent"
               bind:value={form.intent}
-              class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             >
               <option value="INFORMATIONAL">{$_('seo.intentInformational')}</option>
               <option value="NAVIGATIONAL">{$_('seo.intentNavigational')}</option>
               <option value="COMMERCIAL">{$_('seo.intentCommercial')}</option>
               <option value="TRANSACTIONAL">{$_('seo.intentTransactional')}</option>
             </select>
-            <p class="mt-1 text-xs text-gray-400">{$_('seo.intentHelper')}</p>
+            <p class="mt-1 text-xs text-ink-subtle">{$_('seo.intentHelper')}</p>
           </div>
         </div>
 
         <!-- Search Locale -->
         <div>
-          <label for="seo-locale" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('seo.locale')}</label>
+          <label for="seo-locale" class="block text-sm font-medium text-ink mb-1.5">{$_('seo.locale')}</label>
           <select
             id="seo-locale"
             bind:value={form.searchLocale}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
           >
             <option value="pl-PL">Polski (pl-PL)</option>
             <option value="en-US">English (en-US)</option>
             <option value="ru-RU">Русский (ru-RU)</option>
           </select>
-          <p class="mt-1 text-xs text-gray-400">{$_('seo.localeHelper')}</p>
+          <p class="mt-1 text-xs text-ink-subtle">{$_('seo.localeHelper')}</p>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={addKeyword}
           disabled={adding || !form.keyword.trim() || urlError}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
         >
           {#if adding}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -939,7 +939,7 @@
             {$_('seo.addKeyword')}
           {/if}
         </button>
-        <button on:click={() => showModal = false} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={() => showModal = false} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>
@@ -952,15 +952,15 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => deletingId = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm">
       <div class="p-6">
         <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-4">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900 mb-2">{$_('seo.deleteKeyword')}</h2>
-        <p class="text-sm text-gray-500 mb-6">{$_('seo.confirmDelete')}</p>
+        <h2 class="text-lg font-semibold text-ink mb-2">{$_('seo.deleteKeyword')}</h2>
+        <p class="text-sm text-ink-muted mb-6">{$_('seo.confirmDelete')}</p>
         <div class="flex gap-3">
           <button
             on:click={() => deletingId && deleteKeyword(deletingId)}
@@ -968,7 +968,7 @@
           >
             {$_('common.delete')}
           </button>
-          <button on:click={() => deletingId = null} class="flex-1 px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+          <button on:click={() => deletingId = null} class="flex-1 px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
             {$_('common.cancel')}
           </button>
         </div>
@@ -986,24 +986,24 @@
     on:click|self={closeRecordModal}
     on:keydown={handleRecordModalKeydown}
   >
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
-        <div class="w-8 h-8 bg-primary-50 rounded-lg flex items-center justify-center flex-shrink-0">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
+        <div class="w-8 h-8 bg-brand-subtle/10 rounded-lg flex items-center justify-center flex-shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487zm0 0L19.5 7.125" />
           </svg>
         </div>
         <div class="min-w-0 flex-1">
-          <h2 class="text-lg font-semibold text-gray-900">{$_('seo.recordPosition.title')}</h2>
-          <p class="text-xs text-gray-500 truncate">{recordModalKeyword.keyword}</p>
+          <h2 class="text-lg font-semibold text-ink">{$_('seo.recordPosition.title')}</h2>
+          <p class="text-xs text-ink-muted truncate">{recordModalKeyword.keyword}</p>
         </div>
       </div>
       <div class="p-6 space-y-4">
-        <p class="text-sm text-gray-500">{$_('seo.recordPosition.description')}</p>
+        <p class="text-sm text-ink-muted">{$_('seo.recordPosition.description')}</p>
 
         <!-- Current rank -->
         <div>
-          <label for="record-rank" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('seo.recordPosition.rank')}</label>
+          <label for="record-rank" class="block text-sm font-medium text-ink mb-1.5">{$_('seo.recordPosition.rank')}</label>
           <input
             id="record-rank"
             type="number"
@@ -1011,37 +1011,37 @@
             max="100"
             bind:value={recordRank}
             disabled={recordNotInTop100}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent disabled:bg-gray-50 disabled:text-gray-400"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent disabled:bg-gray-50 disabled:text-gray-400"
             placeholder={$_('seo.recordPosition.rankPlaceholder')}
           />
           <label class="flex items-center gap-2 mt-2 cursor-pointer select-none">
             <input
               type="checkbox"
               bind:checked={recordNotInTop100}
-              class="w-4 h-4 text-primary-600 rounded border-gray-300 cursor-pointer"
+              class="w-4 h-4 text-brand rounded border-border cursor-pointer"
             />
-            <span class="text-sm text-gray-600">{$_('seo.recordPosition.notInTop100')}</span>
+            <span class="text-sm text-ink-muted">{$_('seo.recordPosition.notInTop100')}</span>
           </label>
         </div>
 
         <!-- Matched URL -->
         <div>
-          <label for="record-url" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('seo.recordPosition.url')}</label>
+          <label for="record-url" class="block text-sm font-medium text-ink mb-1.5">{$_('seo.recordPosition.url')}</label>
           <input
             id="record-url"
             type="text"
             bind:value={recordUrl}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             placeholder="https://example.com/page"
           />
-          <p class="mt-1 text-xs text-gray-400">{$_('seo.recordPosition.urlHelper')}</p>
+          <p class="mt-1 text-xs text-ink-subtle">{$_('seo.recordPosition.urlHelper')}</p>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={saveRecordPosition}
           disabled={recordSaving || (!recordNotInTop100 && (!recordRank || Number(recordRank) < 1 || Number(recordRank) > 100))}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
         >
           {#if recordSaving}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -1053,7 +1053,7 @@
             {$_('seo.recordPosition.save')}
           {/if}
         </button>
-        <button on:click={closeRecordModal} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={closeRecordModal} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>

--- a/apps/web/src/routes/(app)/projects/[id]/seo/keywords/[keywordId]/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/seo/keywords/[keywordId]/+page.svelte
@@ -309,7 +309,7 @@
 
   const intentBadge: Record<string, string> = {
     INFORMATIONAL: 'bg-blue-100 text-blue-700',
-    NAVIGATIONAL: 'bg-gray-100 text-gray-700',
+    NAVIGATIONAL: 'bg-surface-2 text-ink',
     COMMERCIAL: 'bg-amber-100 text-amber-700',
     TRANSACTIONAL: 'bg-green-100 text-green-700',
   };
@@ -343,7 +343,7 @@
   <!-- Back link -->
   <a
     href="/projects/{projectId}/seo"
-    class="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 mb-5 transition-colors"
+    class="inline-flex items-center gap-1.5 text-sm text-ink-muted hover:text-gray-700 mb-5 transition-colors"
   >
     <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
       <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
@@ -355,34 +355,34 @@
     <!-- Skeleton -->
     <div class="animate-pulse space-y-4">
       <div class="h-8 bg-gray-200 rounded w-1/3"></div>
-      <div class="h-4 bg-gray-100 rounded w-1/4"></div>
-      <div class="h-72 bg-gray-100 rounded-xl mt-6"></div>
+      <div class="h-4 bg-surface-2 rounded w-1/4"></div>
+      <div class="h-72 bg-surface-2 rounded-xl mt-6"></div>
     </div>
 
   {:else if keyword}
     <!-- Header block -->
     <div class="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4 mb-6">
       <div class="min-w-0 flex-1">
-        <h1 class="text-2xl font-bold text-gray-900 break-words">{keyword.keyword}</h1>
+        <h1 class="text-2xl font-bold text-ink break-words">{keyword.keyword}</h1>
 
         <!-- Badges row -->
         <div class="flex flex-wrap items-center gap-2 mt-2">
           {#if keyword.locale}
-            <span class="text-xs px-2 py-0.5 rounded-full bg-gray-100 text-gray-600 font-mono">{keyword.locale}</span>
+            <span class="text-xs px-2 py-0.5 rounded-full bg-surface-2 text-ink-muted font-mono">{keyword.locale}</span>
           {/if}
           {#if keyword.intent}
-            <span class="text-xs px-2 py-0.5 rounded-full font-medium {intentBadge[keyword.intent] || 'bg-gray-100 text-gray-600'}">
+            <span class="text-xs px-2 py-0.5 rounded-full font-medium {intentBadge[keyword.intent] || 'bg-surface-2 text-ink-muted'}">
               {$_(intentLabel[keyword.intent] || 'seo.intentInformational')}
             </span>
           {/if}
           {#if keyword.currentRank != null}
             <span class="text-xs px-2 py-0.5 rounded-full font-medium
-              {keyword.currentRank <= 10 ? 'bg-green-100 text-green-700' : keyword.currentRank <= 30 ? 'bg-amber-100 text-amber-700' : 'bg-gray-100 text-gray-600'}">
+              {keyword.currentRank <= 10 ? 'bg-green-100 text-green-700' : keyword.currentRank <= 30 ? 'bg-amber-100 text-amber-700' : 'bg-surface-2 text-ink-muted'}">
               #{keyword.currentRank}
             </span>
           {/if}
           {#if keyword.lastCheckedAt}
-            <span class="text-xs text-gray-400">
+            <span class="text-xs text-ink-subtle">
               {$_('seo.history.lastCheckedAt', { values: { when: formatRelative(keyword.lastCheckedAt) } })}
             </span>
           {/if}
@@ -394,7 +394,7 @@
             href={keyword.url}
             target="_blank"
             rel="noopener noreferrer"
-            class="inline-flex items-center gap-1 mt-2 text-sm text-primary-600 hover:text-primary-700 hover:underline break-all"
+            class="inline-flex items-center gap-1 mt-2 text-sm text-brand hover:text-primary-700 hover:underline break-all"
           >
             {keyword.url}
             <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -409,7 +409,7 @@
         <!-- Record position -->
         <button
           on:click={openRecordModal}
-          class="flex items-center gap-2 px-3 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 transition-colors cursor-pointer"
+          class="flex items-center gap-2 px-3 py-2 text-sm font-medium text-white bg-brand rounded-lg hover:brightness-110 transition-colors cursor-pointer"
         >
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487zm0 0L19.5 7.125" />
@@ -420,7 +420,7 @@
         <!-- Edit -->
         <button
           on:click={() => { editForm = { targetRank: keyword.targetRank ?? null, url: keyword.url ?? '', intent: keyword.intent ?? 'INFORMATIONAL' }; showEditModal = true; }}
-          class="flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-gray-700 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors cursor-pointer"
+          class="flex items-center gap-1.5 px-3 py-2 text-sm font-medium text-ink border border-border rounded-lg hover:bg-surface-2 transition-colors cursor-pointer"
         >
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125" />
@@ -442,9 +442,9 @@
     </div>
 
     <!-- Rank History section -->
-    <div class="bg-white rounded-xl border border-gray-200 p-5 mb-6">
+    <div class="bg-surface rounded-xl border border-border p-5 mb-6">
       <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 mb-4">
-        <h2 class="text-base font-semibold text-gray-800">{$_('seo.history.title')}</h2>
+        <h2 class="text-base font-semibold text-ink">{$_('seo.history.title')}</h2>
 
         <!-- Range tabs -->
         <div class="flex items-center gap-1 flex-wrap">
@@ -453,8 +453,8 @@
               on:click={() => selectedRange = r}
               class="px-3 py-1 text-xs font-medium rounded-full transition-colors cursor-pointer
                 {selectedRange === r
-                  ? 'bg-primary-600 text-white'
-                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}"
+                  ? 'bg-brand text-white'
+                  : 'bg-surface-2 text-ink-muted hover:bg-gray-200'}"
             >
               {#if r === '7d'}{$_('seo.history.range7d')}
               {:else if r === '30d'}{$_('seo.history.range30d')}
@@ -469,20 +469,20 @@
       <!-- Custom date pickers -->
       {#if selectedRange === 'custom'}
         <div class="flex items-center gap-3 mb-4 flex-wrap">
-          <label class="flex items-center gap-2 text-sm text-gray-600">
+          <label class="flex items-center gap-2 text-sm text-ink-muted">
             {$_('seo.history.customFrom')}
             <input
               type="date"
               bind:value={customFrom}
-              class="px-2 py-1 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+              class="px-2 py-1 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
             />
           </label>
-          <label class="flex items-center gap-2 text-sm text-gray-600">
+          <label class="flex items-center gap-2 text-sm text-ink-muted">
             {$_('seo.history.customTo')}
             <input
               type="date"
               bind:value={customTo}
-              class="px-2 py-1 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+              class="px-2 py-1 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
             />
           </label>
         </div>
@@ -491,15 +491,15 @@
       <!-- Chart -->
       {#if filteredHistory.length === 0}
         <div class="flex flex-col items-center justify-center py-16 text-center">
-          <div class="w-14 h-14 bg-gray-50 rounded-2xl flex items-center justify-center mb-4">
-            <svg xmlns="http://www.w3.org/2000/svg" class="w-7 h-7 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+          <div class="w-14 h-14 bg-surface-2 rounded-2xl flex items-center justify-center mb-4">
+            <svg xmlns="http://www.w3.org/2000/svg" class="w-7 h-7 text-ink-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
               <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
             </svg>
           </div>
-          <p class="text-sm text-gray-500 max-w-xs">{$_('seo.history.empty')}</p>
+          <p class="text-sm text-ink-muted max-w-xs">{$_('seo.history.empty')}</p>
           <button
             on:click={openRecordModal}
-            class="mt-4 flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary-600 rounded-lg hover:bg-primary-700 transition-colors cursor-pointer"
+            class="mt-4 flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-brand rounded-lg hover:brightness-110 transition-colors cursor-pointer"
           >
             {$_('seo.recordPosition.title')}
           </button>
@@ -513,30 +513,30 @@
 
     <!-- Recent history table -->
     {#if filteredHistory.length > 0}
-      <div class="bg-white rounded-xl border border-gray-200 overflow-hidden">
-        <div class="px-5 py-3 border-b border-gray-100">
-          <h3 class="text-sm font-semibold text-gray-700">{$_('seo.history.title')}</h3>
+      <div class="bg-surface rounded-xl border border-border overflow-hidden">
+        <div class="px-5 py-3 border-b border-border">
+          <h3 class="text-sm font-semibold text-ink">{$_('seo.history.title')}</h3>
         </div>
         <div class="overflow-x-auto">
           <table class="w-full text-sm">
             <thead>
-              <tr class="border-b border-gray-100 bg-gray-50/50">
-                <th class="text-left text-xs font-medium text-gray-500 uppercase tracking-wider px-5 py-3">{$_('seo.history.tableHeaderDate')}</th>
-                <th class="text-right text-xs font-medium text-gray-500 uppercase tracking-wider px-5 py-3">{$_('seo.history.tableHeaderRank')}</th>
-                <th class="text-left text-xs font-medium text-gray-500 uppercase tracking-wider px-5 py-3">{$_('seo.history.tableHeaderUrl')}</th>
+              <tr class="border-b border-border bg-surface-2/50">
+                <th class="text-left text-xs font-medium text-ink-muted uppercase tracking-wider px-5 py-3">{$_('seo.history.tableHeaderDate')}</th>
+                <th class="text-right text-xs font-medium text-ink-muted uppercase tracking-wider px-5 py-3">{$_('seo.history.tableHeaderRank')}</th>
+                <th class="text-left text-xs font-medium text-ink-muted uppercase tracking-wider px-5 py-3">{$_('seo.history.tableHeaderUrl')}</th>
               </tr>
             </thead>
             <tbody class="divide-y divide-gray-50">
               {#each [...filteredHistory].reverse().slice(0, 30) as entry}
-                <tr class="hover:bg-gray-50/50 transition-colors duration-100">
-                  <td class="px-5 py-3 text-gray-600">{formatDate(entry.date)}</td>
+                <tr class="hover:bg-surface-2/50 transition-colors duration-100">
+                  <td class="px-5 py-3 text-ink-muted">{formatDate(entry.date)}</td>
                   <td class="px-5 py-3 text-right">
                     {#if entry.rank != null}
-                      <span class="font-medium {entry.rank <= 10 ? 'text-green-600' : entry.rank <= 30 ? 'text-amber-600' : 'text-gray-700'}">
+                      <span class="font-medium {entry.rank <= 10 ? 'text-green-600' : entry.rank <= 30 ? 'text-amber-600' : 'text-ink'}">
                         #{entry.rank}
                       </span>
                     {:else}
-                      <span class="text-gray-400 italic">{$_('seo.history.notRanked')}</span>
+                      <span class="text-ink-subtle italic">{$_('seo.history.notRanked')}</span>
                     {/if}
                   </td>
                   <td class="px-5 py-3 max-w-[280px]">
@@ -545,13 +545,13 @@
                         href={entry.url}
                         target="_blank"
                         rel="noopener noreferrer"
-                        class="text-primary-600 hover:text-primary-700 hover:underline truncate block"
+                        class="text-brand hover:text-primary-700 hover:underline truncate block"
                         title={entry.url}
                       >
                         {entry.url}
                       </a>
                     {:else}
-                      <span class="text-gray-400">—</span>
+                      <span class="text-ink-subtle">—</span>
                     {/if}
                   </td>
                 </tr>
@@ -603,41 +603,41 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showEditModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100">
-        <h2 class="text-lg font-semibold text-gray-900">{$_('common.edit')} — {keyword?.keyword}</h2>
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border">
+        <h2 class="text-lg font-semibold text-ink">{$_('common.edit')} — {keyword?.keyword}</h2>
       </div>
       <div class="p-6 space-y-4">
         <!-- Target URL -->
         <div>
-          <label for="edit-url" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('seo.targetUrl')}</label>
+          <label for="edit-url" class="block text-sm font-medium text-ink mb-1.5">{$_('seo.targetUrl')}</label>
           <input
             id="edit-url"
             type="text"
             bind:value={editForm.url}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
             placeholder="https://your-page.com/path"
           />
         </div>
         <!-- Target Rank -->
         <div>
-          <label for="edit-target" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('seo.targetRank')}</label>
+          <label for="edit-target" class="block text-sm font-medium text-ink mb-1.5">{$_('seo.targetRank')}</label>
           <input
             id="edit-target"
             type="number"
             min="1"
             max="100"
             bind:value={editForm.targetRank}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
           />
         </div>
         <!-- Intent -->
         <div>
-          <label for="edit-intent" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('seo.intent')}</label>
+          <label for="edit-intent" class="block text-sm font-medium text-ink mb-1.5">{$_('seo.intent')}</label>
           <select
             id="edit-intent"
             bind:value={editForm.intent}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
           >
             <option value="INFORMATIONAL">{$_('seo.intentInformational')}</option>
             <option value="NAVIGATIONAL">{$_('seo.intentNavigational')}</option>
@@ -646,11 +646,11 @@
           </select>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={saveKeyword}
           disabled={saving}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer transition-colors"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer transition-colors"
         >
           {#if saving}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -660,7 +660,7 @@
           {/if}
           {$_('common.save')}
         </button>
-        <button on:click={() => showEditModal = false} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm cursor-pointer transition-colors">
+        <button on:click={() => showEditModal = false} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 text-sm cursor-pointer transition-colors">
           {$_('common.cancel')}
         </button>
       </div>
@@ -673,15 +673,15 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showDeleteModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm">
       <div class="p-6">
         <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-4">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900 mb-2">{$_('seo.deleteKeyword')}</h2>
-        <p class="text-sm text-gray-500 mb-6">{$_('seo.confirmDelete')}</p>
+        <h2 class="text-lg font-semibold text-ink mb-2">{$_('seo.deleteKeyword')}</h2>
+        <p class="text-sm text-ink-muted mb-6">{$_('seo.confirmDelete')}</p>
         <div class="flex gap-3">
           <button
             on:click={deleteKeyword}
@@ -690,7 +690,7 @@
           >
             {$_('common.delete')}
           </button>
-          <button on:click={() => showDeleteModal = false} class="flex-1 px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 text-sm cursor-pointer transition-colors">
+          <button on:click={() => showDeleteModal = false} class="flex-1 px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 text-sm cursor-pointer transition-colors">
             {$_('common.cancel')}
           </button>
         </div>
@@ -708,26 +708,26 @@
     on:click|self={closeRecordModal}
     on:keydown={(e) => e.key === 'Escape' && closeRecordModal()}
   >
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
-        <div class="w-8 h-8 bg-primary-50 rounded-lg flex items-center justify-center flex-shrink-0">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
+        <div class="w-8 h-8 bg-brand-subtle/10 rounded-lg flex items-center justify-center flex-shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M16.862 4.487l1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L6.832 19.82a4.5 4.5 0 0 1-1.897 1.13l-2.685.8.8-2.685a4.5 4.5 0 0 1 1.13-1.897L16.863 4.487zm0 0L19.5 7.125" />
           </svg>
         </div>
         <div class="min-w-0 flex-1">
-          <h2 class="text-lg font-semibold text-gray-900">{$_('seo.recordPosition.title')}</h2>
+          <h2 class="text-lg font-semibold text-ink">{$_('seo.recordPosition.title')}</h2>
           {#if keyword}
-            <p class="text-xs text-gray-500 truncate">{keyword.keyword}</p>
+            <p class="text-xs text-ink-muted truncate">{keyword.keyword}</p>
           {/if}
         </div>
       </div>
       <div class="p-6 space-y-4">
-        <p class="text-sm text-gray-500">{$_('seo.recordPosition.description')}</p>
+        <p class="text-sm text-ink-muted">{$_('seo.recordPosition.description')}</p>
 
         <!-- Current rank -->
         <div>
-          <label for="detail-record-rank" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('seo.recordPosition.rank')}</label>
+          <label for="detail-record-rank" class="block text-sm font-medium text-ink mb-1.5">{$_('seo.recordPosition.rank')}</label>
           <input
             id="detail-record-rank"
             type="number"
@@ -735,37 +735,37 @@
             max="100"
             bind:value={recordRank}
             disabled={recordNotInTop100}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent disabled:bg-gray-50 disabled:text-gray-400"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent disabled:bg-gray-50 disabled:text-gray-400"
             placeholder={$_('seo.recordPosition.rankPlaceholder')}
           />
           <label class="flex items-center gap-2 mt-2 cursor-pointer select-none">
             <input
               type="checkbox"
               bind:checked={recordNotInTop100}
-              class="w-4 h-4 text-primary-600 rounded border-gray-300 cursor-pointer"
+              class="w-4 h-4 text-brand rounded border-border cursor-pointer"
             />
-            <span class="text-sm text-gray-600">{$_('seo.recordPosition.notInTop100')}</span>
+            <span class="text-sm text-ink-muted">{$_('seo.recordPosition.notInTop100')}</span>
           </label>
         </div>
 
         <!-- Matched URL -->
         <div>
-          <label for="detail-record-url" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('seo.recordPosition.url')}</label>
+          <label for="detail-record-url" class="block text-sm font-medium text-ink mb-1.5">{$_('seo.recordPosition.url')}</label>
           <input
             id="detail-record-url"
             type="text"
             bind:value={recordUrl}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             placeholder="https://example.com/page"
           />
-          <p class="mt-1 text-xs text-gray-400">{$_('seo.recordPosition.urlHelper')}</p>
+          <p class="mt-1 text-xs text-ink-subtle">{$_('seo.recordPosition.urlHelper')}</p>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={saveRecordPosition}
           disabled={recordSaving || (!recordNotInTop100 && (!recordRank || Number(recordRank) < 1 || Number(recordRank) > 100))}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
         >
           {#if recordSaving}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -777,7 +777,7 @@
             {$_('seo.recordPosition.save')}
           {/if}
         </button>
-        <button on:click={closeRecordModal} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={closeRecordModal} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>

--- a/apps/web/src/routes/(app)/projects/[id]/sequences/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/sequences/+page.svelte
@@ -75,7 +75,7 @@
 
   // ── Badge maps ─────────────────────────────────────────────────────────
   const statusBadge: Record<string, string> = {
-    DRAFT: 'bg-gray-100 text-gray-600',
+    DRAFT: 'bg-surface-2 text-ink-muted',
     ACTIVE: 'bg-green-100 text-green-700',
     PAUSED: 'bg-yellow-100 text-yellow-700',
     COMPLETED: 'bg-blue-100 text-blue-700',
@@ -90,7 +90,7 @@
 
   const triggerBadge: Record<string, string> = {
     SIGNUP: 'bg-green-100 text-green-700',
-    MANUAL: 'bg-gray-100 text-gray-600',
+    MANUAL: 'bg-surface-2 text-ink-muted',
     EVENT: 'bg-purple-100 text-purple-700',
     DATE: 'bg-blue-100 text-blue-700',
   };
@@ -280,10 +280,10 @@
   <SectionHint sectionKey="sequences" titleKey="hints.sequences.title" descKey="hints.sequences.desc" />
   <!-- Header -->
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-gray-900">{$_('sequences.title')}</h1>
+    <h1 class="text-2xl font-bold text-ink">{$_('sequences.title')}</h1>
     <button
       on:click={() => showCreateModal = true}
-      class="bg-primary-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+      class="bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
     >
       <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -296,23 +296,23 @@
   {#if loading}
     <div class="space-y-3">
       {#each Array(3) as _}
-        <div class="bg-white rounded-xl border border-gray-200 p-5 animate-pulse h-28"></div>
+        <div class="bg-surface rounded-xl border border-border p-5 animate-pulse h-28"></div>
       {/each}
     </div>
 
   <!-- Empty state -->
   {:else if sequences.length === 0}
     <div class="flex flex-col items-center justify-center py-20 text-center">
-      <div class="w-20 h-20 bg-primary-50 rounded-2xl flex items-center justify-center mb-6">
+      <div class="w-20 h-20 bg-brand-subtle/10 rounded-2xl flex items-center justify-center mb-6">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 text-primary-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 0 1-2.25 2.25h-15a2.25 2.25 0 0 1-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0 0 19.5 4.5h-15a2.25 2.25 0 0 0-2.25 2.25m19.5 0v.243a2.25 2.25 0 0 1-1.07 1.916l-7.5 4.615a2.25 2.25 0 0 1-2.36 0L3.32 8.91a2.25 2.25 0 0 1-1.07-1.916V6.75" />
         </svg>
       </div>
-      <h2 class="text-xl font-semibold text-gray-900 mb-2">{$_('sequences.empty')}</h2>
-      <p class="text-gray-500 mb-6 max-w-sm">{$_('sequences.emptyDesc')}</p>
+      <h2 class="text-xl font-semibold text-ink mb-2">{$_('sequences.empty')}</h2>
+      <p class="text-ink-muted mb-6 max-w-sm">{$_('sequences.emptyDesc')}</p>
       <button
         on:click={() => showCreateModal = true}
-        class="bg-primary-600 text-white px-6 py-3 rounded-xl font-medium hover:bg-primary-700 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
+        class="bg-brand text-white px-6 py-3 rounded-xl font-medium hover:brightness-110 transition-colors duration-150 flex items-center gap-2 cursor-pointer"
       >
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
@@ -327,20 +327,20 @@
       {#each sequences as sequence (sequence.id)}
         {@const steps = (sequence.steps || []).sort((a, b) => a.order - b.order)}
         {@const enrollments = sequence._count?.enrollments ?? 0}
-        <div class="bg-white rounded-xl border border-gray-200 border-l-4 {statusBorderAccent[sequence.status] || 'border-l-gray-300'} transition-shadow duration-150 hover:shadow-sm">
+        <div class="bg-surface rounded-xl border border-border border-l-4 {statusBorderAccent[sequence.status] || 'border-l-gray-300'} transition-shadow duration-150 hover:shadow-sm">
           <!-- Card header -->
           <div class="p-5">
             <div class="flex items-start justify-between gap-4">
               <div class="flex-1 min-w-0">
                 <!-- Badges row -->
                 <div class="flex flex-wrap items-center gap-1.5 mb-2">
-                  <span class="text-xs px-2 py-0.5 rounded font-medium {triggerBadge[sequence.triggerType] || 'bg-gray-100 text-gray-600'}">
+                  <span class="text-xs px-2 py-0.5 rounded font-medium {triggerBadge[sequence.triggerType] || 'bg-surface-2 text-ink-muted'}">
                     {$_(`sequences.trigger_${sequence.triggerType.toLowerCase()}`)}
                   </span>
-                  <span class="text-xs px-2 py-0.5 rounded {statusBadge[sequence.status] || 'bg-gray-100 text-gray-600'}">
+                  <span class="text-xs px-2 py-0.5 rounded {statusBadge[sequence.status] || 'bg-surface-2 text-ink-muted'}">
                     {$_(`sequences.status_${sequence.status.toLowerCase()}`)}
                   </span>
-                  <span class="text-xs px-2 py-0.5 bg-gray-50 text-gray-500 rounded">
+                  <span class="text-xs px-2 py-0.5 bg-surface-2 text-ink-muted rounded">
                     {$_('sequences.stepCount', { values: { count: steps.length } })}
                   </span>
                   {#if enrollments > 0}
@@ -351,13 +351,13 @@
                 </div>
 
                 <!-- Name & description -->
-                <h3 class="font-medium text-gray-900 truncate">{sequence.name}</h3>
+                <h3 class="font-medium text-ink truncate">{sequence.name}</h3>
                 {#if sequence.description}
-                  <p class="text-sm text-gray-500 mt-1 line-clamp-1">{sequence.description}</p>
+                  <p class="text-sm text-ink-muted mt-1 line-clamp-1">{sequence.description}</p>
                 {/if}
 
                 <!-- Meta row -->
-                <div class="flex flex-wrap items-center gap-3 mt-1.5 text-xs text-gray-400">
+                <div class="flex flex-wrap items-center gap-3 mt-1.5 text-xs text-ink-subtle">
                   <span>{formatDate(sequence.createdAt)}</span>
                 </div>
               </div>
@@ -386,7 +386,7 @@
                 <!-- Add step -->
                 <button
                   on:click={() => openAddStep(sequence.id)}
-                  class="text-xs px-3 py-1.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
+                  class="text-xs px-3 py-1.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
                   title={$_('sequences.addStep')}
                 >
                   {$_('sequences.addStep')}
@@ -395,10 +395,10 @@
                 <!-- Expand / Collapse -->
                 <button
                   on:click={() => toggleExpand(sequence.id)}
-                  class="text-xs px-2 py-1.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
+                  class="text-xs px-2 py-1.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
                   title={expandedIds.has(sequence.id) ? $_('sequences.collapse') : $_('sequences.expand')}
                 >
-                  <svg class="w-4 h-4 text-gray-500 transition-transform duration-200 {expandedIds.has(sequence.id) ? 'rotate-180' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                  <svg class="w-4 h-4 text-ink-muted transition-transform duration-200 {expandedIds.has(sequence.id) ? 'rotate-180' : ''}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                     <path stroke-linecap="round" stroke-linejoin="round" d="M19.5 8.25l-7.5 7.5-7.5-7.5" />
                   </svg>
                 </button>
@@ -419,13 +419,13 @@
 
           <!-- Expanded steps timeline -->
           {#if expandedIds.has(sequence.id)}
-            <div transition:slide={{ duration: 200 }} class="border-t border-gray-100 px-5 pb-5 pt-4">
+            <div transition:slide={{ duration: 200 }} class="border-t border-border px-5 pb-5 pt-4">
               {#if steps.length === 0}
                 <div class="text-center py-6">
-                  <p class="text-sm text-gray-400 mb-3">{$_('sequences.noSteps')}</p>
+                  <p class="text-sm text-ink-subtle mb-3">{$_('sequences.noSteps')}</p>
                   <button
                     on:click={() => openAddStep(sequence.id)}
-                    class="text-sm text-primary-600 font-medium hover:text-primary-700 transition-colors cursor-pointer"
+                    class="text-sm text-brand font-medium hover:text-primary-700 transition-colors cursor-pointer"
                   >
                     + {$_('sequences.addStep')}
                   </button>
@@ -436,7 +436,7 @@
                     <div class="flex gap-3">
                       <!-- Timeline connector -->
                       <div class="flex flex-col items-center flex-shrink-0">
-                        <div class="w-8 h-8 rounded-full bg-primary-100 text-primary-700 flex items-center justify-center text-xs font-bold">
+                        <div class="w-8 h-8 rounded-full bg-primary-100 text-brand flex items-center justify-center text-xs font-bold">
                           {step.order || i + 1}
                         </div>
                         {#if i < steps.length - 1}
@@ -448,16 +448,16 @@
                       <div class="flex-1 min-w-0 pb-4">
                         <div class="flex items-start justify-between gap-2">
                           <div class="min-w-0 flex-1">
-                            <h4 class="text-sm font-medium text-gray-900 truncate">{step.subject}</h4>
+                            <h4 class="text-sm font-medium text-ink truncate">{step.subject}</h4>
                             {#if step.previewText}
-                              <p class="text-xs text-gray-400 mt-0.5 truncate">{step.previewText}</p>
+                              <p class="text-xs text-ink-subtle mt-0.5 truncate">{step.previewText}</p>
                             {/if}
                             <!-- Delay badge -->
                             <div class="flex items-center gap-1.5 mt-1.5">
-                              <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+                              <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 text-ink-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
                                 <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" />
                               </svg>
-                              <span class="text-xs text-gray-500">
+                              <span class="text-xs text-ink-muted">
                                 {$_('sequences.delayLabel')}: {formatDelay(step.delayDays, step.delayHours)}
                               </span>
                             </div>
@@ -468,7 +468,7 @@
                             <button
                               on:click={() => moveStep(sequence.id, step.id, 'up')}
                               disabled={i === 0}
-                              class="p-1 rounded text-gray-400 hover:text-gray-600 hover:bg-gray-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors cursor-pointer"
+                              class="p-1 rounded text-ink-subtle hover:text-gray-600 hover:bg-surface-2 disabled:opacity-30 disabled:cursor-not-allowed transition-colors cursor-pointer"
                               title={$_('sequences.moveUp')}
                             >
                               <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -478,7 +478,7 @@
                             <button
                               on:click={() => moveStep(sequence.id, step.id, 'down')}
                               disabled={i === steps.length - 1}
-                              class="p-1 rounded text-gray-400 hover:text-gray-600 hover:bg-gray-100 disabled:opacity-30 disabled:cursor-not-allowed transition-colors cursor-pointer"
+                              class="p-1 rounded text-ink-subtle hover:text-gray-600 hover:bg-surface-2 disabled:opacity-30 disabled:cursor-not-allowed transition-colors cursor-pointer"
                               title={$_('sequences.moveDown')}
                             >
                               <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -487,7 +487,7 @@
                             </button>
                             <button
                               on:click={() => deleteStep(sequence.id, step.id)}
-                              class="p-1 rounded text-gray-400 hover:text-red-500 hover:bg-red-50 transition-colors cursor-pointer"
+                              class="p-1 rounded text-ink-subtle hover:text-red-500 hover:bg-red-50 transition-colors cursor-pointer"
                               title={$_('sequences.deleteStep')}
                             >
                               <svg class="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -514,45 +514,45 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showCreateModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
-        <div class="w-8 h-8 bg-primary-50 rounded-lg flex items-center justify-center flex-shrink-0">
-          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-primary-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
+        <div class="w-8 h-8 bg-brand-subtle/10 rounded-lg flex items-center justify-center flex-shrink-0">
+          <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-brand" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900">{$_('sequences.create')}</h2>
+        <h2 class="text-lg font-semibold text-ink">{$_('sequences.create')}</h2>
       </div>
       <div class="p-6 space-y-4">
         <div>
-          <label for="seq-name" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('sequences.name')} *</label>
+          <label for="seq-name" class="block text-sm font-medium text-ink mb-1.5">{$_('sequences.name')} *</label>
           <input
             id="seq-name"
             type="text"
             bind:value={createForm.name}
             placeholder={$_('sequences.namePlaceholder')}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
           />
         </div>
         <div>
-          <label for="seq-desc" class="block text-sm font-medium text-gray-700 mb-1.5">
+          <label for="seq-desc" class="block text-sm font-medium text-ink mb-1.5">
             {$_('common.description')}
-            <span class="text-gray-400 font-normal">({$_('common.optional')})</span>
+            <span class="text-ink-subtle font-normal">({$_('common.optional')})</span>
           </label>
           <textarea
             id="seq-desc"
             bind:value={createForm.description}
             rows="2"
             placeholder={$_('sequences.descriptionPlaceholder')}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-none"
           ></textarea>
         </div>
         <div>
-          <label for="seq-trigger" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('sequences.triggerType')}</label>
+          <label for="seq-trigger" class="block text-sm font-medium text-ink mb-1.5">{$_('sequences.triggerType')}</label>
           <select
             id="seq-trigger"
             bind:value={createForm.triggerType}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
           >
             {#each TRIGGER_TYPES as t}
               <option value={t}>{$_(`sequences.trigger_${t.toLowerCase()}`)}</option>
@@ -560,11 +560,11 @@
           </select>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={createSequence}
           disabled={creating || !createForm.name.trim()}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
         >
           {#if creating}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -578,7 +578,7 @@
         </button>
         <button
           on:click={() => showCreateModal = false}
-          class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer"
+          class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer"
         >
           {$_('common.cancel')}
         </button>
@@ -592,78 +592,78 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => addStepSequenceId = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-lg">
-      <div class="p-6 border-b border-gray-100 flex items-center gap-2.5">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-lg">
+      <div class="p-6 border-b border-border flex items-center gap-2.5">
         <div class="w-8 h-8 bg-indigo-50 rounded-lg flex items-center justify-center flex-shrink-0">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 4.5v15m7.5-7.5h-15" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900">{$_('sequences.addStep')}</h2>
+        <h2 class="text-lg font-semibold text-ink">{$_('sequences.addStep')}</h2>
       </div>
       <div class="p-6 space-y-4">
         <div>
-          <label for="step-subject" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('sequences.stepSubject')} *</label>
+          <label for="step-subject" class="block text-sm font-medium text-ink mb-1.5">{$_('sequences.stepSubject')} *</label>
           <input
             id="step-subject"
             type="text"
             bind:value={stepForm.subject}
             placeholder={$_('sequences.stepSubjectPlaceholder')}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
           />
         </div>
         <div>
-          <label for="step-preview" class="block text-sm font-medium text-gray-700 mb-1.5">
+          <label for="step-preview" class="block text-sm font-medium text-ink mb-1.5">
             {$_('sequences.stepPreviewText')}
-            <span class="text-gray-400 font-normal">({$_('common.optional')})</span>
+            <span class="text-ink-subtle font-normal">({$_('common.optional')})</span>
           </label>
           <input
             id="step-preview"
             type="text"
             bind:value={stepForm.previewText}
             placeholder={$_('sequences.stepPreviewPlaceholder')}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
           />
         </div>
         <div>
-          <label for="step-html" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('sequences.stepContent')} *</label>
+          <label for="step-html" class="block text-sm font-medium text-ink mb-1.5">{$_('sequences.stepContent')} *</label>
           <textarea
             id="step-html"
             bind:value={stepForm.html}
             rows="6"
             placeholder={$_('sequences.stepContentPlaceholder')}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-y"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent resize-y"
           ></textarea>
         </div>
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>
-            <label for="step-delay-days" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('sequences.delayDays')}</label>
+            <label for="step-delay-days" class="block text-sm font-medium text-ink mb-1.5">{$_('sequences.delayDays')}</label>
             <input
               id="step-delay-days"
               type="number"
               min="0"
               bind:value={stepForm.delayDays}
-              class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             />
           </div>
           <div>
-            <label for="step-delay-hours" class="block text-sm font-medium text-gray-700 mb-1.5">{$_('sequences.delayHours')}</label>
+            <label for="step-delay-hours" class="block text-sm font-medium text-ink mb-1.5">{$_('sequences.delayHours')}</label>
             <input
               id="step-delay-hours"
               type="number"
               min="0"
               max="23"
               bind:value={stepForm.delayHours}
-              class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
+              class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 focus:border-transparent"
             />
           </div>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={addStep}
           disabled={addingStep || !stepForm.subject.trim() || !stepForm.html.trim()}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 text-sm flex items-center justify-center gap-2 cursor-pointer"
         >
           {#if addingStep}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
@@ -677,7 +677,7 @@
         </button>
         <button
           on:click={() => addStepSequenceId = null}
-          class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer"
+          class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer"
         >
           {$_('common.cancel')}
         </button>
@@ -691,15 +691,15 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => deletingId = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm">
       <div class="p-6">
         <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-4">
           <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0" />
           </svg>
         </div>
-        <h2 class="text-lg font-semibold text-gray-900 mb-2">{$_('sequences.deleteSequence')}</h2>
-        <p class="text-sm text-gray-500 mb-6">{$_('sequences.confirmDelete')}</p>
+        <h2 class="text-lg font-semibold text-ink mb-2">{$_('sequences.deleteSequence')}</h2>
+        <p class="text-sm text-ink-muted mb-6">{$_('sequences.confirmDelete')}</p>
         <div class="flex gap-3">
           <button
             on:click={() => deleteSequence(deletingId)}
@@ -709,7 +709,7 @@
           </button>
           <button
             on:click={() => deletingId = null}
-            class="flex-1 px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer"
+            class="flex-1 px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer"
           >
             {$_('common.cancel')}
           </button>

--- a/apps/web/src/routes/(app)/projects/[id]/settings/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/[id]/settings/+page.svelte
@@ -117,7 +117,7 @@
 
   const platformColor: Record<string, string> = {
     LINKEDIN: 'text-[#0077B5] bg-[#0077B5]/10',
-    TWITTER: 'text-gray-900 bg-gray-100',
+    TWITTER: 'text-ink bg-surface-2',
     FACEBOOK: 'text-[#1877F2] bg-[#1877F2]/10',
     TELEGRAM: 'text-[#26A5E4] bg-[#26A5E4]/10',
     INSTAGRAM: 'text-[#E1306C] bg-[#E1306C]/10',
@@ -485,24 +485,24 @@
 
 <div class="p-6 max-w-2xl">
   <div class="mb-6">
-    <h1 class="text-2xl font-bold text-gray-900">{$_('projects.settings')}</h1>
+    <h1 class="text-2xl font-bold text-ink">{$_('projects.settings')}</h1>
   </div>
 
   <!-- Base Currency section -->
-  <div class="bg-white rounded-xl border border-gray-200 p-5 mb-6">
+  <div class="bg-surface rounded-xl border border-border p-5 mb-6">
     <div class="mb-4">
-      <h2 class="text-base font-semibold text-gray-900">{$_('projects.baseCurrency')}</h2>
+      <h2 class="text-base font-semibold text-ink">{$_('projects.baseCurrency')}</h2>
     </div>
     <select
       bind:value={baseCurrency}
       on:change={saveBaseCurrency}
-      class="w-full max-w-xs px-3 py-2 bg-white border border-gray-300 rounded-lg text-gray-900 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+      class="w-full max-w-xs px-3 py-2 bg-surface border border-border rounded-lg text-ink text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
     >
       {#each currencies as c}
         <option value={c}>{c}</option>
       {/each}
     </select>
-    <p class="text-sm text-gray-500 mt-2">{$_('projects.baseCurrencyWarning')}</p>
+    <p class="text-sm text-ink-muted mt-2">{$_('projects.baseCurrencyWarning')}</p>
     {#if currencySaved}
       <span class="text-sm text-green-600 flex items-center gap-1 mt-2">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -514,25 +514,25 @@
   </div>
 
   <!-- Social Networks section -->
-  <div class="bg-white rounded-xl border border-gray-200 p-5">
+  <div class="bg-surface rounded-xl border border-border p-5">
     <div class="mb-4">
-      <h2 class="text-base font-semibold text-gray-900">{$_('projects.socialNetworks')}</h2>
-      <p class="text-sm text-gray-500 mt-0.5">{$_('projects.socialNetworksDesc')}</p>
+      <h2 class="text-base font-semibold text-ink">{$_('projects.socialNetworks')}</h2>
+      <p class="text-sm text-ink-muted mt-0.5">{$_('projects.socialNetworksDesc')}</p>
     </div>
 
     {#if loading}
       <div class="space-y-2">
         {#each Array(3) as _}
-          <div class="h-12 bg-gray-100 rounded-lg animate-pulse"></div>
+          <div class="h-12 bg-surface-2 rounded-lg animate-pulse"></div>
         {/each}
       </div>
     {:else if allAccounts.length === 0}
-      <div class="text-center py-8 text-gray-500">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 mx-auto mb-3 text-gray-300" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+      <div class="text-center py-8 text-ink-muted">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-10 h-10 mx-auto mb-3 text-ink-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244" />
         </svg>
-        <p class="text-sm font-medium text-gray-600 mb-1">{$_('projects.noOrgAccounts')}</p>
-        <a href="/settings/integrations" class="text-sm text-primary-600 hover:underline">{$_('projects.noOrgAccountsLink')}</a>
+        <p class="text-sm font-medium text-ink-muted mb-1">{$_('projects.noOrgAccounts')}</p>
+        <a href="/settings/integrations" class="text-sm text-brand hover:underline">{$_('projects.noOrgAccountsLink')}</a>
       </div>
     {:else}
       <div class="space-y-2 mb-4">
@@ -540,30 +540,30 @@
           <!-- svelte-ignore a11y-click-events-have-key-events -->
           <!-- svelte-ignore a11y-no-static-element-interactions -->
           <div
-            class="flex items-center gap-3 p-3 rounded-xl border cursor-pointer transition-colors duration-150 {enabledIds.has(account.id) ? 'border-primary-400 bg-primary-50' : 'border-gray-200 hover:bg-gray-50'}"
+            class="flex items-center gap-3 p-3 rounded-xl border cursor-pointer transition-colors duration-150 {enabledIds.has(account.id) ? 'border-primary-400 bg-brand-subtle/10' : 'border-border hover:bg-surface-2'}"
             on:click={() => toggle(account.id)}
           >
             <input
               type="checkbox"
               checked={enabledIds.has(account.id)}
-              class="w-4 h-4 text-primary-600 rounded border-gray-300 cursor-pointer flex-shrink-0"
+              class="w-4 h-4 text-brand rounded border-border cursor-pointer flex-shrink-0"
               readonly
             />
-            <div class="w-8 h-8 rounded-lg {platformColor[account.platform] || 'bg-gray-100 text-gray-500'} flex items-center justify-center flex-shrink-0">
+            <div class="w-8 h-8 rounded-lg {platformColor[account.platform] || 'bg-surface-2 text-ink-muted'} flex items-center justify-center flex-shrink-0">
               {@html platformIcon[account.platform] || ''}
             </div>
             <div class="flex-1 min-w-0">
-              <div class="text-sm font-medium text-gray-900 truncate" title={account.accountName}>{account.accountName}</div>
-              <div class="text-xs text-gray-500 flex items-center gap-1.5">
+              <div class="text-sm font-medium text-ink truncate" title={account.accountName}>{account.accountName}</div>
+              <div class="text-xs text-ink-muted flex items-center gap-1.5">
                 <span>{account.platform}</span>
                 {#if account.accountId}
-                  <span class="text-gray-300">·</span>
+                  <span class="text-ink-subtle">·</span>
                   <span class="font-mono truncate" title={account.accountId}>{account.accountId}</span>
                 {/if}
               </div>
             </div>
             {#if enabledIds.has(account.id)}
-              <span class="text-xs px-2 py-0.5 bg-primary-100 text-primary-700 rounded-full flex-shrink-0">{$_('social.connected')}</span>
+              <span class="text-xs px-2 py-0.5 bg-primary-100 text-brand rounded-full flex-shrink-0">{$_('social.connected')}</span>
             {/if}
           </div>
         {/each}
@@ -573,7 +573,7 @@
         <button
           on:click={save}
           disabled={saving}
-          class="px-5 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 cursor-pointer"
+          class="px-5 py-2 bg-brand text-white rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 cursor-pointer"
         >
           {saving ? $_('common.loading') : $_('common.save')}
         </button>
@@ -590,20 +590,20 @@
   </div>
 
   <!-- Website Tracking section -->
-  <div class="bg-white rounded-xl border border-gray-200 p-5 mt-6">
+  <div class="bg-surface rounded-xl border border-border p-5 mt-6">
     <div class="mb-4">
-      <h2 class="text-base font-semibold text-gray-900">{$_('tracking.title')}</h2>
-      <p class="text-sm text-gray-500 mt-0.5">{$_('tracking.description')}</p>
+      <h2 class="text-base font-semibold text-ink">{$_('tracking.title')}</h2>
+      <p class="text-sm text-ink-muted mt-0.5">{$_('tracking.description')}</p>
     </div>
 
     {#if trackingInfo}
       <div class="mb-4">
-        <label class="block text-xs font-medium text-gray-600 mb-1">{$_('tracking.trackingId')}</label>
-        <code class="text-sm bg-gray-50 px-3 py-1.5 rounded border border-gray-200 font-mono inline-block">{trackingInfo.trackingId}</code>
+        <label class="block text-xs font-medium text-ink-muted mb-1">{$_('tracking.trackingId')}</label>
+        <code class="text-sm bg-surface-2 px-3 py-1.5 rounded border border-border font-mono inline-block">{trackingInfo.trackingId}</code>
       </div>
 
       <div class="mb-4">
-        <label class="block text-xs font-medium text-gray-600 mb-1">{$_('tracking.snippet')}</label>
+        <label class="block text-xs font-medium text-ink-muted mb-1">{$_('tracking.snippet')}</label>
         <pre class="text-xs bg-gray-900 text-green-400 p-4 rounded-lg overflow-x-auto max-h-48 whitespace-pre-wrap">&lt;!-- Marketing AI Tracking --&gt;
 &lt;script src="{trackingInfo.snippetUrl}"&gt;&lt;/script&gt;</pre>
       </div>
@@ -611,36 +611,36 @@
       <div class="flex items-center gap-3 mb-5">
         <button
           on:click={copySnippet}
-          class="px-4 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 cursor-pointer flex items-center gap-1.5"
+          class="px-4 py-2 bg-brand text-white rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 cursor-pointer flex items-center gap-1.5"
         >
           <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
           </svg>
           {snippetCopied ? $_('common.copied') : $_('tracking.copySnippet')}
         </button>
-        <p class="text-xs text-gray-500">{$_('tracking.copyHint')}</p>
+        <p class="text-xs text-ink-muted">{$_('tracking.copyHint')}</p>
       </div>
 
-      <div class="border-t border-gray-100 pt-4 space-y-3">
+      <div class="border-t border-border pt-4 space-y-3">
         <div>
-          <h3 class="text-xs font-semibold text-gray-700">{$_('tracking.customEvents')}</h3>
-          <code class="text-xs text-gray-500 font-mono">mktai('event', 'button_click', &#123;label: 'signup'&#125;)</code>
+          <h3 class="text-xs font-semibold text-ink">{$_('tracking.customEvents')}</h3>
+          <code class="text-xs text-ink-muted font-mono">mktai('event', 'button_click', &#123;label: 'signup'&#125;)</code>
         </div>
         <div>
-          <h3 class="text-xs font-semibold text-gray-700">{$_('tracking.conversions')}</h3>
-          <code class="text-xs text-gray-500 font-mono">mktai('conversion', 'purchase', &#123;value: 99&#125;)</code>
+          <h3 class="text-xs font-semibold text-ink">{$_('tracking.conversions')}</h3>
+          <code class="text-xs text-ink-muted font-mono">mktai('conversion', 'purchase', &#123;value: 99&#125;)</code>
         </div>
       </div>
     {:else if !loading}
-      <div class="text-sm text-gray-500">{$_('common.loading')}</div>
+      <div class="text-sm text-ink-muted">{$_('common.loading')}</div>
     {/if}
   </div>
 
   <!-- Google Search Console section -->
-  <div class="bg-white rounded-xl border border-gray-200 p-5 mt-6">
+  <div class="bg-surface rounded-xl border border-border p-5 mt-6">
     <div class="mb-4">
-      <h2 class="text-base font-semibold text-gray-900">{$_('seo.gscConfig.title')}</h2>
-      <p class="text-sm text-gray-500 mt-0.5">{$_('seo.gscConfig.description')}</p>
+      <h2 class="text-base font-semibold text-ink">{$_('seo.gscConfig.title')}</h2>
+      <p class="text-sm text-ink-muted mt-0.5">{$_('seo.gscConfig.description')}</p>
     </div>
 
     {#if gscSuccess}
@@ -663,7 +663,7 @@
     {#if gscLoading}
       <div class="space-y-2">
         {#each Array(2) as _}
-          <div class="h-10 bg-gray-100 rounded-lg animate-pulse"></div>
+          <div class="h-10 bg-surface-2 rounded-lg animate-pulse"></div>
         {/each}
       </div>
     {:else if gscConfig?.accessToken}
@@ -671,16 +671,16 @@
       <div class="space-y-4">
         <div class="flex items-center gap-2">
           <div class="w-3 h-3 rounded-full bg-green-500"></div>
-          <span class="text-sm font-medium text-gray-900">{$_('seo.gscConfig.connected')}</span>
+          <span class="text-sm font-medium text-ink">{$_('seo.gscConfig.connected')}</span>
         </div>
 
         <div>
-          <label class="block text-xs font-medium text-gray-600 mb-1.5">
+          <label class="block text-xs font-medium text-ink-muted mb-1.5">
             {$_('seo.gscConfig.siteUrl')}
-            <span class="font-normal text-gray-400 ml-1">— {$_('seo.gscConfig.siteUrlHelper')}</span>
+            <span class="font-normal text-ink-subtle ml-1">— {$_('seo.gscConfig.siteUrlHelper')}</span>
           </label>
           {#if gscSitesLoading}
-            <div class="h-10 bg-gray-100 rounded-lg animate-pulse"></div>
+            <div class="h-10 bg-surface-2 rounded-lg animate-pulse"></div>
           {:else if gscSites.length === 0}
             <div class="p-3 bg-amber-50 border border-amber-200 rounded-lg text-xs text-amber-800">
               No verified properties found in this Google account. Add and verify your site in <a href="https://search.google.com/search-console" target="_blank" rel="noopener" class="underline">Google Search Console</a>, then reconnect.
@@ -689,7 +689,7 @@
             <div class="flex gap-2">
               <select
                 bind:value={gscSiteUrl}
-                class="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
+                class="flex-1 px-3 py-1.5 text-sm border border-border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500"
               >
                 {#each gscSites as site}
                   <option value={site.siteUrl}>{site.siteUrl}</option>
@@ -704,7 +704,7 @@
               </button>
             </div>
             {#if projectWebsite}
-              <p class="text-xs text-gray-500 mt-1.5">
+              <p class="text-xs text-ink-muted mt-1.5">
                 Project website: <span class="font-medium">{projectWebsite}</span> — pre-selected the matching property if available.
               </p>
             {/if}
@@ -724,11 +724,11 @@
       <div class="space-y-3">
         <div class="flex items-center gap-2">
           <div class="w-3 h-3 rounded-full bg-gray-300"></div>
-          <span class="text-sm text-gray-500">{$_('common.notConnected') || 'Not connected'}</span>
+          <span class="text-sm text-ink-muted">{$_('common.notConnected') || 'Not connected'}</span>
         </div>
         <button
           on:click={connectGsc}
-          class="px-4 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 cursor-pointer flex items-center gap-2"
+          class="px-4 py-2 bg-brand text-white rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 cursor-pointer flex items-center gap-2"
         >
           <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
             <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
@@ -738,7 +738,7 @@
           </svg>
           {$_('seo.gscConfig.connect')}
         </button>
-        <p class="text-xs text-gray-400">
+        <p class="text-xs text-ink-subtle">
           Pick the property verified in Search Console for this project. The app will pull rank positions from yesterday's GSC data.
         </p>
       </div>
@@ -747,10 +747,10 @@
 
   <!-- Google Play Console section (mobile apps only) -->
   {#if isMobileApp}
-    <div class="bg-white rounded-xl border border-gray-200 p-5 mt-6">
+    <div class="bg-surface rounded-xl border border-border p-5 mt-6">
       <div class="mb-4">
-        <h2 class="text-base font-semibold text-gray-900">{$_('googlePlay.connection.title')}</h2>
-        <p class="text-sm text-gray-500 mt-0.5">{$_('googlePlay.connection.description')}</p>
+        <h2 class="text-base font-semibold text-ink">{$_('googlePlay.connection.title')}</h2>
+        <p class="text-sm text-ink-muted mt-0.5">{$_('googlePlay.connection.description')}</p>
       </div>
 
       <!-- Success / Error banners -->
@@ -774,7 +774,7 @@
       {#if gpLoading}
         <div class="space-y-2">
           {#each Array(2) as _}
-            <div class="h-10 bg-gray-100 rounded-lg animate-pulse"></div>
+            <div class="h-10 bg-surface-2 rounded-lg animate-pulse"></div>
           {/each}
         </div>
       {:else if gpStatus?.connected}
@@ -782,28 +782,28 @@
         <div class="space-y-4">
           <div class="flex items-center gap-3">
             <div class="w-3 h-3 rounded-full {gpStatus.status === 'OK' ? 'bg-green-500' : gpStatus.status === 'ERROR' ? 'bg-red-500' : 'bg-yellow-500'}"></div>
-            <span class="text-sm font-medium text-gray-900">
+            <span class="text-sm font-medium text-ink">
               {#if gpStatus.status === 'OK'}{$_('googlePlay.connection.status.ok')}
               {:else if gpStatus.status === 'ERROR'}{$_('googlePlay.connection.status.error')}
               {:else}{$_('googlePlay.connection.status.syncing')}
               {/if}
             </span>
             {#if gpStatus.authMethod}
-              <span class="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">{gpStatus.authMethod === 'oauth2' ? 'OAuth' : 'Service Account'}</span>
+              <span class="text-xs bg-surface-2 text-ink-muted px-2 py-0.5 rounded-full">{gpStatus.authMethod === 'oauth2' ? 'OAuth' : 'Service Account'}</span>
             {/if}
           </div>
 
           <div>
-            <span class="text-xs font-medium text-gray-500">{$_('googlePlay.connection.packageName')}</span>
+            <span class="text-xs font-medium text-ink-muted">{$_('googlePlay.connection.packageName')}</span>
             {#if gpStatus.packageName}
-              <code class="ml-2 text-sm bg-gray-50 px-2 py-0.5 rounded border border-gray-200 font-mono">{gpStatus.packageName}</code>
+              <code class="ml-2 text-sm bg-surface-2 px-2 py-0.5 rounded border border-border font-mono">{gpStatus.packageName}</code>
             {:else}
               <div class="flex gap-2 mt-1">
                 <input
                   type="text"
                   bind:value={gpPackageName}
                   placeholder={$_('googlePlay.connection.enterPackageName')}
-                  class="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 font-mono"
+                  class="flex-1 px-3 py-1.5 text-sm border border-border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 font-mono"
                 />
                 <button
                   on:click={savePackageName}
@@ -816,7 +816,7 @@
             {/if}
           </div>
 
-          <div class="text-xs text-gray-500">
+          <div class="text-xs text-ink-muted">
             {$_('googlePlay.connection.lastSync', { values: { time: formatLastSync(gpStatus.lastSyncAt) } })}
           </div>
 
@@ -827,17 +827,17 @@
           {/if}
 
           <!-- Cloud Storage Bucket URI -->
-          <div class="mt-3 p-3 bg-gray-50 rounded-lg border border-gray-200">
-            <label class="block text-xs font-medium text-gray-600 mb-1.5">
+          <div class="mt-3 p-3 bg-surface-2 rounded-lg border border-border">
+            <label class="block text-xs font-medium text-ink-muted mb-1.5">
               Cloud Storage URI
-              <span class="font-normal text-gray-400">(Google Play Console → Download reports → Copy Cloud Storage URI)</span>
+              <span class="font-normal text-ink-subtle">(Google Play Console → Download reports → Copy Cloud Storage URI)</span>
             </label>
             <div class="flex gap-2">
               <input
                 type="text"
                 bind:value={gpBucketUri}
                 placeholder="gs://pubsite_prod_rev_XXXXXXXXXXXX"
-                class="flex-1 px-3 py-1.5 text-sm border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 font-mono"
+                class="flex-1 px-3 py-1.5 text-sm border border-border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500 font-mono"
               />
               <button
                 on:click={saveBucketUri}
@@ -851,14 +851,14 @@
                 {/if}
               </button>
             </div>
-            <p class="text-xs text-gray-400 mt-1.5">Required for install counts, ratings distribution, and store listing performance data.</p>
+            <p class="text-xs text-ink-subtle mt-1.5">Required for install counts, ratings distribution, and store listing performance data.</p>
           </div>
 
           <div class="flex items-center gap-3">
             <button
               on:click={syncNow}
               disabled={gpSyncing}
-              class="px-4 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 cursor-pointer flex items-center gap-1.5"
+              class="px-4 py-2 bg-brand text-white rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 cursor-pointer flex items-center gap-1.5"
             >
               {#if gpSyncing}
                 <svg class="animate-spin w-4 h-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
@@ -887,13 +887,13 @@
           <!-- svelte-ignore a11y-click-events-have-key-events -->
           <!-- svelte-ignore a11y-no-static-element-interactions -->
           <div class="fixed inset-0 bg-black/40 flex items-center justify-center z-50" on:click|self={() => { showDisconnectConfirm = false; }}>
-            <div class="bg-white rounded-xl shadow-xl p-6 max-w-sm mx-4">
-              <h3 class="text-lg font-semibold text-gray-900 mb-2">{$_('googlePlay.connection.disconnect')}</h3>
-              <p class="text-sm text-gray-600 mb-5">{$_('googlePlay.connection.disconnectConfirm')}</p>
+            <div class="bg-surface rounded-xl shadow-xl p-6 max-w-sm mx-4">
+              <h3 class="text-lg font-semibold text-ink mb-2">{$_('googlePlay.connection.disconnect')}</h3>
+              <p class="text-sm text-ink-muted mb-5">{$_('googlePlay.connection.disconnectConfirm')}</p>
               <div class="flex items-center gap-3 justify-end">
                 <button
                   on:click={() => { showDisconnectConfirm = false; }}
-                  class="px-4 py-2 text-sm text-gray-600 border border-gray-200 rounded-lg hover:bg-gray-50 cursor-pointer"
+                  class="px-4 py-2 text-sm text-ink-muted border border-border rounded-lg hover:bg-surface-2 cursor-pointer"
                 >
                   Cancel
                 </button>
@@ -914,13 +914,13 @@
         <div class="space-y-4">
           <div class="flex items-center gap-2 mb-2">
             <div class="w-3 h-3 rounded-full bg-gray-300"></div>
-            <span class="text-sm text-gray-500">{$_('googlePlay.connection.disconnected')}</span>
+            <span class="text-sm text-ink-muted">{$_('googlePlay.connection.disconnected')}</span>
           </div>
 
           <div class="flex flex-wrap gap-3">
             <button
               on:click={connectOAuth}
-              class="px-4 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 cursor-pointer flex items-center gap-2"
+              class="px-4 py-2 bg-brand text-white rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 cursor-pointer flex items-center gap-2"
             >
               <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor">
                 <path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/>
@@ -932,36 +932,36 @@
             </button>
             <button
               on:click={() => { gpShowServiceAccountForm = !gpShowServiceAccountForm; }}
-              class="px-4 py-2 text-gray-700 border border-gray-300 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
+              class="px-4 py-2 text-ink border border-border rounded-lg text-sm font-medium hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
             >
               {$_('googlePlay.connection.connectServiceAccount')}
             </button>
           </div>
 
           {#if gpShowServiceAccountForm}
-            <div class="border border-gray-200 rounded-lg p-4 space-y-3 mt-3">
+            <div class="border border-border rounded-lg p-4 space-y-3 mt-3">
               <div>
-                <label class="block text-xs font-medium text-gray-600 mb-1">{$_('googlePlay.connection.uploadJson')}</label>
+                <label class="block text-xs font-medium text-ink-muted mb-1">{$_('googlePlay.connection.uploadJson')}</label>
                 <input
                   type="file"
                   accept=".json"
                   on:change={handleFileSelect}
-                  class="block w-full text-sm text-gray-500 file:mr-3 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-primary-50 file:text-primary-700 hover:file:bg-primary-100 file:cursor-pointer cursor-pointer"
+                  class="block w-full text-sm text-ink-muted file:mr-3 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-medium file:bg-brand-subtle/10 file:text-primary-700 hover:file:bg-primary-100 file:cursor-pointer cursor-pointer"
                 />
               </div>
               <div>
-                <label class="block text-xs font-medium text-gray-600 mb-1">{$_('googlePlay.connection.packageName')}</label>
+                <label class="block text-xs font-medium text-ink-muted mb-1">{$_('googlePlay.connection.packageName')}</label>
                 <input
                   type="text"
                   bind:value={gpPackageName}
                   placeholder={$_('googlePlay.connection.enterPackageName')}
-                  class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+                  class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
                 />
               </div>
               <button
                 on:click={connectServiceAccount}
                 disabled={gpConnecting || !gpServiceAccountFile || !gpPackageName.trim()}
-                class="px-4 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 cursor-pointer"
+                class="px-4 py-2 bg-brand text-white rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 cursor-pointer"
               >
                 {gpConnecting ? $_('common.loading') : $_('googlePlay.connection.connectServiceAccount')}
               </button>

--- a/apps/web/src/routes/(app)/projects/new/+page.svelte
+++ b/apps/web/src/routes/(app)/projects/new/+page.svelte
@@ -41,32 +41,32 @@
 
 <div class="max-w-2xl mx-auto p-6">
   <div class="mb-6">
-    <a href="/dashboard" class="text-sm text-gray-500 hover:text-primary-600 flex items-center gap-1 transition-colors duration-150 cursor-pointer">
+    <a href="/dashboard" class="text-sm text-ink-muted hover:text-primary-600 flex items-center gap-1 transition-colors duration-150 cursor-pointer">
       <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
       {$_('common.back')}
     </a>
-    <h1 class="text-2xl font-bold text-gray-900 mt-3">{$_('projects.create')}</h1>
-    <p class="text-gray-500 mt-1 text-sm">{$_('projects.createDesc')}</p>
+    <h1 class="text-2xl font-bold text-ink mt-3">{$_('projects.create')}</h1>
+    <p class="text-ink-muted mt-1 text-sm">{$_('projects.createDesc')}</p>
   </div>
 
   {#if error}
     <div class="bg-red-50 border border-red-200 text-red-700 rounded-lg p-3 mb-4 text-sm">{error}</div>
   {/if}
 
-  <div class="bg-white rounded-xl border border-gray-200 border-t-4 border-t-primary-500 p-6">
+  <div class="bg-surface rounded-xl border border-border border-t-4 border-t-primary-500 p-6">
     <form on:submit|preventDefault={handleCreate} class="space-y-5">
       <div>
-        <label for="new-name" class="block text-sm font-medium text-gray-700 mb-1">{$_('projects.name')} <span class="text-red-400">*</span></label>
-        <input id="new-name" type="text" bind:value={name} required class="w-full px-3 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm" placeholder={$_('projects.namePlaceholder')} />
+        <label for="new-name" class="block text-sm font-medium text-ink mb-1">{$_('projects.name')} <span class="text-red-400">*</span></label>
+        <input id="new-name" type="text" bind:value={name} required class="w-full px-3 py-2.5 border border-border rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-transparent text-sm" placeholder={$_('projects.namePlaceholder')} />
       </div>
       <div>
-        <label class="block text-sm font-medium text-gray-700 mb-2">{$_('projects.projectType')}</label>
+        <label class="block text-sm font-medium text-ink mb-2">{$_('projects.projectType')}</label>
         <div class="grid grid-cols-3 gap-2">
           {#each projectTypes as pt}
             <button
               type="button"
               on:click={() => projectType = pt}
-              class="px-3 py-2 text-sm rounded-lg border transition-colors duration-150 cursor-pointer {projectType === pt ? 'border-primary-500 bg-primary-50 text-primary-700 font-medium' : 'border-gray-200 text-gray-600 hover:border-gray-300 hover:bg-gray-50'}"
+              class="px-3 py-2 text-sm rounded-lg border transition-colors duration-150 cursor-pointer {projectType === pt ? 'border-primary-500 bg-brand-subtle/10 text-brand font-medium' : 'border-border text-ink-muted hover:border-gray-300 hover:bg-surface-2'}"
             >
               {$_(`projects.types.${pt}`)}
             </button>
@@ -74,19 +74,19 @@
         </div>
       </div>
       <div>
-        <label for="new-desc" class="block text-sm font-medium text-gray-700 mb-1">{$_('projects.description')}</label>
-        <textarea id="new-desc" bind:value={description} rows="3" class="w-full px-3 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 text-sm resize-none" placeholder={$_('projects.descriptionPlaceholder')}></textarea>
+        <label for="new-desc" class="block text-sm font-medium text-ink mb-1">{$_('projects.description')}</label>
+        <textarea id="new-desc" bind:value={description} rows="3" class="w-full px-3 py-2.5 border border-border rounded-lg focus:ring-2 focus:ring-primary-500 text-sm resize-none" placeholder={$_('projects.descriptionPlaceholder')}></textarea>
       </div>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {#if showWebsiteUrl}
           <div>
-            <label for="new-website" class="block text-sm font-medium text-gray-700 mb-1">{$_('projects.website')}</label>
-            <input id="new-website" type="url" bind:value={websiteUrl} class="w-full px-3 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 text-sm" placeholder={$_('projects.websitePlaceholder')} />
+            <label for="new-website" class="block text-sm font-medium text-ink mb-1">{$_('projects.website')}</label>
+            <input id="new-website" type="url" bind:value={websiteUrl} class="w-full px-3 py-2.5 border border-border rounded-lg focus:ring-2 focus:ring-primary-500 text-sm" placeholder={$_('projects.websitePlaceholder')} />
           </div>
         {/if}
         <div>
-          <label for="new-industry" class="block text-sm font-medium text-gray-700 mb-1">{$_('projects.industry')}</label>
-          <select id="new-industry" bind:value={industry} class="w-full px-3 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 text-sm">
+          <label for="new-industry" class="block text-sm font-medium text-ink mb-1">{$_('projects.industry')}</label>
+          <select id="new-industry" bind:value={industry} class="w-full px-3 py-2.5 border border-border rounded-lg focus:ring-2 focus:ring-primary-500 text-sm">
             <option value="">{$_('projects.selectIndustry')}</option>
             {#each industries as ind}
               <option value={ind}>{ind}</option>
@@ -95,11 +95,11 @@
         </div>
       </div>
       <div>
-        <label for="new-audience" class="block text-sm font-medium text-gray-700 mb-1">{$_('projects.targetAudience')}</label>
-        <textarea id="new-audience" bind:value={targetAudience} rows="2" class="w-full px-3 py-2.5 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500 text-sm resize-none" placeholder={$_('projects.targetAudiencePlaceholder')}></textarea>
+        <label for="new-audience" class="block text-sm font-medium text-ink mb-1">{$_('projects.targetAudience')}</label>
+        <textarea id="new-audience" bind:value={targetAudience} rows="2" class="w-full px-3 py-2.5 border border-border rounded-lg focus:ring-2 focus:ring-primary-500 text-sm resize-none" placeholder={$_('projects.targetAudiencePlaceholder')}></textarea>
       </div>
-      <div class="flex gap-3 pt-2 border-t border-gray-100">
-        <button type="submit" disabled={loading || !name} class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed text-sm flex items-center justify-center gap-2 cursor-pointer">
+      <div class="flex gap-3 pt-2 border-t border-border">
+        <button type="submit" disabled={loading || !name} class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed text-sm flex items-center justify-center gap-2 cursor-pointer">
           {#if loading}
             <svg class="animate-spin w-4 h-4" fill="none" viewBox="0 0 24 24">
               <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
@@ -108,7 +108,7 @@
           {/if}
           {loading ? $_('common.loading') : $_('projects.create')}
         </button>
-        <a href="/dashboard" class="px-6 py-2.5 border border-gray-300 rounded-lg text-gray-700 hover:bg-gray-50 transition-colors duration-150 text-center text-sm cursor-pointer">
+        <a href="/dashboard" class="px-6 py-2.5 border border-border rounded-lg text-ink hover:bg-surface-2 transition-colors duration-150 text-center text-sm cursor-pointer">
           {$_('common.cancel')}
         </a>
       </div>

--- a/apps/web/src/routes/(app)/seo/+page.svelte
+++ b/apps/web/src/routes/(app)/seo/+page.svelte
@@ -33,24 +33,24 @@
 </script>
 
 <div class="p-4 sm:p-6">
-  <div class="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 mb-1">
+  <div class="flex items-center gap-1.5 text-sm text-ink-muted mb-1">
     <span>{currentOrg?.name || $_('header.orgContext')}</span>
     {#if $currentProjectStore}
-      <span class="text-gray-300">›</span>
+      <span class="text-ink-subtle">›</span>
       <span class="text-indigo-600 dark:text-indigo-400">{$currentProjectStore.name}</span>
     {/if}
-    <span class="text-gray-300">›</span>
-    <span class="text-gray-700 dark:text-gray-200">{$_('nav.orgSeo')}</span>
+    <span class="text-ink-subtle">›</span>
+    <span class="text-ink">{$_('nav.orgSeo')}</span>
   </div>
 
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{$_('nav.orgSeo')}</h1>
+    <h1 class="text-2xl font-bold text-ink">{$_('nav.orgSeo')}</h1>
     {#if $currentProjectStore}
       <a href="/projects/{$currentProjectStore.id}/seo" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors">
         + {$_('common.create')}
       </a>
     {:else}
-      <button disabled class="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-400 text-sm font-medium rounded-lg cursor-not-allowed" title={$_('common.selectProjectToCreate')}>
+      <button disabled class="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-ink-subtle text-sm font-medium rounded-lg cursor-not-allowed" title={$_('common.selectProjectToCreate')}>
         + {$_('common.create')}
       </button>
     {/if}
@@ -61,17 +61,17 @@
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500"></div>
     </div>
   {:else if items.length === 0}
-    <div class="text-center py-12 text-gray-500 dark:text-gray-400">
+    <div class="text-center py-12 text-ink-muted">
       <p>{$_('common.noData')}</p>
     </div>
   {:else}
     <div class="space-y-3">
       {#each items as item}
-        <a href="/projects/{item.projectId}/seo" class="block bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
+        <a href="/projects/{item.projectId}/seo" class="block bg-surface rounded-lg border border-border p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
           <div class="flex items-center justify-between">
             <div>
-              <h3 class="font-medium text-gray-900 dark:text-white">{item.name || item.title || 'SEO'}</h3>
-              <p class="text-sm text-gray-500 dark:text-gray-400">{item.type || ''}</p>
+              <h3 class="font-medium text-ink">{item.name || item.title || 'SEO'}</h3>
+              <p class="text-sm text-ink-muted">{item.type || ''}</p>
             </div>
             {#if ctx.type === 'organization'}
               <span class="text-xs px-2 py-1 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">

--- a/apps/web/src/routes/(app)/sequences/+page.svelte
+++ b/apps/web/src/routes/(app)/sequences/+page.svelte
@@ -33,24 +33,24 @@
 </script>
 
 <div class="p-4 sm:p-6">
-  <div class="flex items-center gap-1.5 text-sm text-gray-500 dark:text-gray-400 mb-1">
+  <div class="flex items-center gap-1.5 text-sm text-ink-muted mb-1">
     <span>{currentOrg?.name || $_('header.orgContext')}</span>
     {#if $currentProjectStore}
-      <span class="text-gray-300">›</span>
+      <span class="text-ink-subtle">›</span>
       <span class="text-indigo-600 dark:text-indigo-400">{$currentProjectStore.name}</span>
     {/if}
-    <span class="text-gray-300">›</span>
-    <span class="text-gray-700 dark:text-gray-200">{$_('nav.orgSequences')}</span>
+    <span class="text-ink-subtle">›</span>
+    <span class="text-ink">{$_('nav.orgSequences')}</span>
   </div>
 
   <div class="flex items-center justify-between mb-6">
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-white">{$_('nav.orgSequences')}</h1>
+    <h1 class="text-2xl font-bold text-ink">{$_('nav.orgSequences')}</h1>
     {#if $currentProjectStore}
       <a href="/projects/{$currentProjectStore.id}/sequences" class="inline-flex items-center gap-2 px-4 py-2 bg-indigo-600 text-white text-sm font-medium rounded-lg hover:bg-indigo-700 transition-colors">
         + {$_('common.create')}
       </a>
     {:else}
-      <button disabled class="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-gray-400 text-sm font-medium rounded-lg cursor-not-allowed" title={$_('common.selectProjectToCreate')}>
+      <button disabled class="inline-flex items-center gap-2 px-4 py-2 bg-gray-200 text-ink-subtle text-sm font-medium rounded-lg cursor-not-allowed" title={$_('common.selectProjectToCreate')}>
         + {$_('common.create')}
       </button>
     {/if}
@@ -61,17 +61,17 @@
       <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-500"></div>
     </div>
   {:else if items.length === 0}
-    <div class="text-center py-12 text-gray-500 dark:text-gray-400">
+    <div class="text-center py-12 text-ink-muted">
       <p>{$_('common.noData')}</p>
     </div>
   {:else}
     <div class="space-y-3">
       {#each items as item}
-        <a href="/projects/{item.projectId}/sequences" class="block bg-white dark:bg-gray-800 rounded-lg border border-gray-200 dark:border-gray-700 p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
+        <a href="/projects/{item.projectId}/sequences" class="block bg-surface rounded-lg border border-border p-4 hover:border-indigo-300 dark:hover:border-indigo-600 hover:shadow-sm transition-all cursor-pointer">
           <div class="flex items-center justify-between">
             <div>
-              <h3 class="font-medium text-gray-900 dark:text-white">{item.name || item.title || 'Sequence'}</h3>
-              <p class="text-sm text-gray-500 dark:text-gray-400">{item.type || ''}</p>
+              <h3 class="font-medium text-ink">{item.name || item.title || 'Sequence'}</h3>
+              <p class="text-sm text-ink-muted">{item.type || ''}</p>
             </div>
             {#if ctx.type === 'organization'}
               <span class="text-xs px-2 py-1 rounded-full bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-300">

--- a/apps/web/src/routes/(app)/settings/billing/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/billing/+page.svelte
@@ -41,7 +41,7 @@
   $: plans = [
     {
       id: 'FREE', nameKey: 'billing.freePlan', price: '$0', badgeKey: null,
-      border: 'border-gray-200',
+      border: 'border-border',
       featuresKey: 'billing.planFeatures.free',
     },
     {
@@ -51,22 +51,22 @@
     },
     {
       id: 'ENTERPRISE', nameKey: 'billing.enterprisePlan', price: '$99', badgeKey: null,
-      border: 'border-gray-200',
+      border: 'border-border',
       featuresKey: 'billing.planFeatures.enterprise',
     },
   ];
 </script>
 
 <div class="p-6 max-w-5xl mx-auto">
-  <h1 class="text-2xl font-bold text-gray-900 mb-1">{$_('billing.title')}</h1>
-  <p class="text-gray-500 text-sm mb-8">{$_('billing.manageDesc')}</p>
+  <h1 class="text-2xl font-bold text-ink mb-1">{$_('billing.title')}</h1>
+  <p class="text-ink-muted text-sm mb-8">{$_('billing.manageDesc')}</p>
 
   {#if !loading && subscription}
-    <div class="bg-white rounded-xl border border-gray-200 p-5 mb-8 flex items-center justify-between">
+    <div class="bg-surface rounded-xl border border-border p-5 mb-8 flex items-center justify-between">
       <div>
-        <p class="text-xs font-medium text-gray-500 uppercase tracking-wide">{$_('billing.currentPlan')}</p>
-        <p class="text-2xl font-bold text-gray-900 mt-1">{subscription.plan}</p>
-        <p class="text-sm text-gray-500 mt-1 flex items-center gap-1.5 flex-wrap">
+        <p class="text-xs font-medium text-ink-muted uppercase tracking-wide">{$_('billing.currentPlan')}</p>
+        <p class="text-2xl font-bold text-ink mt-1">{subscription.plan}</p>
+        <p class="text-sm text-ink-muted mt-1 flex items-center gap-1.5 flex-wrap">
           {#if subscription.status === 'trialing'}
             <span class="inline-flex items-center gap-1 text-amber-600">
               <svg class="w-4 h-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -82,12 +82,12 @@
               {$_('billing.active')}
             </span>
           {/if}
-          <span class="text-gray-300">·</span>
+          <span class="text-ink-subtle">·</span>
           <span>{$_('billing.renews')} {new Date(subscription.currentPeriodEnd).toLocaleDateString()}</span>
         </p>
       </div>
       {#if subscription.plan !== 'FREE'}
-        <button on:click={openPortal} class="px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors duration-150 cursor-pointer">
+        <button on:click={openPortal} class="px-4 py-2 border border-border rounded-lg text-sm font-medium hover:bg-surface-2 transition-colors duration-150 cursor-pointer">
           {$_('billing.manage')}
         </button>
       {/if}
@@ -96,31 +96,31 @@
 
   <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
     {#each plans as plan}
-      <div class="bg-white rounded-xl border-2 {plan.border} p-6 relative hover:shadow-lg transition-shadow duration-200 {plan.badgeKey ? 'ring-2 ring-primary-400 ring-offset-2' : ''}">
+      <div class="bg-surface rounded-xl border-2 {plan.border} p-6 relative hover:shadow-lg transition-shadow duration-200 {plan.badgeKey ? 'ring-2 ring-primary-400 ring-offset-2' : ''}">
         {#if plan.badgeKey}
-          <div class="absolute -top-3.5 left-1/2 -translate-x-1/2 bg-primary-600 text-white text-xs font-bold px-3 py-1 rounded-full">{$_(plan.badgeKey)}</div>
+          <div class="absolute -top-3.5 left-1/2 -translate-x-1/2 bg-brand text-white text-xs font-bold px-3 py-1 rounded-full">{$_(plan.badgeKey)}</div>
         {/if}
-        <h3 class="text-xl font-bold text-gray-900">{$_(plan.nameKey)}</h3>
+        <h3 class="text-xl font-bold text-ink">{$_(plan.nameKey)}</h3>
         <div class="my-3">
-          <span class="text-3xl font-bold text-gray-900">{plan.price}</span>
-          <span class="text-gray-400 text-sm">{$_('billing.monthly')}</span>
+          <span class="text-3xl font-bold text-ink">{plan.price}</span>
+          <span class="text-ink-subtle text-sm">{$_('billing.monthly')}</span>
         </div>
         <ul class="space-y-2 mb-6">
           {#each ($_( plan.featuresKey) as string[]) as f}
-            <li class="flex items-center gap-2 text-sm text-gray-600">
+            <li class="flex items-center gap-2 text-sm text-ink-muted">
               <svg class="w-4 h-4 text-green-500 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" /></svg>
               {f}
             </li>
           {/each}
         </ul>
         {#if !loading && subscription?.plan === plan.id}
-          <div class="w-full py-2 text-center text-sm text-gray-400 border border-gray-200 rounded-lg">{$_('billing.currentPlanBtn')}</div>
+          <div class="w-full py-2 text-center text-sm text-ink-subtle border border-border rounded-lg">{$_('billing.currentPlanBtn')}</div>
         {:else if plan.id !== 'FREE'}
-          <button on:click={() => checkout(plan.id)} class="w-full py-2.5 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 cursor-pointer">
+          <button on:click={() => checkout(plan.id)} class="w-full py-2.5 bg-brand text-white rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 cursor-pointer">
             {$_('billing.upgradeTo', { values: { plan: $_(plan.nameKey) } })}
           </button>
         {:else}
-          <div class="w-full py-2 text-center text-sm text-gray-400">{$_('billing.freeForever')}</div>
+          <div class="w-full py-2 text-center text-sm text-ink-subtle">{$_('billing.freeForever')}</div>
         {/if}
       </div>
     {/each}

--- a/apps/web/src/routes/(app)/settings/email-accounts/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/email-accounts/+page.svelte
@@ -143,7 +143,7 @@
   };
   const statusColors: Record<string, string> = {
     ACTIVE: 'bg-green-100 text-green-700',
-    INACTIVE: 'bg-gray-100 text-gray-600',
+    INACTIVE: 'bg-surface-2 text-ink-muted',
     ERROR: 'bg-red-100 text-red-700',
   };
 </script>
@@ -152,8 +152,8 @@
   <!-- Header -->
   <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3 mb-6">
     <div>
-      <h1 class="text-2xl font-bold text-gray-900">{$_('email.accounts')}</h1>
-      <p class="text-sm text-gray-500 mt-1">{$_('email.noAccountsDesc')}</p>
+      <h1 class="text-2xl font-bold text-ink">{$_('email.accounts')}</h1>
+      <p class="text-sm text-ink-muted mt-1">{$_('email.noAccountsDesc')}</p>
     </div>
     <button
       on:click={openAddModal}
@@ -178,15 +178,15 @@
       <div class="w-6 h-6 border-2 border-indigo-600 border-t-transparent rounded-full animate-spin"></div>
     </div>
   {:else if accounts.length === 0}
-    <div class="text-center py-16 bg-gray-50 rounded-xl border border-dashed border-gray-200">
+    <div class="text-center py-16 bg-surface-2 rounded-xl border border-dashed border-border">
       <div class="w-12 h-12 bg-indigo-50 rounded-full flex items-center justify-center mx-auto mb-3">
         <svg class="w-6 h-6 text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
             d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
         </svg>
       </div>
-      <p class="text-gray-700 font-medium text-sm">{$_('email.noAccounts')}</p>
-      <p class="text-gray-400 text-xs mt-1 mb-4">{$_('email.noAccountsDesc')}</p>
+      <p class="text-ink font-medium text-sm">{$_('email.noAccounts')}</p>
+      <p class="text-ink-subtle text-xs mt-1 mb-4">{$_('email.noAccountsDesc')}</p>
       <button on:click={openAddModal} class="bg-indigo-600 text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors">
         {$_('email.addAccount')}
       </button>
@@ -194,7 +194,7 @@
   {:else}
     <div class="space-y-3">
       {#each accounts as account (account.id)}
-        <div class="bg-white border border-gray-200 rounded-xl p-4 flex items-start gap-4">
+        <div class="bg-surface border border-border rounded-xl p-4 flex items-start gap-4">
           <div class="w-10 h-10 bg-indigo-50 rounded-lg flex items-center justify-center shrink-0">
             <svg class="w-5 h-5 text-indigo-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -204,20 +204,20 @@
 
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-2 flex-wrap">
-              <span class="font-medium text-gray-900 text-sm">{account.email}</span>
+              <span class="font-medium text-ink text-sm">{account.email}</span>
               {#if account.displayName}
-                <span class="text-gray-400 text-xs">({account.displayName})</span>
+                <span class="text-ink-subtle text-xs">({account.displayName})</span>
               {/if}
             </div>
             <div class="flex items-center gap-2 mt-1 flex-wrap">
-              <span class="text-xs px-2 py-0.5 rounded-full font-medium {providerColors[account.provider] ?? 'bg-gray-100 text-gray-600'}">
+              <span class="text-xs px-2 py-0.5 rounded-full font-medium {providerColors[account.provider] ?? 'bg-surface-2 text-ink-muted'}">
                 {account.provider === 'RESEND' ? $_('email.resend') : $_('email.smtp')}
               </span>
-              <span class="text-xs px-2 py-0.5 rounded-full font-medium {statusColors[account.status] ?? 'bg-gray-100 text-gray-600'}">
+              <span class="text-xs px-2 py-0.5 rounded-full font-medium {statusColors[account.status] ?? 'bg-surface-2 text-ink-muted'}">
                 {account.status}
               </span>
               {#if account.smtpHost}
-                <span class="text-xs text-gray-400">{account.smtpHost}:{account.smtpPort}</span>
+                <span class="text-xs text-ink-subtle">{account.smtpHost}:{account.smtpPort}</span>
               {/if}
             </div>
             {#if testResults[account.id]}
@@ -233,7 +233,7 @@
             <button
               on:click={() => testConnection(account.id)}
               disabled={testingId === account.id}
-              class="text-xs text-gray-600 border border-gray-200 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors disabled:opacity-50 whitespace-nowrap"
+              class="text-xs text-ink-muted border border-border px-3 py-1.5 rounded-lg hover:bg-surface-2 transition-colors disabled:opacity-50 whitespace-nowrap"
             >
               {testingId === account.id ? '...' : $_('email.testConnection')}
             </button>
@@ -261,13 +261,13 @@
     on:click|self={() => (showAddModal = false)}
     on:keydown={(e) => e.key === 'Escape' && (showAddModal = false)}
   >
-    <div class="bg-white rounded-2xl shadow-xl w-full max-w-md max-h-[90vh] overflow-y-auto">
+    <div class="bg-surface rounded-2xl shadow-xl w-full max-w-md max-h-[90vh] overflow-y-auto">
       <div class="p-6">
         <div class="flex items-center justify-between mb-5">
-          <h2 class="text-lg font-semibold text-gray-900">{$_('email.addAccountTitle')}</h2>
+          <h2 class="text-lg font-semibold text-ink">{$_('email.addAccountTitle')}</h2>
           <button
             on:click={() => (showAddModal = false)}
-            class="text-gray-400 hover:text-gray-600 transition-colors"
+            class="text-ink-subtle hover:text-gray-600 transition-colors"
           >
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -281,19 +281,19 @@
 
         <!-- Provider toggle -->
         <div class="mb-5">
-          <label class="block text-sm font-medium text-gray-700 mb-2">{$_('email.provider')}</label>
-          <div class="flex rounded-lg border border-gray-200 overflow-hidden">
+          <label class="block text-sm font-medium text-ink mb-2">{$_('email.provider')}</label>
+          <div class="flex rounded-lg border border-border overflow-hidden">
             <button
               type="button"
               on:click={() => (provider = 'SMTP')}
-              class="flex-1 py-2 text-sm font-medium transition-colors {provider === 'SMTP' ? 'bg-indigo-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}"
+              class="flex-1 py-2 text-sm font-medium transition-colors {provider === 'SMTP' ? 'bg-indigo-600 text-white' : 'bg-surface text-ink-muted hover:bg-surface-2'}"
             >
               {$_('email.smtp')}
             </button>
             <button
               type="button"
               on:click={() => (provider = 'RESEND')}
-              class="flex-1 py-2 text-sm font-medium transition-colors {provider === 'RESEND' ? 'bg-indigo-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}"
+              class="flex-1 py-2 text-sm font-medium transition-colors {provider === 'RESEND' ? 'bg-indigo-600 text-white' : 'bg-surface text-ink-muted hover:bg-surface-2'}"
             >
               {$_('email.resend')}
             </button>
@@ -302,99 +302,99 @@
 
         <form on:submit|preventDefault={addAccount} class="space-y-4">
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">{$_('email.fromEmail')} *</label>
+            <label class="block text-sm font-medium text-ink mb-1">{$_('email.fromEmail')} *</label>
             <input
               type="email"
               bind:value={form.email}
               required
               placeholder="campaigns@yourcompany.com"
-              class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              class="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
             />
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">
-              {$_('email.displayName')} <span class="text-gray-400 font-normal">({$_('common.optional')})</span>
+            <label class="block text-sm font-medium text-ink mb-1">
+              {$_('email.displayName')} <span class="text-ink-subtle font-normal">({$_('common.optional')})</span>
             </label>
             <input
               type="text"
               bind:value={form.displayName}
               placeholder={$_('email.placeholderDisplayName')}
-              class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              class="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
             />
           </div>
 
           {#if provider === 'SMTP'}
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">{$_('email.smtpHost')} *</label>
+                <label class="block text-sm font-medium text-ink mb-1">{$_('email.smtpHost')} *</label>
                 <input
                   type="text"
                   bind:value={form.smtpHost}
                   required
                   placeholder="smtp.example.com"
-                  class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  class="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">{$_('email.smtpPort')}</label>
+                <label class="block text-sm font-medium text-ink mb-1">{$_('email.smtpPort')}</label>
                 <input
                   type="number"
                   bind:value={form.smtpPort}
-                  class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  class="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 />
               </div>
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">{$_('email.username')} *</label>
+              <label class="block text-sm font-medium text-ink mb-1">{$_('email.username')} *</label>
               <input
                 type="text"
                 bind:value={form.smtpUser}
                 required
                 placeholder="user@example.com"
-                class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                class="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
               />
             </div>
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">{$_('email.password')} *</label>
+              <label class="block text-sm font-medium text-ink mb-1">{$_('email.password')} *</label>
               <input
                 type="password"
                 bind:value={form.smtpPassword}
                 required
-                class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                class="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
               />
             </div>
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">
-                  {$_('email.imapHost')} <span class="text-gray-400 font-normal">({$_('common.optional')})</span>
+                <label class="block text-sm font-medium text-ink mb-1">
+                  {$_('email.imapHost')} <span class="text-ink-subtle font-normal">({$_('common.optional')})</span>
                 </label>
                 <input
                   type="text"
                   bind:value={form.imapHost}
                   placeholder="imap.example.com"
-                  class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  class="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 />
               </div>
               <div>
-                <label class="block text-sm font-medium text-gray-700 mb-1">{$_('email.imapPort')}</label>
+                <label class="block text-sm font-medium text-ink mb-1">{$_('email.imapPort')}</label>
                 <input
                   type="number"
                   bind:value={form.imapPort}
-                  class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                  class="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
                 />
               </div>
             </div>
           {:else}
             <div>
-              <label class="block text-sm font-medium text-gray-700 mb-1">{$_('email.apiKey')} *</label>
+              <label class="block text-sm font-medium text-ink mb-1">{$_('email.apiKey')} *</label>
               <input
                 type="password"
                 bind:value={form.apiKey}
                 required
                 placeholder="re_xxxxxxxxxxxxxxxx"
-                class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                class="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
               />
-              <p class="text-xs text-gray-400 mt-1">{$_('email.resendApiKeyHint')}</p>
+              <p class="text-xs text-ink-subtle mt-1">{$_('email.resendApiKeyHint')}</p>
             </div>
           {/if}
 
@@ -402,7 +402,7 @@
             <button
               type="button"
               on:click={() => (showAddModal = false)}
-              class="flex-1 border border-gray-200 text-gray-700 text-sm font-medium py-2.5 rounded-xl hover:bg-gray-50 transition-colors"
+              class="flex-1 border border-border text-ink text-sm font-medium py-2.5 rounded-xl hover:bg-surface-2 transition-colors"
             >
               {$_('common.cancel')}
             </button>

--- a/apps/web/src/routes/(app)/settings/integrations/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/integrations/+page.svelte
@@ -286,7 +286,7 @@
 
   const platformColor: Record<string, string> = {
     LINKEDIN: 'text-[#0077B5] bg-[#0077B5]/10',
-    TWITTER: 'text-gray-900 bg-gray-100',
+    TWITTER: 'text-ink bg-surface-2',
     FACEBOOK: 'text-[#1877F2] bg-[#1877F2]/10',
     TELEGRAM: 'text-[#26A5E4] bg-[#26A5E4]/10',
     INSTAGRAM: 'text-[#E1306C] bg-[#E1306C]/10',
@@ -296,27 +296,27 @@
 
 <div class="p-4 sm:p-6 max-w-4xl">
   <div class="mb-6">
-    <h1 class="text-2xl font-bold text-gray-900">{$_('social.title')}</h1>
-    <p class="text-gray-500 text-sm mt-1">{$_('social.subtitle')}</p>
+    <h1 class="text-2xl font-bold text-ink">{$_('social.title')}</h1>
+    <p class="text-ink-muted text-sm mt-1">{$_('social.subtitle')}</p>
   </div>
 
   {#if loading}
     <div class="space-y-3">
       {#each Array(4) as _}
-        <div class="bg-white rounded-xl border border-gray-200 p-5 animate-pulse h-20"></div>
+        <div class="bg-surface rounded-xl border border-border p-5 animate-pulse h-20"></div>
       {/each}
     </div>
   {:else}
     <!-- LinkedIn -->
-    <div class="bg-white rounded-xl border border-gray-200 p-5 mb-3">
+    <div class="bg-surface rounded-xl border border-border p-5 mb-3">
       <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
         <div class="flex items-center gap-3">
           <div class="w-10 h-10 rounded-lg {platformColor['LINKEDIN']} flex items-center justify-center flex-shrink-0">
             {@html platformIcon['LINKEDIN']}
           </div>
           <div>
-            <div class="font-medium text-gray-900">{$_('social.linkedin')}</div>
-            <div class="text-xs text-gray-500">{$_('social.linkedinDesc')}</div>
+            <div class="font-medium text-ink">{$_('social.linkedin')}</div>
+            <div class="text-xs text-ink-muted">{$_('social.linkedinDesc')}</div>
           </div>
         </div>
         <div class="flex flex-col gap-2">
@@ -325,12 +325,12 @@
               {#if account.profileImageUrl}
                 <img src={account.profileImageUrl} alt={account.accountName} class="w-7 h-7 rounded-full" />
               {/if}
-              <span class="text-sm text-gray-700 font-medium">{account.accountName}</span>
+              <span class="text-sm text-ink font-medium">{account.accountName}</span>
               <span class="text-xs px-2 py-0.5 bg-green-100 text-green-700 rounded-full">{$_('social.connected')}</span>
               <select
                 bind:value={account.language}
                 on:change={() => updateAccountLanguage(account)}
-                class="text-sm border border-gray-300 rounded px-2 py-1 bg-white"
+                class="text-sm border border-border rounded px-2 py-1 bg-surface"
               >
                 <option value="">{$_('social.noLanguage')}</option>
                 <option value="en">English</option>
@@ -350,15 +350,15 @@
     </div>
 
     <!-- Twitter / X -->
-    <div class="bg-white rounded-xl border border-gray-200 p-5 mb-3">
+    <div class="bg-surface rounded-xl border border-border p-5 mb-3">
       <div class="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-3">
         <div class="flex items-center gap-3">
           <div class="w-10 h-10 rounded-lg {platformColor['TWITTER']} flex items-center justify-center flex-shrink-0">
             {@html platformIcon['TWITTER']}
           </div>
           <div>
-            <div class="font-medium text-gray-900">{$_('social.twitter')}</div>
-            <div class="text-xs text-gray-500">{$_('social.twitterDesc')}</div>
+            <div class="font-medium text-ink">{$_('social.twitter')}</div>
+            <div class="text-xs text-ink-muted">{$_('social.twitterDesc')}</div>
           </div>
         </div>
         <div class="flex flex-col gap-2">
@@ -367,12 +367,12 @@
               {#if account.profileImageUrl}
                 <img src={account.profileImageUrl} alt={account.accountName} class="w-7 h-7 rounded-full" />
               {/if}
-              <span class="text-sm text-gray-700 font-medium">@{account.accountName}</span>
+              <span class="text-sm text-ink font-medium">@{account.accountName}</span>
               <span class="text-xs px-2 py-0.5 bg-green-100 text-green-700 rounded-full">{$_('social.connected')}</span>
               <select
                 bind:value={account.language}
                 on:change={() => updateAccountLanguage(account)}
-                class="text-sm border border-gray-300 rounded px-2 py-1 bg-white"
+                class="text-sm border border-border rounded px-2 py-1 bg-surface"
               >
                 <option value="">{$_('social.noLanguage')}</option>
                 <option value="en">English</option>
@@ -392,19 +392,19 @@
     </div>
 
     <!-- Facebook -->
-    <div class="bg-white rounded-xl border border-gray-200 p-5 mb-3">
+    <div class="bg-surface rounded-xl border border-border p-5 mb-3">
       <div class="flex items-center gap-3 mb-3">
         <div class="w-10 h-10 rounded-lg {platformColor['FACEBOOK']} flex items-center justify-center flex-shrink-0">
           {@html platformIcon['FACEBOOK']}
         </div>
         <div>
-          <div class="font-medium text-gray-900">{$_('social.facebook')}</div>
-          <div class="text-xs text-gray-500">{$_('social.facebookDesc')}</div>
+          <div class="font-medium text-ink">{$_('social.facebook')}</div>
+          <div class="text-xs text-ink-muted">{$_('social.facebookDesc')}</div>
         </div>
       </div>
       <div class="flex flex-col gap-2">
         {#each accounts.filter(a => a.platform === 'FACEBOOK') as account}
-          <div class="flex flex-col gap-2 p-2.5 rounded-lg border {account.status === 'REAUTH_REQUIRED' ? 'border-orange-300 bg-orange-50' : 'border-gray-100 bg-gray-50/50'}">
+          <div class="flex flex-col gap-2 p-2.5 rounded-lg border {account.status === 'REAUTH_REQUIRED' ? 'border-orange-300 bg-orange-50' : 'border-border bg-surface-2/50'}">
             <div class="flex flex-wrap items-center justify-between gap-2">
               <div class="flex items-center gap-2 min-w-0">
                 {#if account.profileImageUrl}
@@ -412,31 +412,31 @@
                 {/if}
                 <div class="flex flex-col min-w-0">
                   <div class="flex items-center gap-2">
-                    <span class="text-sm text-gray-800 font-medium truncate" title={account.accountName}>{account.accountName}</span>
+                    <span class="text-sm text-ink font-medium truncate" title={account.accountName}>{account.accountName}</span>
                     {#if account.status === 'REAUTH_REQUIRED'}
                       <span class="text-xs px-2 py-0.5 bg-orange-100 text-orange-700 rounded-full flex-shrink-0">{$_('social.reauthRequired.badge')}</span>
                     {:else}
                       <span class="text-xs px-2 py-0.5 bg-green-100 text-green-700 rounded-full flex-shrink-0">{$_('social.connected')}</span>
                     {/if}
                   </div>
-                  <span class="text-xs text-gray-500 font-mono truncate" title={account.accountId}>{account.accountId}</span>
+                  <span class="text-xs text-ink-muted font-mono truncate" title={account.accountId}>{account.accountId}</span>
                 </div>
               </div>
               <div class="flex items-center gap-2 flex-shrink-0">
                 <select
                   bind:value={account.language}
                   on:change={() => updateAccountLanguage(account)}
-                  class="text-sm border border-gray-300 rounded px-2 py-1 bg-white"
+                  class="text-sm border border-border rounded px-2 py-1 bg-surface"
                 >
                   <option value="">{$_('social.noLanguage')}</option>
                   <option value="en">English</option>
                   <option value="pl">Polski</option>
                   <option value="ru">Русский</option>
                 </select>
-                <button on:click={() => openEditFacebook(account)} class="text-xs px-3 py-1.5 border {account.status === 'REAUTH_REQUIRED' ? 'border-orange-400 text-orange-700 bg-orange-100 hover:bg-orange-200 font-medium' : 'border-gray-300 text-gray-700 bg-white hover:bg-gray-50'} rounded-lg transition-colors duration-150 cursor-pointer">
+                <button on:click={() => openEditFacebook(account)} class="text-xs px-3 py-1.5 border {account.status === 'REAUTH_REQUIRED' ? 'border-orange-400 text-orange-700 bg-orange-100 hover:bg-orange-200 font-medium' : 'border-border text-ink bg-surface hover:bg-surface-2'} rounded-lg transition-colors duration-150 cursor-pointer">
                   {account.status === 'REAUTH_REQUIRED' ? $_('social.reauthRequired.cta') : $_('common.edit')}
                 </button>
-                <button on:click={() => disconnectingId = account.id} class="text-xs px-3 py-1.5 border border-red-200 text-red-500 rounded-lg hover:bg-red-50 transition-colors duration-150 cursor-pointer bg-white">
+                <button on:click={() => disconnectingId = account.id} class="text-xs px-3 py-1.5 border border-red-200 text-red-500 rounded-lg hover:bg-red-50 transition-colors duration-150 cursor-pointer bg-surface">
                   {$_('social.disconnect')}
                 </button>
               </div>
@@ -453,43 +453,43 @@
     </div>
 
     <!-- Instagram -->
-    <div class="bg-white rounded-xl border border-gray-200 p-5 mb-3">
+    <div class="bg-surface rounded-xl border border-border p-5 mb-3">
       <div class="flex items-center gap-3 mb-3">
         <div class="w-10 h-10 rounded-lg {platformColor['INSTAGRAM']} flex items-center justify-center flex-shrink-0">
           {@html platformIcon['INSTAGRAM']}
         </div>
         <div>
-          <div class="font-medium text-gray-900">Instagram</div>
-          <div class="text-xs text-gray-500">{$_('social.instagram.description')}</div>
+          <div class="font-medium text-ink">Instagram</div>
+          <div class="text-xs text-ink-muted">{$_('social.instagram.description')}</div>
         </div>
       </div>
       <div class="flex flex-col gap-2">
         {#each accounts.filter(a => a.platform === 'INSTAGRAM') as account}
-          <div class="flex flex-wrap items-center justify-between gap-2 p-2.5 rounded-lg border border-gray-100 bg-gray-50/50">
+          <div class="flex flex-wrap items-center justify-between gap-2 p-2.5 rounded-lg border border-border bg-surface-2/50">
             <div class="flex items-center gap-2 min-w-0">
               {#if account.profileImageUrl}
                 <img src={account.profileImageUrl} alt={account.accountName} class="w-7 h-7 rounded-full flex-shrink-0" />
               {/if}
               <div class="flex flex-col min-w-0">
                 <div class="flex items-center gap-2">
-                  <span class="text-sm text-gray-800 font-medium truncate" title={account.accountName}>{account.accountName}</span>
+                  <span class="text-sm text-ink font-medium truncate" title={account.accountName}>{account.accountName}</span>
                   <span class="text-xs px-2 py-0.5 bg-green-100 text-green-700 rounded-full flex-shrink-0">{$_('social.connected')}</span>
                 </div>
-                <span class="text-xs text-gray-500 font-mono truncate" title={account.accountId}>{account.accountId}</span>
+                <span class="text-xs text-ink-muted font-mono truncate" title={account.accountId}>{account.accountId}</span>
               </div>
             </div>
             <div class="flex items-center gap-2 flex-shrink-0">
               <select
                 bind:value={account.language}
                 on:change={() => updateAccountLanguage(account)}
-                class="text-sm border border-gray-300 rounded px-2 py-1 bg-white"
+                class="text-sm border border-border rounded px-2 py-1 bg-surface"
               >
                 <option value="">{$_('social.noLanguage')}</option>
                 <option value="en">English</option>
                 <option value="pl">Polski</option>
                 <option value="ru">Русский</option>
               </select>
-              <button on:click={() => disconnectingId = account.id} class="text-xs px-3 py-1.5 border border-red-200 text-red-500 rounded-lg hover:bg-red-50 transition-colors duration-150 cursor-pointer bg-white">
+              <button on:click={() => disconnectingId = account.id} class="text-xs px-3 py-1.5 border border-red-200 text-red-500 rounded-lg hover:bg-red-50 transition-colors duration-150 cursor-pointer bg-surface">
                 {$_('social.disconnect')}
               </button>
             </div>
@@ -502,43 +502,43 @@
     </div>
 
     <!-- Threads -->
-    <div class="bg-white rounded-xl border border-gray-200 p-5 mb-3">
+    <div class="bg-surface rounded-xl border border-border p-5 mb-3">
       <div class="flex items-center gap-3 mb-3">
         <div class="w-10 h-10 rounded-lg {platformColor['THREADS']} flex items-center justify-center flex-shrink-0">
           {@html platformIcon['THREADS']}
         </div>
         <div>
-          <div class="font-medium text-gray-900">Threads</div>
-          <div class="text-xs text-gray-500">{$_('social.threads.description')}</div>
+          <div class="font-medium text-ink">Threads</div>
+          <div class="text-xs text-ink-muted">{$_('social.threads.description')}</div>
         </div>
       </div>
       <div class="flex flex-col gap-2">
         {#each accounts.filter(a => a.platform === 'THREADS') as account}
-          <div class="flex flex-wrap items-center justify-between gap-2 p-2.5 rounded-lg border border-gray-100 bg-gray-50/50">
+          <div class="flex flex-wrap items-center justify-between gap-2 p-2.5 rounded-lg border border-border bg-surface-2/50">
             <div class="flex items-center gap-2 min-w-0">
               {#if account.profileImageUrl}
                 <img src={account.profileImageUrl} alt={account.accountName} class="w-7 h-7 rounded-full flex-shrink-0" />
               {/if}
               <div class="flex flex-col min-w-0">
                 <div class="flex items-center gap-2">
-                  <span class="text-sm text-gray-800 font-medium truncate" title={account.accountName}>{account.accountName}</span>
+                  <span class="text-sm text-ink font-medium truncate" title={account.accountName}>{account.accountName}</span>
                   <span class="text-xs px-2 py-0.5 bg-green-100 text-green-700 rounded-full flex-shrink-0">{$_('social.connected')}</span>
                 </div>
-                <span class="text-xs text-gray-500 font-mono truncate" title={account.accountId}>{account.accountId}</span>
+                <span class="text-xs text-ink-muted font-mono truncate" title={account.accountId}>{account.accountId}</span>
               </div>
             </div>
             <div class="flex items-center gap-2 flex-shrink-0">
               <select
                 bind:value={account.language}
                 on:change={() => updateAccountLanguage(account)}
-                class="text-sm border border-gray-300 rounded px-2 py-1 bg-white"
+                class="text-sm border border-border rounded px-2 py-1 bg-surface"
               >
                 <option value="">{$_('social.noLanguage')}</option>
                 <option value="en">English</option>
                 <option value="pl">Polski</option>
                 <option value="ru">Русский</option>
               </select>
-              <button on:click={() => disconnectingId = account.id} class="text-xs px-3 py-1.5 border border-red-200 text-red-500 rounded-lg hover:bg-red-50 transition-colors duration-150 cursor-pointer bg-white">
+              <button on:click={() => disconnectingId = account.id} class="text-xs px-3 py-1.5 border border-red-200 text-red-500 rounded-lg hover:bg-red-50 transition-colors duration-150 cursor-pointer bg-surface">
                 {$_('social.disconnect')}
               </button>
             </div>
@@ -551,46 +551,46 @@
     </div>
 
     <!-- Telegram -->
-    <div class="bg-white rounded-xl border border-gray-200 p-5 mb-3">
+    <div class="bg-surface rounded-xl border border-border p-5 mb-3">
       <div class="flex items-center gap-3 mb-3">
         <div class="w-10 h-10 rounded-lg {platformColor['TELEGRAM']} flex items-center justify-center flex-shrink-0">
           {@html platformIcon['TELEGRAM']}
         </div>
         <div>
-          <div class="font-medium text-gray-900">{$_('social.telegram')}</div>
-          <div class="text-xs text-gray-500">{$_('social.telegramDesc')}</div>
+          <div class="font-medium text-ink">{$_('social.telegram')}</div>
+          <div class="text-xs text-ink-muted">{$_('social.telegramDesc')}</div>
         </div>
       </div>
       <div class="flex flex-col gap-2">
         {#each accounts.filter(a => a.platform === 'TELEGRAM') as account}
-          <div class="flex flex-wrap items-center justify-between gap-2 p-2.5 rounded-lg border border-gray-100 bg-gray-50/50">
+          <div class="flex flex-wrap items-center justify-between gap-2 p-2.5 rounded-lg border border-border bg-surface-2/50">
             <div class="flex items-center gap-2 min-w-0">
               {#if account.profileImageUrl}
                 <img src={account.profileImageUrl} alt={account.accountName} class="w-7 h-7 rounded-full flex-shrink-0" />
               {/if}
               <div class="flex flex-col min-w-0">
                 <div class="flex items-center gap-2">
-                  <span class="text-sm text-gray-800 font-medium truncate" title={account.accountName}>{account.accountName}</span>
+                  <span class="text-sm text-ink font-medium truncate" title={account.accountName}>{account.accountName}</span>
                   <span class="text-xs px-2 py-0.5 bg-green-100 text-green-700 rounded-full flex-shrink-0">{$_('social.connected')}</span>
                 </div>
-                <span class="text-xs text-gray-500 font-mono truncate" title={account.accountId}>{account.accountId}</span>
+                <span class="text-xs text-ink-muted font-mono truncate" title={account.accountId}>{account.accountId}</span>
               </div>
             </div>
             <div class="flex items-center gap-2 flex-shrink-0">
               <select
                 bind:value={account.language}
                 on:change={() => updateAccountLanguage(account)}
-                class="text-sm border border-gray-300 rounded px-2 py-1 bg-white"
+                class="text-sm border border-border rounded px-2 py-1 bg-surface"
               >
                 <option value="">{$_('social.noLanguage')}</option>
                 <option value="en">English</option>
                 <option value="pl">Polski</option>
                 <option value="ru">Русский</option>
               </select>
-              <button on:click={() => openEditTelegram(account)} class="text-xs px-3 py-1.5 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors duration-150 cursor-pointer bg-white">
+              <button on:click={() => openEditTelegram(account)} class="text-xs px-3 py-1.5 border border-border text-ink rounded-lg hover:bg-surface-2 transition-colors duration-150 cursor-pointer bg-surface">
                 {$_('common.edit')}
               </button>
-              <button on:click={() => disconnectingId = account.id} class="text-xs px-3 py-1.5 border border-red-200 text-red-500 rounded-lg hover:bg-red-50 transition-colors duration-150 cursor-pointer bg-white">
+              <button on:click={() => disconnectingId = account.id} class="text-xs px-3 py-1.5 border border-red-200 text-red-500 rounded-lg hover:bg-red-50 transition-colors duration-150 cursor-pointer bg-surface">
                 {$_('social.disconnect')}
               </button>
             </div>
@@ -609,29 +609,29 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showLinkedInModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border">
         <div class="flex items-center gap-2.5 mb-1">
           <div class="w-8 h-8 bg-[#0077B5]/10 rounded-lg flex items-center justify-center flex-shrink-0 text-[#0077B5]">
             {@html platformIcon['LINKEDIN']}
           </div>
-          <h2 class="text-lg font-semibold text-gray-900">{$_('social.linkedinManualTitle')}</h2>
+          <h2 class="text-lg font-semibold text-ink">{$_('social.linkedinManualTitle')}</h2>
         </div>
-        <p class="text-sm text-gray-500 ml-10">{$_('social.linkedinManualDesc')}</p>
+        <p class="text-sm text-ink-muted ml-10">{$_('social.linkedinManualDesc')}</p>
       </div>
       <div class="p-6 space-y-3">
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1">{$_('social.accountName')}</label>
-          <input type="text" bind:value={linkedInForm.accountName} placeholder="John Doe" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+          <label class="block text-xs font-medium text-ink mb-1">{$_('social.accountName')}</label>
+          <input type="text" bind:value={linkedInForm.accountName} placeholder="John Doe" class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1">{$_('social.linkedinPersonUrn')} <span class="text-gray-400 font-normal">(Person ID)</span></label>
-          <input type="text" bind:value={linkedInForm.accountId} placeholder="ABC123xyz" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary-500" />
-          <p class="text-xs text-gray-400 mt-1">{$_('social.linkedinPersonUrnHint')}</p>
+          <label class="block text-xs font-medium text-ink mb-1">{$_('social.linkedinPersonUrn')} <span class="text-ink-subtle font-normal">(Person ID)</span></label>
+          <input type="text" bind:value={linkedInForm.accountId} placeholder="ABC123xyz" class="w-full px-3 py-2 border border-border rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary-500" />
+          <p class="text-xs text-ink-subtle mt-1">{$_('social.linkedinPersonUrnHint')}</p>
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1">{$_('social.accessToken')}</label>
-          <input type="password" bind:value={linkedInForm.accessToken} placeholder="AQV..." class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary-500" />
+          <label class="block text-xs font-medium text-ink mb-1">{$_('social.accessToken')}</label>
+          <input type="password" bind:value={linkedInForm.accessToken} placeholder="AQV..." class="w-full px-3 py-2 border border-border rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary-500" />
           <p class="text-xs text-amber-600 mt-1.5 flex items-start gap-1">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
@@ -640,8 +640,8 @@
           </p>
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{$_('social.accountLanguage')}</label>
-          <select bind:value={linkedInForm.language} class="w-full border border-gray-300 rounded-lg px-3 py-2">
+          <label class="block text-sm font-medium text-ink mb-1">{$_('social.accountLanguage')}</label>
+          <select bind:value={linkedInForm.language} class="w-full border border-border rounded-lg px-3 py-2">
             <option value="">{$_('social.noLanguage')}</option>
             <option value="en">English</option>
             <option value="pl">Polski</option>
@@ -649,7 +649,7 @@
           </select>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={connectLinkedIn}
           disabled={linkedInSaving || !linkedInForm.accountName || !linkedInForm.accountId || !linkedInForm.accessToken}
@@ -657,7 +657,7 @@
         >
           {linkedInSaving ? $_('common.loading') : $_('social.connect')}
         </button>
-        <button on:click={() => showLinkedInModal = false} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={() => showLinkedInModal = false} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>
@@ -670,46 +670,46 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => showTwitterModal = false}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border">
         <div class="flex items-center gap-2.5 mb-1">
-          <div class="w-8 h-8 bg-gray-100 rounded-lg flex items-center justify-center flex-shrink-0">
+          <div class="w-8 h-8 bg-surface-2 rounded-lg flex items-center justify-center flex-shrink-0">
             {@html platformIcon['TWITTER']}
           </div>
-          <h2 class="text-lg font-semibold text-gray-900">{$_('social.twitterManualTitle')}</h2>
+          <h2 class="text-lg font-semibold text-ink">{$_('social.twitterManualTitle')}</h2>
         </div>
-        <p class="text-sm text-gray-500 ml-10">{$_('social.twitterManualDesc')}</p>
+        <p class="text-sm text-ink-muted ml-10">{$_('social.twitterManualDesc')}</p>
       </div>
       <div class="p-6 space-y-3">
         <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>
-            <label class="block text-xs font-medium text-gray-700 mb-1">{$_('social.accountName')}</label>
-            <input type="text" bind:value={twitterForm.accountName} placeholder="@username" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+            <label class="block text-xs font-medium text-ink mb-1">{$_('social.accountName')}</label>
+            <input type="text" bind:value={twitterForm.accountName} placeholder="@username" class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
           </div>
           <div>
-            <label class="block text-xs font-medium text-gray-700 mb-1">{$_('social.accountId')}</label>
-            <input type="text" bind:value={twitterForm.accountId} placeholder="123456789" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+            <label class="block text-xs font-medium text-ink mb-1">{$_('social.accountId')}</label>
+            <input type="text" bind:value={twitterForm.accountId} placeholder="123456789" class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
           </div>
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1">{$_('social.appKey')}</label>
-          <input type="password" bind:value={twitterForm.appKey} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+          <label class="block text-xs font-medium text-ink mb-1">{$_('social.appKey')}</label>
+          <input type="password" bind:value={twitterForm.appKey} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1">{$_('social.appSecret')}</label>
-          <input type="password" bind:value={twitterForm.appSecret} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+          <label class="block text-xs font-medium text-ink mb-1">{$_('social.appSecret')}</label>
+          <input type="password" bind:value={twitterForm.appSecret} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1">{$_('social.accessToken')}</label>
-          <input type="password" bind:value={twitterForm.accessToken} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+          <label class="block text-xs font-medium text-ink mb-1">{$_('social.accessToken')}</label>
+          <input type="password" bind:value={twitterForm.accessToken} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1">{$_('social.accessSecret')}</label>
-          <input type="password" bind:value={twitterForm.accessSecret} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+          <label class="block text-xs font-medium text-ink mb-1">{$_('social.accessSecret')}</label>
+          <input type="password" bind:value={twitterForm.accessSecret} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{$_('social.accountLanguage')}</label>
-          <select bind:value={twitterForm.language} class="w-full border border-gray-300 rounded-lg px-3 py-2">
+          <label class="block text-sm font-medium text-ink mb-1">{$_('social.accountLanguage')}</label>
+          <select bind:value={twitterForm.language} class="w-full border border-border rounded-lg px-3 py-2">
             <option value="">{$_('social.noLanguage')}</option>
             <option value="en">English</option>
             <option value="pl">Polski</option>
@@ -717,7 +717,7 @@
           </select>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={connectTwitter}
           disabled={twitterSaving || !twitterForm.accountName || !twitterForm.accountId || !twitterForm.appKey || !twitterForm.appSecret || !twitterForm.accessToken || !twitterForm.accessSecret}
@@ -725,7 +725,7 @@
         >
           {twitterSaving ? $_('common.loading') : $_('social.connect')}
         </button>
-        <button on:click={() => showTwitterModal = false} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={() => showTwitterModal = false} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>
@@ -738,32 +738,32 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={closeFacebookModal}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border">
         <div class="flex items-center gap-2.5 mb-1">
           <div class="w-8 h-8 bg-[#1877F2]/10 rounded-lg flex items-center justify-center flex-shrink-0 text-[#1877F2]">
             {@html platformIcon['FACEBOOK']}
           </div>
-          <h2 class="text-lg font-semibold text-gray-900">{$_('social.facebookManualTitle')}</h2>
+          <h2 class="text-lg font-semibold text-ink">{$_('social.facebookManualTitle')}</h2>
         </div>
-        <p class="text-sm text-gray-500 ml-10">{$_('social.facebookManualDesc')}</p>
+        <p class="text-sm text-ink-muted ml-10">{$_('social.facebookManualDesc')}</p>
       </div>
       <div class="p-6 space-y-3">
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1">{$_('social.facebookPageName')}</label>
-          <input type="text" bind:value={facebookForm.accountName} placeholder="My Business Page" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+          <label class="block text-xs font-medium text-ink mb-1">{$_('social.facebookPageName')}</label>
+          <input type="text" bind:value={facebookForm.accountName} placeholder="My Business Page" class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1">{$_('social.facebookPageId')}</label>
-          <input type="text" bind:value={facebookForm.pageId} placeholder="123456789012345" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary-500" />
-          <p class="text-xs text-gray-400 mt-1">{$_('social.facebookPageIdHint')}</p>
+          <label class="block text-xs font-medium text-ink mb-1">{$_('social.facebookPageId')}</label>
+          <input type="text" bind:value={facebookForm.pageId} placeholder="123456789012345" class="w-full px-3 py-2 border border-border rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary-500" />
+          <p class="text-xs text-ink-subtle mt-1">{$_('social.facebookPageIdHint')}</p>
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1">
+          <label class="block text-xs font-medium text-ink mb-1">
             {$_('social.facebookPageToken')}
-            {#if editingFacebookId}<span class="text-gray-400 font-normal">({$_('social.leaveBlankToKeep')})</span>{/if}
+            {#if editingFacebookId}<span class="text-ink-subtle font-normal">({$_('social.leaveBlankToKeep')})</span>{/if}
           </label>
-          <input type="password" bind:value={facebookForm.accessToken} placeholder="EAABsbC..." class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary-500" />
+          <input type="password" bind:value={facebookForm.accessToken} placeholder="EAABsbC..." class="w-full px-3 py-2 border border-border rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary-500" />
           <p class="text-xs text-amber-600 mt-1.5 flex items-start gap-1">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
@@ -772,8 +772,8 @@
           </p>
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{$_('social.accountLanguage')}</label>
-          <select bind:value={facebookForm.language} class="w-full border border-gray-300 rounded-lg px-3 py-2">
+          <label class="block text-sm font-medium text-ink mb-1">{$_('social.accountLanguage')}</label>
+          <select bind:value={facebookForm.language} class="w-full border border-border rounded-lg px-3 py-2">
             <option value="">{$_('social.noLanguage')}</option>
             <option value="en">English</option>
             <option value="pl">Polski</option>
@@ -781,7 +781,7 @@
           </select>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={connectFacebook}
           disabled={facebookSaving || !facebookForm.accountName || !facebookForm.pageId || (!editingFacebookId && !facebookForm.accessToken)}
@@ -789,7 +789,7 @@
         >
           {facebookSaving ? $_('common.loading') : (editingFacebookId ? $_('common.save') : $_('social.connect'))}
         </button>
-        <button on:click={closeFacebookModal} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={closeFacebookModal} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>
@@ -802,31 +802,31 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={closeTelegramModal}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border">
         <div class="flex items-center gap-2.5 mb-1">
           <div class="w-8 h-8 rounded-lg {platformColor['TELEGRAM']} flex items-center justify-center flex-shrink-0">
             {@html platformIcon['TELEGRAM']}
           </div>
-          <h2 class="text-lg font-semibold text-gray-900">{$_('social.telegramManualTitle')}</h2>
+          <h2 class="text-lg font-semibold text-ink">{$_('social.telegramManualTitle')}</h2>
         </div>
-        <p class="text-sm text-gray-500 ml-10">{$_('social.telegramManualDesc')}</p>
+        <p class="text-sm text-ink-muted ml-10">{$_('social.telegramManualDesc')}</p>
       </div>
       <div class="p-6 space-y-3">
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1">{$_('social.accountName')} <span class="text-gray-400 font-normal">(optional)</span></label>
-          <input type="text" bind:value={telegramForm.accountName} placeholder="My Marketing Channel" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+          <label class="block text-xs font-medium text-ink mb-1">{$_('social.accountName')} <span class="text-ink-subtle font-normal">(optional)</span></label>
+          <input type="text" bind:value={telegramForm.accountName} placeholder="My Marketing Channel" class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1">
+          <label class="block text-xs font-medium text-ink mb-1">
             {$_('social.botToken')}
-            {#if editingTelegramId}<span class="text-gray-400 font-normal">({$_('social.leaveBlankToKeep')})</span>{/if}
+            {#if editingTelegramId}<span class="text-ink-subtle font-normal">({$_('social.leaveBlankToKeep')})</span>{/if}
           </label>
-          <input type="password" bind:value={telegramForm.botToken} placeholder="1234567890:ABCdefGHIjklMNOpqrstUVwxyz" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary-500" />
+          <input type="password" bind:value={telegramForm.botToken} placeholder="1234567890:ABCdefGHIjklMNOpqrstUVwxyz" class="w-full px-3 py-2 border border-border rounded-lg text-sm font-mono focus:outline-none focus:ring-2 focus:ring-primary-500" />
         </div>
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1">{$_('social.chatId')}</label>
-          <input type="text" bind:value={telegramForm.chatId} placeholder={$_('social.chatIdPlaceholder')} class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
+          <label class="block text-xs font-medium text-ink mb-1">{$_('social.chatId')}</label>
+          <input type="text" bind:value={telegramForm.chatId} placeholder={$_('social.chatIdPlaceholder')} class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500" />
           <p class="text-xs text-amber-600 mt-1.5 flex items-start gap-1">
             <svg xmlns="http://www.w3.org/2000/svg" class="w-3.5 h-3.5 flex-shrink-0 mt-0.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
               <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
@@ -835,8 +835,8 @@
           </p>
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 mb-1">{$_('social.accountLanguage')}</label>
-          <select bind:value={telegramForm.language} class="w-full border border-gray-300 rounded-lg px-3 py-2">
+          <label class="block text-sm font-medium text-ink mb-1">{$_('social.accountLanguage')}</label>
+          <select bind:value={telegramForm.language} class="w-full border border-border rounded-lg px-3 py-2">
             <option value="">{$_('social.noLanguage')}</option>
             <option value="en">English</option>
             <option value="pl">Polski</option>
@@ -844,7 +844,7 @@
           </select>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={connectTelegram}
           disabled={telegramSaving || !telegramForm.chatId || (!editingTelegramId && !telegramForm.botToken)}
@@ -852,7 +852,7 @@
         >
           {telegramSaving ? $_('common.loading') : (editingTelegramId ? $_('common.save') : $_('social.connect'))}
         </button>
-        <button on:click={closeTelegramModal} class="px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={closeTelegramModal} class="px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>
@@ -865,14 +865,14 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => disconnectingId = null}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm p-6">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm p-6">
       <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-4">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round" d="M13.181 8.68a4.503 4.503 0 0 1 1.903 6.405m-9.768-3.782L3 6.757l4.416-1.596m6.784 9.645L10.632 18l-4.416-1.596m9.963-3.782a4.503 4.503 0 0 1-8.271-1.15" />
         </svg>
       </div>
-      <h2 class="text-lg font-semibold text-gray-900 mb-1">{$_('social.disconnectConfirm')}</h2>
-      <p class="text-sm text-gray-500 mb-6">{$_('social.disconnectDesc')}</p>
+      <h2 class="text-lg font-semibold text-ink mb-1">{$_('social.disconnectConfirm')}</h2>
+      <p class="text-sm text-ink-muted mb-6">{$_('social.disconnectDesc')}</p>
       <div class="flex gap-3">
         <button
           on:click={() => disconnectAccount(disconnectingId!)}
@@ -880,7 +880,7 @@
         >
           {$_('social.disconnect')}
         </button>
-        <button on:click={() => disconnectingId = null} class="flex-1 px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer">
+        <button on:click={() => disconnectingId = null} class="flex-1 px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer">
           {$_('common.cancel')}
         </button>
       </div>

--- a/apps/web/src/routes/(app)/settings/organization/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/organization/+page.svelte
@@ -33,7 +33,7 @@
 
   $: org = ($currentUser as any)?.memberships?.[0]?.organization;
   $: planBadge = org?.plan === 'PRO'
-    ? 'bg-primary-100 text-primary-700'
+    ? 'bg-primary-100 text-brand'
     : org?.plan === 'ENTERPRISE'
       ? 'bg-purple-100 text-purple-700'
       : 'bg-green-100 text-green-700';
@@ -78,8 +78,8 @@
 </script>
 
 <div class="p-6 max-w-3xl mx-auto">
-  <h1 class="text-2xl font-bold text-gray-900 mb-1">{$_('settings.organizationTitle')}</h1>
-  <p class="text-gray-500 text-sm mb-8">{$_('settings.organizationDesc')}</p>
+  <h1 class="text-2xl font-bold text-ink mb-1">{$_('settings.organizationTitle')}</h1>
+  <p class="text-ink-muted text-sm mb-8">{$_('settings.organizationDesc')}</p>
 
   {#if loading}
     <div class="flex justify-center py-12">
@@ -87,9 +87,9 @@
     </div>
   {:else}
     <!-- Organization Information -->
-    <div class="bg-white rounded-xl border border-gray-200 p-5 mb-6">
-      <h2 class="text-base font-semibold text-gray-900 mb-4 flex items-center gap-2">
-        <svg class="w-5 h-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+    <div class="bg-surface rounded-xl border border-border p-5 mb-6">
+      <h2 class="text-base font-semibold text-ink mb-4 flex items-center gap-2">
+        <svg class="w-5 h-5 text-ink-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 21h16.5M4.5 3h15M5.25 3v18m13.5-18v18M9 6.75h1.5m-1.5 3h1.5m-1.5 3h1.5m3-6H15m-1.5 3H15m-1.5 3H15M9 21v-3.375c0-.621.504-1.125 1.125-1.125h3.75c.621 0 1.125.504 1.125 1.125V21" />
         </svg>
         {$_('settings.organizationInfo')}
@@ -104,46 +104,46 @@
 
       <div class="space-y-4">
         <div>
-          <label for="org-name" class="block text-xs font-medium text-gray-700 mb-1">{$_('settings.organizationName')}</label>
+          <label for="org-name" class="block text-xs font-medium text-ink mb-1">{$_('settings.organizationName')}</label>
           <input
             id="org-name"
             type="text"
             bind:value={orgForm.name}
             disabled={!isAdmin}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed"
           />
         </div>
 
         <div>
-          <label for="org-slug" class="block text-xs font-medium text-gray-700 mb-1">{$_('settings.organizationSlug')}</label>
+          <label for="org-slug" class="block text-xs font-medium text-ink mb-1">{$_('settings.organizationSlug')}</label>
           <input
             id="org-slug"
             type="text"
             value={org?.slug || ''}
             disabled
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-gray-50 text-gray-500 cursor-not-allowed"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm bg-surface-2 text-ink-muted cursor-not-allowed"
           />
         </div>
 
         <div>
-          <label for="org-logo" class="block text-xs font-medium text-gray-700 mb-1">{$_('settings.organizationLogo')}</label>
+          <label for="org-logo" class="block text-xs font-medium text-ink mb-1">{$_('settings.organizationLogo')}</label>
           <input
             id="org-logo"
             type="text"
             bind:value={orgForm.logoUrl}
             disabled={!isAdmin}
             placeholder={$_('settings.organizationLogoPlaceholder')}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:bg-gray-50 disabled:text-gray-500 disabled:cursor-not-allowed"
           />
           {#if orgForm.logoUrl}
             <div class="mt-2">
-              <img src={orgForm.logoUrl} alt="Logo" class="h-12 w-12 rounded-lg object-cover border border-gray-200" on:error={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }} />
+              <img src={orgForm.logoUrl} alt="Logo" class="h-12 w-12 rounded-lg object-cover border border-border" on:error={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }} />
             </div>
           {/if}
         </div>
 
         <div>
-          <label class="block text-xs font-medium text-gray-700 mb-1">{$_('settings.organizationPlan')}</label>
+          <label class="block text-xs font-medium text-ink mb-1">{$_('settings.organizationPlan')}</label>
           <span class="inline-flex items-center px-2.5 py-1 rounded-full text-xs font-semibold {planBadge}">
             {org?.plan || 'FREE'}
           </span>
@@ -154,7 +154,7 @@
             <button
               on:click={saveOrg}
               disabled={orgSaving || !orgForm.name}
-              class="px-5 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+              class="px-5 py-2 bg-brand text-white rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
             >
               {orgSaving ? $_('common.loading') : $_('common.save')}
             </button>
@@ -164,14 +164,14 @@
     </div>
 
     <!-- Personal Profile -->
-    <div class="bg-white rounded-xl border border-gray-200 p-5 mb-6">
-      <h2 class="text-base font-semibold text-gray-900 mb-4 flex items-center gap-2">
-        <svg class="w-5 h-5 text-gray-400" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+    <div class="bg-surface rounded-xl border border-border p-5 mb-6">
+      <h2 class="text-base font-semibold text-ink mb-4 flex items-center gap-2">
+        <svg class="w-5 h-5 text-ink-subtle" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
         </svg>
         {$_('settings.personalProfile')}
       </h2>
-      <p class="text-xs text-gray-500 mb-4">{$_('settings.personalProfileDesc')}</p>
+      <p class="text-xs text-ink-muted mb-4">{$_('settings.personalProfileDesc')}</p>
 
       {#if userSuccess}
         <div class="bg-green-50 border border-green-200 text-green-700 rounded-lg px-3 py-2 text-sm mb-4">{userSuccess}</div>
@@ -182,29 +182,29 @@
 
       <div class="space-y-4">
         <div>
-          <label for="user-name" class="block text-xs font-medium text-gray-700 mb-1">{$_('settings.userName')}</label>
+          <label for="user-name" class="block text-xs font-medium text-ink mb-1">{$_('settings.userName')}</label>
           <input
             id="user-name"
             type="text"
             bind:value={userForm.name}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
           />
         </div>
 
         <div>
-          <label for="user-email" class="block text-xs font-medium text-gray-700 mb-1">{$_('settings.userEmail')}</label>
+          <label for="user-email" class="block text-xs font-medium text-ink mb-1">{$_('settings.userEmail')}</label>
           <input
             id="user-email"
             type="email"
             value={$currentUser?.email || ''}
             disabled
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm bg-gray-50 text-gray-500 cursor-not-allowed"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm bg-surface-2 text-ink-muted cursor-not-allowed"
           />
-          <p class="text-xs text-gray-400 mt-1">{$_('settings.emailReadonly')}</p>
+          <p class="text-xs text-ink-subtle mt-1">{$_('settings.emailReadonly')}</p>
         </div>
 
         <div>
-          <label for="user-avatar" class="block text-xs font-medium text-gray-700 mb-1">{$_('settings.userAvatar')}</label>
+          <label for="user-avatar" class="block text-xs font-medium text-ink mb-1">{$_('settings.userAvatar')}</label>
           <div class="flex items-center gap-3">
             <div class="w-10 h-10 rounded-full bg-gradient-to-br from-primary-400 to-primary-600 flex items-center justify-center text-white font-semibold text-sm flex-shrink-0 overflow-hidden">
               {#if userForm.avatarUrl}
@@ -218,7 +218,7 @@
               type="text"
               bind:value={userForm.avatarUrl}
               placeholder={$_('settings.userAvatarPlaceholder')}
-              class="flex-1 px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+              class="flex-1 px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
             />
           </div>
         </div>
@@ -227,7 +227,7 @@
           <button
             on:click={saveProfile}
             disabled={userSaving || !userForm.name}
-            class="px-5 py-2 bg-primary-600 text-white rounded-lg text-sm font-medium hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+            class="px-5 py-2 bg-brand text-white rounded-lg text-sm font-medium hover:brightness-110 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
           >
             {userSaving ? $_('common.loading') : $_('common.save')}
           </button>
@@ -237,14 +237,14 @@
 
     <!-- Danger Zone -->
     {#if isAdmin}
-      <div class="bg-white rounded-xl border border-red-200 p-5">
+      <div class="bg-surface rounded-xl border border-red-200 p-5">
         <h2 class="text-base font-semibold text-red-600 mb-2 flex items-center gap-2">
           <svg class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
           </svg>
           {$_('settings.dangerZone')}
         </h2>
-        <p class="text-sm text-gray-500 mb-4">{$_('settings.dangerZoneDesc')}</p>
+        <p class="text-sm text-ink-muted mb-4">{$_('settings.dangerZoneDesc')}</p>
         <button
           disabled
           class="px-4 py-2 bg-red-600 text-white rounded-lg text-sm font-medium opacity-50 cursor-not-allowed"
@@ -252,7 +252,7 @@
         >
           {$_('settings.deleteOrg')}
         </button>
-        <p class="text-xs text-gray-400 mt-2">{$_('settings.deleteOrgNotAvailable')}</p>
+        <p class="text-xs text-ink-subtle mt-2">{$_('settings.deleteOrgNotAvailable')}</p>
       </div>
     {/if}
   {/if}

--- a/apps/web/src/routes/(app)/settings/team/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/team/+page.svelte
@@ -37,7 +37,7 @@
     switch (role) {
       case 'OWNER': return 'bg-amber-100 text-amber-700';
       case 'ADMIN': return 'bg-blue-100 text-blue-700';
-      default: return 'bg-gray-100 text-gray-600';
+      default: return 'bg-surface-2 text-ink-muted';
     }
   }
 
@@ -151,8 +151,8 @@
   <!-- Header -->
   <div class="flex items-center justify-between mb-6">
     <div>
-      <h1 class="text-2xl font-bold text-gray-900">{$_('settings.teamTitle')}</h1>
-      <p class="text-sm text-gray-500 mt-1">{$_('settings.teamDesc')}</p>
+      <h1 class="text-2xl font-bold text-ink">{$_('settings.teamTitle')}</h1>
+      <p class="text-sm text-ink-muted mt-1">{$_('settings.teamDesc')}</p>
     </div>
     <div class="flex items-center gap-2">
       {#if !isOwner}
@@ -169,7 +169,7 @@
       {#if isAdmin}
         <button
           on:click={() => { showInviteModal = true; inviteError = ''; }}
-          class="inline-flex items-center gap-2 bg-primary-600 text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-primary-700 transition-colors duration-150 cursor-pointer"
+          class="inline-flex items-center gap-2 bg-brand text-white text-sm font-medium px-4 py-2 rounded-lg hover:brightness-110 transition-colors duration-150 cursor-pointer"
         >
           <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="M18 7.5v3m0 0v3m0-3h3m-3 0h-3m-2.25-4.125a3.375 3.375 0 1 1-6.75 0 3.375 3.375 0 0 1 6.75 0ZM3 19.235v-.11a6.375 6.375 0 0 1 12.75 0v.109A12.318 12.318 0 0 1 9.374 21c-2.331 0-4.512-.645-6.374-1.766Z" />
@@ -209,19 +209,19 @@
                 {initials(member.user?.name || '')}
               </div>
               <div class="flex-1 min-w-0">
-                <span class="font-medium text-gray-900 text-sm">{member.user?.name || '—'}</span>
-                <div class="text-xs text-gray-500 mt-0.5">{member.user?.email || ''}</div>
+                <span class="font-medium text-ink text-sm">{member.user?.name || '—'}</span>
+                <div class="text-xs text-ink-muted mt-0.5">{member.user?.email || ''}</div>
               </div>
               <div class="flex items-center gap-2 flex-shrink-0">
                 <button
                   on:click={() => approveRequest(member.userId)}
-                  class="inline-flex items-center bg-primary-600 text-white text-xs font-medium px-3 py-1.5 rounded-lg hover:bg-primary-700 transition-colors duration-150 cursor-pointer"
+                  class="inline-flex items-center bg-brand text-white text-xs font-medium px-3 py-1.5 rounded-lg hover:brightness-110 transition-colors duration-150 cursor-pointer"
                 >
                   {$_('settings.approve')}
                 </button>
                 <button
                   on:click={() => declineRequest(member.userId)}
-                  class="inline-flex items-center border border-gray-300 text-gray-700 text-xs font-medium px-3 py-1.5 rounded-lg hover:bg-gray-100 transition-colors duration-150 cursor-pointer"
+                  class="inline-flex items-center border border-border text-ink text-xs font-medium px-3 py-1.5 rounded-lg hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
                 >
                   {$_('settings.decline')}
                 </button>
@@ -235,7 +235,7 @@
     <!-- Members List -->
     <div class="space-y-3">
       {#each activeMembers as member}
-        <div class="bg-white border border-gray-200 rounded-xl p-4 flex items-center gap-4">
+        <div class="bg-surface border border-border rounded-xl p-4 flex items-center gap-4">
           <!-- Avatar -->
           <div class="w-10 h-10 rounded-full bg-gradient-to-br from-primary-400 to-primary-600 flex items-center justify-center text-white font-semibold text-sm flex-shrink-0 overflow-hidden">
             {#if member.user?.avatarUrl}
@@ -248,18 +248,18 @@
           <!-- Info -->
           <div class="flex-1 min-w-0">
             <div class="flex items-center gap-2">
-              <span class="font-medium text-gray-900 text-sm truncate">{member.user?.name || '—'}</span>
+              <span class="font-medium text-ink text-sm truncate">{member.user?.name || '—'}</span>
               {#if member.userId === currentUserId}
-                <span class="text-xs text-gray-400">{$_('settings.you')}</span>
+                <span class="text-xs text-ink-subtle">{$_('settings.you')}</span>
               {/if}
             </div>
             <div class="flex items-center gap-2 mt-0.5 flex-wrap">
-              <span class="text-xs text-gray-500 truncate">{member.user?.email || ''}</span>
+              <span class="text-xs text-ink-muted truncate">{member.user?.email || ''}</span>
               <span class="text-xs px-2 py-0.5 rounded-full font-medium {roleBadgeClass(member.role)}">{roleLabel(member.role)}</span>
               {#if member.joinedAt}
-                <span class="text-xs text-gray-400">{$_('settings.joined')} {formatDate(member.joinedAt)}</span>
+                <span class="text-xs text-ink-subtle">{$_('settings.joined')} {formatDate(member.joinedAt)}</span>
               {:else if member.invitedAt}
-                <span class="text-xs text-gray-400">{$_('settings.invited')} {formatDate(member.invitedAt)}</span>
+                <span class="text-xs text-ink-subtle">{$_('settings.invited')} {formatDate(member.invitedAt)}</span>
               {/if}
             </div>
           </div>
@@ -278,7 +278,7 @@
     </div>
 
     {#if activeMembers.length === 0}
-      <div class="text-center py-12 text-gray-500 text-sm">{$_('common.noData')}</div>
+      <div class="text-center py-12 text-ink-muted text-sm">{$_('common.noData')}</div>
     {/if}
   {/if}
 </div>
@@ -288,48 +288,48 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => (showInviteModal = false)}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-md">
-      <div class="p-6 border-b border-gray-100">
-        <h2 class="text-lg font-semibold text-gray-900">{$_('settings.inviteMember')}</h2>
-        <p class="text-sm text-gray-500 mt-1">{$_('settings.inviteMemberDesc')}</p>
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-md">
+      <div class="p-6 border-b border-border">
+        <h2 class="text-lg font-semibold text-ink">{$_('settings.inviteMember')}</h2>
+        <p class="text-sm text-ink-muted mt-1">{$_('settings.inviteMemberDesc')}</p>
       </div>
       <div class="p-6 space-y-4">
         {#if inviteError}
           <div class="bg-red-50 border border-red-200 text-red-700 rounded-lg px-3 py-2 text-sm">{inviteError}</div>
         {/if}
         <div>
-          <label for="invite-email" class="block text-xs font-medium text-gray-700 mb-1">{$_('settings.inviteEmail')}</label>
+          <label for="invite-email" class="block text-xs font-medium text-ink mb-1">{$_('settings.inviteEmail')}</label>
           <input
             id="invite-email"
             type="email"
             bind:value={inviteForm.email}
             placeholder="colleague@company.com"
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500"
           />
         </div>
         <div>
-          <label for="invite-role" class="block text-xs font-medium text-gray-700 mb-1">{$_('settings.inviteRole')}</label>
+          <label for="invite-role" class="block text-xs font-medium text-ink mb-1">{$_('settings.inviteRole')}</label>
           <select
             id="invite-role"
             bind:value={inviteForm.role}
-            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-white"
+            class="w-full px-3 py-2 border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-primary-500 bg-surface"
           >
             <option value="ADMIN">{$_('settings.admin')}</option>
             <option value="MEMBER">{$_('settings.member')}</option>
           </select>
         </div>
       </div>
-      <div class="p-6 border-t border-gray-100 flex gap-3">
+      <div class="p-6 border-t border-border flex gap-3">
         <button
           on:click={inviteMember}
           disabled={inviteSaving || !inviteForm.email}
-          class="flex-1 bg-primary-600 text-white py-2.5 rounded-lg font-medium text-sm hover:bg-primary-700 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+          class="flex-1 bg-brand text-white py-2.5 rounded-lg font-medium text-sm hover:brightness-110 transition-colors duration-150 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
         >
           {inviteSaving ? $_('common.loading') : $_('settings.inviteMember')}
         </button>
         <button
           on:click={() => (showInviteModal = false)}
-          class="px-5 py-2.5 border border-gray-300 rounded-lg text-sm font-medium hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
+          class="px-5 py-2.5 border border-border rounded-lg text-sm font-medium hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
         >
           {$_('common.cancel')}
         </button>
@@ -343,14 +343,14 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => (showLeaveModal = false)}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm p-6">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm p-6">
       <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-4">
         <svg class="w-6 h-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 9V5.25A2.25 2.25 0 0 0 13.5 3h-6a2.25 2.25 0 0 0-2.25 2.25v13.5A2.25 2.25 0 0 0 7.5 21h6a2.25 2.25 0 0 0 2.25-2.25V15m3 0 3-3m0 0-3-3m3 3H9" />
         </svg>
       </div>
-      <h2 class="text-lg font-semibold text-gray-900 mb-1">{$_('settings.leaveTeamConfirm')}</h2>
-      <p class="text-sm text-gray-500 mb-6">{$_('settings.leaveTeamDesc')}</p>
+      <h2 class="text-lg font-semibold text-ink mb-1">{$_('settings.leaveTeamConfirm')}</h2>
+      <p class="text-sm text-ink-muted mb-6">{$_('settings.leaveTeamDesc')}</p>
       <div class="flex gap-3">
         <button
           on:click={leaveOrganization}
@@ -360,7 +360,7 @@
         </button>
         <button
           on:click={() => (showLeaveModal = false)}
-          class="flex-1 border border-gray-300 rounded-lg text-sm py-2.5 font-medium hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
+          class="flex-1 border border-border rounded-lg text-sm py-2.5 font-medium hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
         >
           {$_('common.cancel')}
         </button>
@@ -374,15 +374,15 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => (removingMember = null)}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm p-6">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm p-6">
       <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-4">
         <svg class="w-6 h-6 text-red-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
         </svg>
       </div>
-      <h2 class="text-lg font-semibold text-gray-900 mb-1">{$_('settings.removeMemberConfirm')}</h2>
-      <p class="text-sm text-gray-500 mb-1">{removingMember.user?.name || removingMember.user?.email}</p>
-      <p class="text-sm text-gray-500 mb-6">{$_('settings.removeMemberDesc')}</p>
+      <h2 class="text-lg font-semibold text-ink mb-1">{$_('settings.removeMemberConfirm')}</h2>
+      <p class="text-sm text-ink-muted mb-1">{removingMember.user?.name || removingMember.user?.email}</p>
+      <p class="text-sm text-ink-muted mb-6">{$_('settings.removeMemberDesc')}</p>
       <div class="flex gap-3">
         <button
           on:click={removeMember}
@@ -392,7 +392,7 @@
         </button>
         <button
           on:click={() => (removingMember = null)}
-          class="flex-1 border border-gray-300 rounded-lg text-sm py-2.5 font-medium hover:bg-gray-50 transition-colors duration-150 cursor-pointer"
+          class="flex-1 border border-border rounded-lg text-sm py-2.5 font-medium hover:bg-surface-2 transition-colors duration-150 cursor-pointer"
         >
           {$_('common.cancel')}
         </button>

--- a/apps/web/src/routes/(app)/settings/webhooks/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/webhooks/+page.svelte
@@ -178,8 +178,8 @@
   <!-- Header -->
   <div class="flex items-center justify-between mb-6">
     <div>
-      <h1 class="text-2xl font-bold text-gray-900">{$_('webhooks.title')}</h1>
-      <p class="text-sm text-gray-500 mt-1">{$_('webhooks.subtitle')}</p>
+      <h1 class="text-2xl font-bold text-ink">{$_('webhooks.title')}</h1>
+      <p class="text-sm text-ink-muted mt-1">{$_('webhooks.subtitle')}</p>
     </div>
     <button
       on:click={openAddModal}
@@ -203,14 +203,14 @@
   {#if loading}
     <div class="space-y-3">
       {#each Array(3) as _}
-        <div class="bg-white rounded-xl border border-gray-200 p-5 animate-pulse">
+        <div class="bg-surface rounded-xl border border-border p-5 animate-pulse">
           <div class="flex items-center gap-4">
             <div class="flex-1 space-y-2">
               <div class="h-4 bg-gray-200 rounded w-2/3"></div>
-              <div class="h-3 bg-gray-100 rounded w-1/3"></div>
+              <div class="h-3 bg-surface-2 rounded w-1/3"></div>
               <div class="flex gap-2 mt-2">
-                <div class="h-5 bg-gray-100 rounded-full w-24"></div>
-                <div class="h-5 bg-gray-100 rounded-full w-20"></div>
+                <div class="h-5 bg-surface-2 rounded-full w-24"></div>
+                <div class="h-5 bg-surface-2 rounded-full w-20"></div>
               </div>
             </div>
             <div class="h-6 w-10 bg-gray-200 rounded-full"></div>
@@ -221,15 +221,15 @@
 
   <!-- Empty state -->
   {:else if webhooks.length === 0}
-    <div class="text-center py-16 bg-gray-50 rounded-xl border border-dashed border-gray-200">
+    <div class="text-center py-16 bg-surface-2 rounded-xl border border-dashed border-border">
       <div class="w-12 h-12 bg-indigo-50 rounded-full flex items-center justify-center mx-auto mb-3">
         <svg class="w-6 h-6 text-indigo-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
             d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" />
         </svg>
       </div>
-      <p class="text-gray-700 font-medium text-sm">{$_('webhooks.empty')}</p>
-      <p class="text-gray-400 text-xs mt-1 mb-4">{$_('webhooks.emptyDesc')}</p>
+      <p class="text-ink font-medium text-sm">{$_('webhooks.empty')}</p>
+      <p class="text-ink-subtle text-xs mt-1 mb-4">{$_('webhooks.emptyDesc')}</p>
       <button
         on:click={openAddModal}
         class="bg-indigo-600 text-white text-sm font-medium px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors cursor-pointer"
@@ -242,7 +242,7 @@
   {:else}
     <div class="space-y-3">
       {#each webhooks as webhook (webhook.id)}
-        <div class="bg-white rounded-xl border border-gray-200 p-5">
+        <div class="bg-surface rounded-xl border border-border p-5">
           <div class="flex items-start gap-4">
             <!-- Icon -->
             <div class="w-10 h-10 bg-indigo-50 rounded-lg flex items-center justify-center shrink-0 mt-0.5">
@@ -256,18 +256,18 @@
             <div class="flex-1 min-w-0">
               <!-- URL + status -->
               <div class="flex items-center gap-2 flex-wrap">
-                <span class="font-medium text-gray-900 text-sm truncate max-w-md">{webhook.url}</span>
+                <span class="font-medium text-ink text-sm truncate max-w-md">{webhook.url}</span>
                 {#if webhook.isActive}
                   <span class="text-xs px-2 py-0.5 bg-green-100 text-green-700 rounded-full font-medium">{$_('webhooks.active')}</span>
                 {:else}
-                  <span class="text-xs px-2 py-0.5 bg-gray-100 text-gray-500 rounded-full font-medium">{$_('webhooks.inactive')}</span>
+                  <span class="text-xs px-2 py-0.5 bg-surface-2 text-ink-muted rounded-full font-medium">{$_('webhooks.inactive')}</span>
                 {/if}
               </div>
 
               <!-- Events -->
               <div class="flex items-center gap-1.5 mt-2 flex-wrap">
                 {#each webhook.events as event}
-                  <span class="text-xs px-2 py-0.5 rounded-full font-medium {eventColors[event] ?? 'bg-gray-100 text-gray-600'}">
+                  <span class="text-xs px-2 py-0.5 rounded-full font-medium {eventColors[event] ?? 'bg-surface-2 text-ink-muted'}">
                     {$_(`webhooks.events.${event}`)}
                   </span>
                 {/each}
@@ -275,13 +275,13 @@
 
               <!-- Secret -->
               <div class="flex items-center gap-2 mt-2.5">
-                <span class="text-xs text-gray-400">{$_('webhooks.secret')}:</span>
-                <code class="text-xs font-mono text-gray-600 bg-gray-50 px-2 py-0.5 rounded">
+                <span class="text-xs text-ink-subtle">{$_('webhooks.secret')}:</span>
+                <code class="text-xs font-mono text-ink-muted bg-surface-2 px-2 py-0.5 rounded">
                   {visibleSecrets[webhook.id] ? webhook.secret : maskSecret(webhook.secret)}
                 </code>
                 <button
                   on:click={() => toggleSecretVisibility(webhook.id)}
-                  class="text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
+                  class="text-ink-subtle hover:text-gray-600 transition-colors cursor-pointer"
                   title={visibleSecrets[webhook.id] ? $_('webhooks.hideSecret') : $_('webhooks.showSecret')}
                 >
                   {#if visibleSecrets[webhook.id]}
@@ -300,7 +300,7 @@
                 </button>
                 <button
                   on:click={() => copySecret(webhook.secret, webhook.id)}
-                  class="text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
+                  class="text-ink-subtle hover:text-gray-600 transition-colors cursor-pointer"
                   title={$_('webhooks.copySecret')}
                 >
                   {#if copiedId === webhook.id}
@@ -318,7 +318,7 @@
 
               <!-- Last triggered -->
               <div class="mt-2">
-                <span class="text-xs text-gray-400">
+                <span class="text-xs text-ink-subtle">
                   {$_('webhooks.lastTriggered')}: {formatDate(webhook.lastTriggeredAt)}
                 </span>
               </div>
@@ -333,14 +333,14 @@
                 title={webhook.isActive ? $_('webhooks.deactivate') : $_('webhooks.activate')}
               >
                 <span
-                  class="inline-block h-4 w-4 transform rounded-full bg-white transition-transform shadow-sm {webhook.isActive ? 'translate-x-6' : 'translate-x-1'}"
+                  class="inline-block h-4 w-4 transform rounded-full bg-surface transition-transform shadow-sm {webhook.isActive ? 'translate-x-6' : 'translate-x-1'}"
                 ></span>
               </button>
 
               <!-- Edit -->
               <button
                 on:click={() => openEditModal(webhook)}
-                class="text-xs text-gray-600 border border-gray-200 px-3 py-1.5 rounded-lg hover:bg-gray-50 transition-colors cursor-pointer whitespace-nowrap"
+                class="text-xs text-ink-muted border border-border px-3 py-1.5 rounded-lg hover:bg-surface-2 transition-colors cursor-pointer whitespace-nowrap"
               >
                 {$_('common.edit')}
               </button>
@@ -370,15 +370,15 @@
     on:click|self={() => (showModal = false)}
     on:keydown={(e) => e.key === 'Escape' && (showModal = false)}
   >
-    <div class="bg-white rounded-2xl shadow-xl w-full max-w-md max-h-[90vh] overflow-y-auto">
+    <div class="bg-surface rounded-2xl shadow-xl w-full max-w-md max-h-[90vh] overflow-y-auto">
       <div class="p-6">
         <div class="flex items-center justify-between mb-5">
-          <h2 class="text-lg font-semibold text-gray-900">
+          <h2 class="text-lg font-semibold text-ink">
             {editingId ? $_('webhooks.editWebhook') : $_('webhooks.addWebhook')}
           </h2>
           <button
             on:click={() => (showModal = false)}
-            class="text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
+            class="text-ink-subtle hover:text-gray-600 transition-colors cursor-pointer"
           >
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
@@ -393,34 +393,34 @@
         <form on:submit|preventDefault={saveWebhook} class="space-y-4">
           <!-- URL -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-1">{$_('webhooks.endpointUrl')} *</label>
+            <label class="block text-sm font-medium text-ink mb-1">{$_('webhooks.endpointUrl')} *</label>
             <input
               type="url"
               bind:value={form.url}
               required
               placeholder="https://example.com/webhook"
-              class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              class="w-full border border-border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
             />
-            <p class="text-xs text-gray-400 mt-1">{$_('webhooks.urlHint')}</p>
+            <p class="text-xs text-ink-subtle mt-1">{$_('webhooks.urlHint')}</p>
           </div>
 
           <!-- Events -->
           <div>
-            <label class="block text-sm font-medium text-gray-700 mb-2">{$_('webhooks.selectEvents')} *</label>
+            <label class="block text-sm font-medium text-ink mb-2">{$_('webhooks.selectEvents')} *</label>
             <div class="space-y-2">
               {#each AVAILABLE_EVENTS as event}
-                <label class="flex items-center gap-3 p-2.5 rounded-lg border border-gray-100 hover:bg-gray-50 transition-colors cursor-pointer">
+                <label class="flex items-center gap-3 p-2.5 rounded-lg border border-border hover:bg-surface-2 transition-colors cursor-pointer">
                   <input
                     type="checkbox"
                     checked={form.events.includes(event)}
                     on:change={() => toggleEvent(event)}
-                    class="w-4 h-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                    class="w-4 h-4 rounded border-border text-indigo-600 focus:ring-indigo-500"
                   />
                   <div class="flex-1">
-                    <span class="text-sm text-gray-800 font-medium">{$_(`webhooks.events.${event}`)}</span>
-                    <p class="text-xs text-gray-400">{$_(`webhooks.eventDescs.${event}`)}</p>
+                    <span class="text-sm text-ink font-medium">{$_(`webhooks.events.${event}`)}</span>
+                    <p class="text-xs text-ink-subtle">{$_(`webhooks.eventDescs.${event}`)}</p>
                   </div>
-                  <span class="text-xs px-2 py-0.5 rounded-full {eventColors[event] ?? 'bg-gray-100 text-gray-600'}">
+                  <span class="text-xs px-2 py-0.5 rounded-full {eventColors[event] ?? 'bg-surface-2 text-ink-muted'}">
                     {event}
                   </span>
                 </label>
@@ -432,7 +432,7 @@
             <button
               type="button"
               on:click={() => (showModal = false)}
-              class="flex-1 border border-gray-200 text-gray-700 text-sm font-medium py-2.5 rounded-xl hover:bg-gray-50 transition-colors cursor-pointer"
+              class="flex-1 border border-border text-ink text-sm font-medium py-2.5 rounded-xl hover:bg-surface-2 transition-colors cursor-pointer"
             >
               {$_('common.cancel')}
             </button>
@@ -455,15 +455,15 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-no-static-element-interactions -->
   <div class="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4" on:click|self={() => (deletingId = null)}>
-    <div class="bg-white rounded-2xl shadow-2xl w-full max-w-sm p-6">
+    <div class="bg-surface rounded-2xl shadow-2xl w-full max-w-sm p-6">
       <div class="w-12 h-12 bg-red-50 rounded-xl flex items-center justify-center mb-4">
         <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6 text-red-500" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
           <path stroke-linecap="round" stroke-linejoin="round"
             d="M12 9v3.75m-9.303 3.376c-.866 1.5.217 3.374 1.948 3.374h14.71c1.73 0 2.813-1.874 1.948-3.374L13.949 3.378c-.866-1.5-3.032-1.5-3.898 0L2.697 16.126ZM12 15.75h.007v.008H12v-.008Z" />
         </svg>
       </div>
-      <h2 class="text-lg font-semibold text-gray-900 mb-1">{$_('webhooks.deleteConfirm')}</h2>
-      <p class="text-sm text-gray-500 mb-6">{$_('webhooks.deleteDesc')}</p>
+      <h2 class="text-lg font-semibold text-ink mb-1">{$_('webhooks.deleteConfirm')}</h2>
+      <p class="text-sm text-ink-muted mb-6">{$_('webhooks.deleteDesc')}</p>
       <div class="flex gap-3">
         <button
           on:click={() => deleteWebhook(deletingId)}
@@ -473,7 +473,7 @@
         </button>
         <button
           on:click={() => (deletingId = null)}
-          class="flex-1 px-5 py-2.5 border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors duration-150 text-sm cursor-pointer"
+          class="flex-1 px-5 py-2.5 border border-border rounded-lg hover:bg-surface-2 transition-colors duration-150 text-sm cursor-pointer"
         >
           {$_('common.cancel')}
         </button>

--- a/apps/web/src/routes/(app)/templates/+page.svelte
+++ b/apps/web/src/routes/(app)/templates/+page.svelte
@@ -160,8 +160,8 @@
 
 <div class="p-4 sm:p-6">
   <div class="mb-6">
-    <h1 class="text-2xl font-bold text-gray-900">{$_('nav.templates')}</h1>
-    <p class="text-gray-500 mt-1 text-sm">{$_('templates.subtitle')}</p>
+    <h1 class="text-2xl font-bold text-ink">{$_('nav.templates')}</h1>
+    <p class="text-ink-muted mt-1 text-sm">{$_('templates.subtitle')}</p>
   </div>
 
   <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
@@ -169,18 +169,18 @@
       <button
         on:click={() => useTemplate(t)}
         disabled={creating}
-        class="bg-white rounded-xl border border-gray-200 p-5 hover:shadow-md hover:border-primary-200 transition-all duration-200 cursor-pointer group flex flex-col text-left disabled:opacity-50 disabled:cursor-wait"
+        class="bg-surface rounded-xl border border-border p-5 hover:shadow-md hover:border-primary-200 transition-all duration-200 cursor-pointer group flex flex-col text-left disabled:opacity-50 disabled:cursor-wait"
       >
         <div class="w-11 h-11 {t.color} rounded-xl flex items-center justify-center mb-3 group-hover:scale-110 transition-transform duration-200">
           {@html t.icon}
         </div>
-        <h3 class="font-semibold text-gray-900 group-hover:text-primary-700 transition-colors duration-150">{$_(t.nameKey)}</h3>
-        <p class="text-xs text-gray-500 mt-1 mb-3 flex-1">{$_(t.descKey)}</p>
+        <h3 class="font-semibold text-ink group-hover:text-primary-700 transition-colors duration-150">{$_(t.nameKey)}</h3>
+        <p class="text-xs text-ink-muted mt-1 mb-3 flex-1">{$_(t.descKey)}</p>
         <div class="flex items-center justify-between">
           <span class="text-xs px-2 py-1 rounded-full {t.type === 'checklist' ? 'bg-green-50 text-green-700' : 'bg-blue-50 text-blue-700'}">
             {$_('templates.' + t.type)}
           </span>
-          <svg class="w-4 h-4 text-gray-300 group-hover:text-primary-500 group-hover:translate-x-0.5 transition-all duration-150" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+          <svg class="w-4 h-4 text-ink-subtle group-hover:text-primary-500 group-hover:translate-x-0.5 transition-all duration-150" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
             <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
           </svg>
         </div>
@@ -192,29 +192,29 @@
 <!-- Project picker modal -->
 {#if showProjectPicker}
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/40" on:click|self={() => { showProjectPicker = false; pendingTemplate = null; }} on:keydown={(e) => e.key === 'Escape' && (showProjectPicker = false, pendingTemplate = null)} role="dialog" tabindex="-1">
-    <div class="bg-white rounded-2xl shadow-xl p-6 max-w-sm w-full mx-4">
-      <h3 class="text-base font-semibold text-gray-900 mb-1">{$_('templates.pickProject')}</h3>
-      <p class="text-sm text-gray-500 mb-4">{$_('templates.pickProjectDesc')}</p>
+    <div class="bg-surface rounded-2xl shadow-xl p-6 max-w-sm w-full mx-4">
+      <h3 class="text-base font-semibold text-ink mb-1">{$_('templates.pickProject')}</h3>
+      <p class="text-sm text-ink-muted mb-4">{$_('templates.pickProjectDesc')}</p>
       <div class="flex flex-col gap-2 max-h-64 overflow-y-auto">
         {#each $projectsStore as project}
           <button
             on:click={() => pickProject(project.id)}
-            class="flex items-center gap-3 px-4 py-3 bg-gray-50 border border-gray-200 rounded-xl hover:border-primary-300 hover:bg-primary-50 transition-colors duration-150 text-left cursor-pointer group"
+            class="flex items-center gap-3 px-4 py-3 bg-surface-2 border border-border rounded-xl hover:border-primary-300 hover:bg-brand-subtle/10 transition-colors duration-150 text-left cursor-pointer group"
           >
-            <div class="w-9 h-9 bg-primary-100 rounded-lg flex items-center justify-center flex-shrink-0 text-primary-700 font-bold text-sm">
+            <div class="w-9 h-9 bg-primary-100 rounded-lg flex items-center justify-center flex-shrink-0 text-brand font-bold text-sm">
               {project.name.charAt(0)}
             </div>
             <div class="min-w-0">
-              <p class="text-sm font-medium text-gray-900 truncate">{project.name}</p>
+              <p class="text-sm font-medium text-ink truncate">{project.name}</p>
               {#if project.industry}
-                <p class="text-xs text-gray-400 truncate">{project.industry}</p>
+                <p class="text-xs text-ink-subtle truncate">{project.industry}</p>
               {/if}
             </div>
           </button>
         {/each}
       </div>
       <button on:click={() => { showProjectPicker = false; pendingTemplate = null; }}
-        class="mt-4 w-full px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors cursor-pointer">
+        class="mt-4 w-full px-4 py-2 text-sm font-medium text-ink bg-surface-2 rounded-lg hover:bg-gray-200 transition-colors cursor-pointer">
         {$_('aiChat.deleteChat.cancel')}
       </button>
     </div>
@@ -224,20 +224,20 @@
 <!-- AI Generation overlay -->
 {#if creating}
   <div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
-    <div class="bg-white rounded-2xl shadow-xl p-8 max-w-sm w-full mx-4 text-center">
+    <div class="bg-surface rounded-2xl shadow-xl p-8 max-w-sm w-full mx-4 text-center">
       <div class="w-16 h-16 bg-primary-100 rounded-2xl flex items-center justify-center mx-auto mb-4">
-        <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 text-primary-600 animate-pulse" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+        <svg xmlns="http://www.w3.org/2000/svg" class="w-8 h-8 text-brand animate-pulse" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
           <path stroke-linecap="round" stroke-linejoin="round" d="M9.813 15.904L9 18.75l-.813-2.846a4.5 4.5 0 00-3.09-3.09L2.25 12l2.846-.813a4.5 4.5 0 003.09-3.09L9 5.25l.813 2.846a4.5 4.5 0 003.09 3.09L15.75 12l-2.846.813a4.5 4.5 0 00-3.09 3.09zM18.259 8.715L18 9.75l-.259-1.035a3.375 3.375 0 00-2.455-2.456L14.25 6l1.036-.259a3.375 3.375 0 002.455-2.456L18 2.25l.259 1.035a3.375 3.375 0 002.456 2.456L21.75 6l-1.035.259a3.375 3.375 0 00-2.456 2.456z" />
         </svg>
       </div>
-      <h3 class="text-lg font-semibold text-gray-900 mb-2">{$_('templates.generating')}</h3>
-      <p class="text-sm text-gray-500 mb-4">{generatingMessage}</p>
+      <h3 class="text-lg font-semibold text-ink mb-2">{$_('templates.generating')}</h3>
+      <p class="text-sm text-ink-muted mb-4">{generatingMessage}</p>
       <div class="flex justify-center gap-1">
         <div class="w-2 h-2 bg-primary-400 rounded-full animate-bounce" style="animation-delay:0ms"></div>
         <div class="w-2 h-2 bg-primary-400 rounded-full animate-bounce" style="animation-delay:150ms"></div>
         <div class="w-2 h-2 bg-primary-400 rounded-full animate-bounce" style="animation-delay:300ms"></div>
       </div>
-      <p class="text-xs text-gray-400 mt-4">{$_('templates.generatingHint')}</p>
+      <p class="text-xs text-ink-subtle mt-4">{$_('templates.generatingHint')}</p>
     </div>
   </div>
 {/if}

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -1,27 +1,59 @@
 /** @type {import('tailwindcss').Config} */
+const iris = {
+  50: '#EEF0FF',
+  100: '#E0E2FF',
+  200: '#C7C8FF',
+  300: '#A5A4FF',
+  400: '#8A82FB',
+  500: '#6E56F0',
+  600: '#5B3DE8',
+  700: '#4B2FC4',
+  800: '#3C2599',
+  900: '#2E1B73',
+  950: '#1C0F47',
+};
+
 export default {
   darkMode: 'class',
   content: ['./src/**/*.{html,js,svelte,ts}'],
   theme: {
     extend: {
       colors: {
-        primary: {
-          50: '#f5f3ff',
-          100: '#ede9fe',
-          200: '#ddd6fe',
-          300: '#c4b5fd',
-          400: '#a78bfa',
-          500: '#8b5cf6',
-          600: '#7c3aed',
-          700: '#6d28d9',
-          800: '#5b21b6',
-          900: '#4c1d95',
-          950: '#2e1065',
+        // Brand ramp
+        iris,
+        // `primary` aliased to the iris ramp during migration so any
+        // un-migrated `primary-*` utility still renders on-brand.
+        primary: iris,
+        // Semantic tokens (flip per theme via CSS vars in app.css)
+        canvas: 'rgb(var(--canvas) / <alpha-value>)',
+        surface: {
+          DEFAULT: 'rgb(var(--surface) / <alpha-value>)',
+          2: 'rgb(var(--surface-2) / <alpha-value>)',
         },
+        border: 'rgb(var(--border) / <alpha-value>)',
+        'border-strong': 'rgb(var(--border-strong) / <alpha-value>)',
+        ink: {
+          DEFAULT: 'rgb(var(--text) / <alpha-value>)',
+          muted: 'rgb(var(--text-muted) / <alpha-value>)',
+          subtle: 'rgb(var(--text-subtle) / <alpha-value>)',
+        },
+        brand: {
+          DEFAULT: 'rgb(var(--brand) / <alpha-value>)',
+          fg: 'rgb(var(--brand-fg) / <alpha-value>)',
+          subtle: 'rgb(var(--brand-subtle) / <alpha-value>)',
+          'subtle-fg': 'rgb(var(--brand-subtle-fg) / <alpha-value>)',
+        },
+        ring: 'rgb(var(--ring) / <alpha-value>)',
+        ok: 'rgb(var(--ok) / <alpha-value>)',
+        warn: 'rgb(var(--warn) / <alpha-value>)',
+        bad: 'rgb(var(--bad) / <alpha-value>)',
       },
       fontFamily: {
         display: ['"Space Grotesk"', 'system-ui', 'sans-serif'],
-        sans: ['"DM Sans"', 'system-ui', 'sans-serif'],
+        sans: ['"Inter"', 'system-ui', 'sans-serif'],
+      },
+      boxShadow: {
+        glow: '0 0 0 1px rgb(var(--brand) / 0.12), 0 18px 50px -22px rgb(var(--brand) / 0.5)',
       },
     },
   },

--- a/docs/superpowers/plans/2026-06-27-ui-redesign-iris.md
+++ b/docs/superpowers/plans/2026-06-27-ui-redesign-iris.md
@@ -1,0 +1,222 @@
+# UI Redesign "Iris" Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reskin the logged-in web app to a bold, modern, dark-first enterprise look ("Iris" violet-indigo) with a genuinely complete dual light/dark theme and an unambiguous two-mode (organization ↔ project) navigation.
+
+**Architecture:** Introduce semantic CSS-variable design tokens (light + dark) exposed through Tailwind, migrate ~1900 hardcoded neutral/`primary` utilities to those tokens via a reviewed codemod, extract repeated patterns into `@layer components` primitives, then rebuild the app shell (Sidebar/Header/ProjectPicker/layout) around a contextual two-mode model and polish the two flagship pages (Dashboard, Project Overview).
+
+**Tech Stack:** SvelteKit 2, TailwindCSS 3 (`darkMode: 'class'`), `@tailwindcss/forms` + `/typography`, svelte-i18n (en/pl/ru).
+
+## Global Constraints
+
+- Spec: `docs/superpowers/specs/2026-06-27-ui-redesign-iris-design.md` is the source of truth.
+- Tailwind text color key is **`ink`** (`text-ink`, `text-ink-muted`, `text-ink-subtle`). CSS vars stay `--text*`.
+- Brand ramp name is **`iris`** (50→950, hexes in spec §1.2). `primary` is aliased to `iris.DEFAULT` during migration — do not delete `primary` until the codemod is verified complete.
+- Tokens stored as space-separated RGB channel triplets; Tailwind references via `rgb(var(--x) / <alpha-value>)`.
+- Fonts: **Space Grotesk** (display) + **Inter** (body). Remove DM Sans entirely.
+- Dark is the **default** interior theme unless `localStorage.theme === 'light'`.
+- Org-level rollups (Analytics, Finances) are **kept**, org-mode only.
+- AI Chat + Templates appear in **both** scopes.
+- GitHub artifacts (commits/PRs) in English. Branch: `redesign/iris-ui` (already created off `origin/development`).
+- Out of scope: `(auth)` group + landing redesign, bespoke per-page polish beyond shell/flagship, any backend change.
+- Verify each phase with `pnpm --filter web build` and `pnpm --filter web lint`; visual walkthrough in both themes.
+
+---
+
+## Phase 1 — Foundation (tokens, fonts, primitives, codemod)
+
+### Task 1: Semantic design tokens + font cleanup in `app.css`
+
+**Files:**
+- Modify: `apps/web/src/app.css`
+
+**Interfaces:**
+- Produces: CSS custom properties on `:root` (light) and `.dark` (dark): `--canvas --surface --surface-2 --border --border-strong --text --text-muted --text-subtle --brand --brand-fg --brand-subtle --brand-subtle-fg --ring --ok --warn --bad`, all as space-separated RGB triplets. Consumed by Task 2 (Tailwind) and Task 4 (primitives).
+
+- [ ] **Step 1:** Replace the Google Fonts `@import` (line 2) with a single import for `Space Grotesk` (400;500;600;700) + `Inter` (400;500;600;700). Remove the DM Sans family.
+- [ ] **Step 2:** In `@layer base { :root { … } }` replace the existing shadcn-style HSL vars with the light token triplets from spec §1.1. Add a `.dark { … }` block with the dark triplets from spec §1.1. Keep the `prefers-reduced-motion` block.
+- [ ] **Step 3:** Update the global `body` rule: `font-family: 'Inter'`, `background-color: rgb(var(--canvas))`, `color: rgb(var(--text))`. Update the `* { border-color }` rule to `rgb(var(--border))`. Update `h1,h2,h3,h4` to Space Grotesk (unchanged). Update `.prose` colors to use `rgb(var(--text-muted))` / heading `rgb(var(--text))`.
+- [ ] **Step 4:** Update `.custom-scroll` thumb colors to `rgb(var(--border-strong))` / hover `rgb(var(--text-subtle))` so the scrollbar works in dark.
+- [ ] **Step 5: Verify:** `cd apps/web && pnpm build` succeeds. (No utilities migrated yet — page will look mixed; that's expected.) Commit: `style(web): add Iris semantic design tokens + standardize fonts`.
+
+### Task 2: Tailwind config — iris ramp + semantic colors + fonts
+
+**Files:**
+- Modify: `apps/web/tailwind.config.js`
+
+**Interfaces:**
+- Consumes: CSS vars from Task 1.
+- Produces: utilities `bg-canvas bg-surface bg-surface-2 border-border text-ink text-ink-muted text-ink-subtle bg-brand text-brand-fg bg-brand-subtle text-brand-subtle-fg ring-ring bg-ok bg-warn bg-bad` + `iris-50…950` + `primary` alias. Consumed by Tasks 4–11 and the codemod (Task 5).
+
+- [ ] **Step 1:** In `theme.extend.colors`, replace `primary` block with: the full `iris` ramp (hexes from spec §1.2); semantic keys mapping to `rgb(var(--token) / <alpha-value>)` per spec §1.3 (`canvas`, `surface`, `surface-2`, `border`, `ink{DEFAULT,muted,subtle}`, `brand{DEFAULT,fg,subtle,subtle-fg}`, `ring`, `ok`, `warn`, `bad`); and `primary: colors-of-iris` alias (set `primary` to the same ramp object so `primary-600` etc. still resolve).
+- [ ] **Step 2:** `fontFamily`: `display: ['"Space Grotesk"', …]`, `sans: ['"Inter"', …]`. Remove DM Sans.
+- [ ] **Step 3:** Add `boxShadow.glow: '0 0 0 1px rgb(var(--brand) / 0.12), 0 18px 50px -22px rgb(var(--brand) / 0.5)'` and `borderRadius` tokens (`sm:8px DEFAULT:10px lg:12px xl:16px`).
+- [ ] **Step 4: Verify:** `pnpm --filter web build` succeeds. Sanity: a throwaway `<div class="bg-surface text-ink">` resolves (grep the generated CSS or just trust build). Commit: `feat(web): expose Iris tokens + iris ramp via Tailwind`.
+
+### Task 3: `app.html` — font link cleanup + dark-by-default bootstrap
+
+**Files:**
+- Modify: `apps/web/src/app.html`
+
+- [ ] **Step 1:** Remove the standalone `<link … Inter …>` (line 10) — fonts now load via `app.css`. Keep the two `preconnect` links.
+- [ ] **Step 2:** Change the inline theme bootstrap so the interior defaults to **dark**: `var theme = localStorage.getItem('theme'); if (theme !== 'light') document.documentElement.classList.add('dark');` (i.e. dark unless explicitly light).
+- [ ] **Step 3: Verify:** `pnpm --filter web build` succeeds; load `/dashboard` in dev → `<html>` has `dark` class on a fresh profile. Commit: `feat(web): dark-by-default interior + consolidate font loading`.
+
+### Task 4: Component primitives in `@layer components`
+
+**Files:**
+- Modify: `apps/web/src/app.css` (append a `@layer components { … }` block)
+
+**Interfaces:**
+- Produces CSS classes consumed by Tasks 6–11 and available app-wide: `.btn .btn-primary .btn-secondary .btn-ghost .btn-danger`, `.card`, `.kpi .kpi-feature`, `.badge .badge-ok .badge-warn .badge-bad .badge-brand`, `.input .select .textarea`, `.modal-overlay .modal-panel`, `.nav-item` (+`.is-active`), `.glow-brand`.
+
+- [ ] **Step 1:** Write the primitives using `@apply` against the new tokens. Examples (use these verbatim as the baseline, refine spacing to match mockups):
+  - `.btn { @apply inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 text-sm font-semibold transition-colors duration-150 cursor-pointer; }`
+  - `.btn-primary { @apply bg-brand text-brand-fg shadow-glow hover:brightness-110; }`
+  - `.btn-secondary { @apply bg-surface text-ink border border-border hover:bg-surface-2; }`
+  - `.btn-ghost { @apply text-ink-muted hover:bg-surface-2 hover:text-ink; }`
+  - `.btn-danger { @apply bg-bad text-white hover:brightness-110; }`
+  - `.card { @apply bg-surface border border-border rounded-lg; }`
+  - `.kpi { @apply card p-4; }` ; `.kpi-feature { @apply rounded-lg p-4 text-white; background: linear-gradient(135deg, rgb(var(--brand)), rgb(var(--iris-700, 75 47 196))); }` (use explicit iris-700 triplet `75 47 196`)
+  - `.badge { @apply inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs font-semibold; }` + `.badge-ok { @apply bg-ok/15 text-ok; }` etc., `.badge-brand { @apply bg-brand-subtle/15 text-brand-subtle-fg; }`
+  - `.input,.select,.textarea { @apply w-full rounded-lg bg-surface border border-border text-ink placeholder:text-ink-subtle px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring/50; }`
+  - `.modal-overlay { @apply fixed inset-0 bg-black/50 dark:bg-black/70 flex items-center justify-center z-50 p-4; }` ; `.modal-panel { @apply bg-surface border border-border rounded-xl shadow-xl w-full; }`
+  - `.nav-item { @apply flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium text-ink-muted hover:bg-surface-2 hover:text-ink transition-colors duration-150 cursor-pointer; }` ; `.nav-item.is-active { @apply bg-brand-subtle/15 text-brand-subtle-fg font-semibold; box-shadow: inset 2px 0 0 rgb(var(--brand)); }`
+  - `.glow-brand { box-shadow: 0 8px 20px -8px rgb(var(--brand) / 0.6); }`
+- [ ] **Step 2: Verify:** `pnpm --filter web build` succeeds. Commit: `feat(web): add Iris component primitives (btn/card/kpi/badge/input/modal/nav)`.
+
+### Task 5: Codemod — migrate hardcoded utilities to tokens
+
+**Files:**
+- Create: `apps/web/scripts/iris-codemod.mjs` (throwaway, committed for traceability)
+- Modify: `apps/web/src/**/*.svelte` (excluding `(auth)/**` and the already-hand-edited shell files if done after Phase 2 — run this BEFORE Phase 2 so the shell starts clean)
+
+**Interfaces:**
+- Consumes: token utilities from Task 2.
+- Produces: app-wide token usage. No new exports.
+
+- [ ] **Step 1:** Write `iris-codemod.mjs` that walks `apps/web/src/routes/(app)` + `apps/web/src/lib` (skip `routes/(auth)`, `routes/+layout.svelte`, `routes/+page.svelte`, `auth/callback`) and applies ordered, word-boundary-safe replacements for these exact class tokens (longest-first to avoid partial hits):
+
+  | From | To |
+  |---|---|
+  | `bg-white` | `bg-surface` |
+  | `bg-gray-100` | `bg-surface-2` |
+  | `bg-gray-50` | `bg-surface-2` |
+  | `hover:bg-gray-50` | `hover:bg-surface-2` |
+  | `hover:bg-gray-100` | `hover:bg-surface-2` |
+  | `text-gray-900` | `text-ink` |
+  | `text-gray-800` | `text-ink` |
+  | `text-gray-700` | `text-ink` |
+  | `text-gray-600` | `text-ink-muted` |
+  | `text-gray-500` | `text-ink-muted` |
+  | `text-gray-400` | `text-ink-subtle` |
+  | `text-gray-300` | `text-ink-subtle` |
+  | `border-gray-200` | `border-border` |
+  | `border-gray-100` | `border-border` |
+  | `border-gray-300` | `border-border` |
+  | `divide-gray-200` | `divide-border` |
+  | `divide-gray-100` | `divide-border` |
+  | `bg-primary-600` | `bg-brand` |
+  | `hover:bg-primary-700` | `hover:brightness-110` |
+  | `text-primary-600` | `text-brand` |
+  | `text-primary-700` | `text-brand` |
+  | `bg-primary-50` | `bg-brand-subtle/10` |
+  | `text-white` (only inside `bg-brand`/`bg-primary` buttons) | leave as `text-white` (brand-fg is white) |
+
+  Match within `class="…"`, `class:…`, and template-literal class strings. Replace as whole space-delimited tokens (regex `(?<=^|[\s"'\`{])TOKEN(?=$|[\s"'\`}])`).
+- [ ] **Step 2:** Run `node apps/web/scripts/iris-codemod.mjs`. It prints a per-file change count.
+- [ ] **Step 3: Review the diff** (`git diff --stat` then spot-read 8-10 varied files). Hand-fix:
+  - `bg-gray-50` that is a full-page wrapper → change to `bg-canvas` (e.g. page roots). The codemod defaults to `surface-2`; correct page-level ones by hand.
+  - Remove now-redundant or conflicting `dark:*` variants the codemod left behind (search `dark:bg-`, `dark:text-` in changed files; tokens already handle dark, so most `dark:` neutral variants should be deleted).
+  - Status/semantic colors using `green/amber/red/emerald/violet/blue` left intact (intentional) — only neutrals + `primary` were targeted.
+- [ ] **Step 4: Verify:** `pnpm --filter web build` + `pnpm --filter web lint` pass. Visual: open `/dashboard`, `/settings/organization`, `/projects` in **both** themes — no white-on-white or black-on-black, no unreadable text. Note remaining rough pages (they get the shell/flagship passes or a later polish).
+- [ ] **Step 5: Commit:** `refactor(web): migrate hardcoded utilities to Iris semantic tokens (codemod)`.
+
+---
+
+## Phase 2 — App shell + navigation IA
+
+### Task 6: i18n keys for the new navigation
+
+**Files:**
+- Modify: `packages/i18n/src/locales/en.json`, `pl.json`, `ru.json` (use the i18n-translator agent or edit all three)
+
+**Interfaces:**
+- Produces keys consumed by Tasks 7–8: `nav.allProjects`, `nav.organization`, `nav.project`, `nav.workspace`, `nav.rollups`, `nav.thisProject`, `nav.switchProject`, `nav.billingTeam` (if combining). Reuse existing `nav.*` where present.
+
+- [ ] **Step 1:** Add the keys to all three locales (EN baseline; PL/RU translated). EN values: `allProjects:"All projects"`, `organization:"Organization"`, `project:"Project"`, `workspace:"Workspace"`, `rollups:"All projects · rollups"`, `thisProject:"This project"`, `switchProject:"Switch project"`.
+- [ ] **Step 2: Verify:** `pnpm --filter web build`. Commit: `i18n: add navigation context strings (en/pl/ru)`.
+
+### Task 7: Sidebar — contextual two-mode rebuild
+
+**Files:**
+- Modify: `apps/web/src/lib/components/layout/Sidebar.svelte`
+
+**Interfaces:**
+- Consumes: `currentProjectStore`, `organizationIdStore`, `currentUser`, `$page`, i18n keys (Task 6), primitives `.nav-item.is-active` (Task 4).
+
+- [ ] **Step 1:** Derive `inProject = !!$currentProjectStore`. Render **two branches**:
+  - **Org mode** (`!inProject`): context chip "Organization" (amber-tinted, org name); group `Workspace` = Dashboard (with "all projects" hint), Projects, AI Chat, Templates; group `nav.rollups` = Analytics, Finances (org `href`s `/analytics`, `/finances`); group Settings = existing `settingsLinks`.
+  - **Project mode** (`inProject`): a `← All projects` link (calls the same clear-project action as ProjectPicker `selectOrg`); context chip "Project" (iris-tinted, project name) that toggles the project dropdown; group `nav.thisProject` = Overview, Content, Checklists, Documents, Campaigns, Email, Analytics, AI Chat, Templates (all prefixed `/projects/:id` except AI Chat/Templates which carry project context — see Task 9); collapsible `Advanced` = SEO, Competitors, Experiments, Sequences, Calendar; group Settings = Project settings only.
+- [ ] **Step 2:** Replace inline active/inactive class ternaries with `.nav-item` + `:class={{ 'is-active': isActive(...) }}`. Keep the existing `isActive`/`getMarketingSegment` logic, multi-org switcher, user/logout block, theme toggle, help link.
+- [ ] **Step 3:** Restyle logo block, context chips, and group labels to the mockup (`nav-ia-v1.html`): logo gradient + `.glow-brand`, chips per spec §5.1 colors.
+- [ ] **Step 4: Verify:** build + lint pass. Manually: no project → only org items; pick a project → menu transforms, "← All projects" returns to org mode; both confusions from the brief gone. Check light + dark. Commit: `feat(web): contextual two-mode sidebar (org ↔ project)`.
+
+### Task 8: Header, ProjectPicker, layout canvas
+
+**Files:**
+- Modify: `apps/web/src/lib/components/layout/Header.svelte`, `apps/web/src/lib/components/layout/ProjectPicker.svelte`, `apps/web/src/routes/(app)/+layout.svelte`
+
+- [ ] **Step 1 (layout):** Change root `bg-gray-50` → `bg-canvas`; loading spinner border to `border-brand`; help FAB to `.btn-primary`-ish (`bg-brand text-brand-fg glow-brand`). Ensure `<main>` inherits canvas.
+- [ ] **Step 2 (Header):** Restyle to tokens (`bg-surface border-border`); language switcher pills use `bg-surface-2` + active `bg-surface text-brand`; keep ProjectPicker mounted (it is the mode switch). Avatar gradient stays.
+- [ ] **Step 3 (ProjectPicker):** Replace hardcoded `indigo-*`/`gray-*` with tokens (`bg-brand-subtle/15 text-brand-subtle-fg` for active project state, `bg-surface-2 text-ink-muted` for org state). Keep all navigation logic (`selectOrg`, `selectProject`, `orgSections`) unchanged.
+- [ ] **Step 4: Verify:** build + lint; header/picker correct in both themes; switching context still routes correctly. Commit: `feat(web): theme header, project picker, app canvas to Iris tokens`.
+
+### Task 9: AI Chat + Templates available in project mode
+
+**Files:**
+- Modify: `apps/web/src/lib/components/layout/Sidebar.svelte` (project-mode links from Task 7)
+
+**Interfaces:**
+- Consumes: existing `/ai-chat` + `/templates` pages already restore `currentProjectStore` from their internal scope picker.
+
+- [ ] **Step 1:** In project mode, render AI Chat → `/ai-chat` and Templates → `/templates` as normal links, but `on:click` set `currentProjectStore` to the active project (it already is) so the pages open pre-scoped. (No new routes.) Confirm the pages honor a pre-set `currentProjectStore`; if a page resets it, pass `?projectId=:id` and read it on mount.
+- [ ] **Step 2: Verify:** from inside a project, AI Chat opens scoped to that project; from org mode it opens with the scope picker. Commit: `feat(web): surface AI Chat + Templates in project scope`.
+
+---
+
+## Phase 3 — Flagship pages
+
+### Task 10: Dashboard (all-projects) + DashboardKpiCards
+
+**Files:**
+- Modify: `apps/web/src/lib/components/DashboardKpiCards.svelte`, `apps/web/src/routes/(app)/dashboard/+page.svelte`, `apps/web/src/lib/components/ProjectCardStats.svelte`
+
+- [ ] **Step 1 (KpiCards):** Convert the 4 KPI tiles to `.kpi` primitive; keep colored icon chips but map to token-tinted backgrounds (`bg-brand-subtle/12 text-brand` for the brand one, `bg-ok/12 text-ok`, `bg-warn/12 text-warn`, `bg-brand-subtle/12`). Period segmented control → token styling (active `bg-brand text-brand-fg`). `trendClass` → `text-ok`/`text-bad`/`text-ink-subtle`. Skeletons `bg-surface-2`.
+- [ ] **Step 2 (dashboard page):** Page title to `text-2xl font-bold text-ink` Space Grotesk; New/Import buttons → `.btn-primary` / `.btn-secondary`; project cards → `.card` with `hover:border-brand/40 hover:shadow-glow`; status badge → `.badge-ok`/`.badge` neutral; empty state icon block → `bg-brand-subtle/12 text-brand`; import modal → `.modal-overlay`/`.modal-panel` + `.btn-*`.
+- [ ] **Step 3 (ProjectCardStats):** Migrate to tokens.
+- [ ] **Step 4: Verify:** build + lint; dashboard matches `direction-v1.html` light shell + dark; both themes. Commit: `feat(web): redesign dashboard + KPI cards (Iris)`.
+
+### Task 11: Project Overview hero + cards
+
+**Files:**
+- Modify: `apps/web/src/routes/(app)/projects/[id]/overview/+page.svelte`
+
+- [ ] **Step 1:** Add a **`.kpi-feature` hero block** (the "confident color block" from the mockup) for the project's headline metric; convert remaining KPI/stat cards to `.kpi`; getting-started steps, quick-actions, and recent-activity list to `.card` + `.nav-item`/`.badge`. Keep all existing data logic and i18n keys.
+- [ ] **Step 2: Verify:** build + lint; overview matches the dark mockup hero; light + dark; project-switch still refetches (existing guarded watcher intact). Commit: `feat(web): redesign project overview with hero KPI (Iris)`.
+
+---
+
+## Finalization
+
+- [ ] **Full build + lint:** `pnpm --filter web build && pnpm --filter web lint`.
+- [ ] **Test suite:** `cd apps/web && pnpm test` — update only snapshots/selectors the redesign legitimately changed.
+- [ ] **Accessibility sweep:** contrast ≥4.5:1 for `ink`/`ink-muted` over `canvas`/`surface` (both themes); visible `ring-ring` focus; icon-only buttons keep `aria-label`/`title`; reduced-motion block intact.
+- [ ] **Responsive:** 375 / 768 / 1024 / 1440 — sidebar drawer + backdrop still work.
+- [ ] **Create GitHub issue + PR** (English) per project convention; PR body links the spec + plan; target `development`.
+
+## Self-Review notes (coverage vs spec)
+
+- Spec §1 tokens → Tasks 1–2. §2 type/shape → Tasks 1–2. §3 primitives → Task 4. §4 codemod → Task 5. §5 nav IA → Tasks 6–9. §5.3 dark-default → Task 3. §6 phases → phase headers. §7 verification → Finalization. §8 risks: `primary` alias (Task 2), forms styling (Task 4 `.input`), codemod over-reach (Task 5 Step 3 review), dark-default returning users (Task 3 `!== 'light'`).
+- Deferred per spec non-goals: per-page bespoke polish (pages get Task 5 cascade only), `(auth)`/landing, backend.

--- a/docs/superpowers/specs/2026-06-27-ui-redesign-iris-design.md
+++ b/docs/superpowers/specs/2026-06-27-ui-redesign-iris-design.md
@@ -1,0 +1,234 @@
+# UI Redesign — "Iris" / Bold Modern, dark-first
+
+**Date:** 2026-06-27
+**Status:** Approved design — ready for implementation planning
+**Scope owner:** Web (`apps/web`)
+
+## Goal
+
+Move the logged-in app from a generic "indie SaaS 2021" look (soft purple gradients, inconsistent type, half-wired dark mode) to a **bold, modern, enterprise-grade** visual identity for 2026: a refined violet-indigo brand ("Iris"), high-contrast surfaces, large display headlines, and a **genuinely finished dual light + dark theme** with dark as the default interior. Also fix the navigation information architecture so organization vs. project context is always unambiguous.
+
+This is a **foundation + app-shell + flagship-pages** redesign. Because the app is token- and component-driven, a foundation-level change cascades to most of the ~50 pages. Bespoke hand-polish of every individual feature page is explicitly a later pass.
+
+## Locked decisions
+
+| Decision | Choice |
+|---|---|
+| Aesthetic direction | Bold modern, deep brand color, high contrast, big headlines |
+| Brand accent | Refine (not replace) the violet/indigo identity → "Iris" |
+| Theme strategy | Full dual light + dark, built now via semantic tokens |
+| Default interior theme | **Dark** |
+| Navigation | Contextual two-mode sidebar (Organization ↔ Project) |
+| Org-level rollups | **Kept** (Analytics, Finances across all projects) |
+| AI Chat & Templates | Available in **both** org and project scopes |
+| Project-menu reorder/rename | Deferred — revisit after the redesign lands |
+
+## Non-goals (this spec)
+
+- Hand-polishing every individual feature page (Content list, SEO detail, Email, etc.). They receive the token cascade + codemod and will look consistent, but bespoke per-page polish is a separate effort.
+- Public marketing/landing page and auth screens (`(auth)` group) redesign — separate spec.
+- Any backend (`apps/api`, `apps/ai-agent`) or schema changes.
+- New features. This is purely visual + IA.
+
+---
+
+## 1. Design tokens
+
+The core architectural move: stop hardcoding `bg-white` / `bg-gray-50` / `text-gray-900` / `bg-primary-600` and route everything through **semantic CSS custom properties** that flip between light and dark via the existing `.dark` class on `<html>`.
+
+### 1.1 Token storage format
+
+Tokens are stored as **space-separated RGB channel triplets** so Tailwind's alpha modifiers (`bg-surface/80`, `border-default/50`) work:
+
+```css
+:root {            /* light */
+  --canvas: 246 246 251;       /* #F6F6FB */
+  --surface: 255 255 255;      /* #FFFFFF */
+  --surface-2: 243 243 248;    /* #F3F3F8 */
+  --border: 236 236 244;       /* #ECECF4 */
+  --border-strong: 221 221 232;
+  --text: 26 23 38;            /* #1A1726 */
+  --text-muted: 116 112 138;   /* #74708A */
+  --text-subtle: 152 147 168;  /* #9893A8 */
+  --brand: 91 61 232;          /* iris-600 #5B3DE8 (action) */
+  --brand-fg: 255 255 255;
+  --brand-subtle: 238 240 255; /* iris-50  (active nav/chips bg) */
+  --brand-subtle-fg: 75 47 196;/* iris-700 (active nav/chips text) */
+  --ring: 110 86 240;          /* iris-500 focus ring */
+  --ok: 22 163 74; --warn: 245 158 11; --bad: 229 72 77;
+}
+.dark {            /* dark (default interior) */
+  --canvas: 11 11 20;          /* #0B0B14 */
+  --surface: 19 19 30;         /* #13131E */
+  --surface-2: 22 22 31;       /* #16161F */
+  --border: 32 32 46;          /* #20202E */
+  --border-strong: 42 42 58;
+  --text: 237 237 246;         /* #EDEDF6 */
+  --text-muted: 148 148 174;   /* #9494AE */
+  --text-subtle: 108 108 134;  /* #6C6C86 */
+  --brand: 110 86 240;         /* iris-500 (brighter for dark) */
+  --brand-fg: 255 255 255;
+  --brand-subtle: 110 86 240;  /* used at low alpha, e.g. bg-brand-subtle/15 */
+  --brand-subtle-fg: 201 194 255;
+  --ring: 138 130 251;
+  --ok: 74 222 128; --warn: 251 191 36; --bad: 248 113 113;
+}
+```
+
+### 1.2 Brand ramp — "Iris" (refined violet-indigo)
+
+Replaces the current `primary` ramp. Slightly cooler/deeper than the existing pinkish `#8b5cf6`.
+
+| Step | Hex | Step | Hex |
+|---|---|---|---|
+| 50 | `#EEF0FF` | 500 | `#6E56F0` |
+| 100 | `#E0E2FF` | 600 | `#5B3DE8` |
+| 200 | `#C7C8FF` | 700 | `#4B2FC4` |
+| 300 | `#A5A4FF` | 800 | `#3C2599` |
+| 400 | `#8A82FB` | 900 | `#2E1B73` |
+| | | 950 | `#1C0F47` |
+
+Keep `primary` as an **alias** of the iris ramp during migration so any un-migrated `primary-*` utility still renders on-brand instead of breaking.
+
+### 1.3 Tailwind config exposure
+
+`tailwind.config.js` `theme.extend.colors` maps semantic names to the channel vars, e.g.:
+
+```js
+canvas:  'rgb(var(--canvas) / <alpha-value>)',
+surface: 'rgb(var(--surface) / <alpha-value>)',
+'surface-2': 'rgb(var(--surface-2) / <alpha-value>)',
+border:  'rgb(var(--border) / <alpha-value>)',
+ink:     { DEFAULT: 'rgb(var(--text) / <alpha-value>)', muted: 'rgb(var(--text-muted) / <alpha-value>)', subtle: 'rgb(var(--text-subtle) / <alpha-value>)' },
+brand:   { DEFAULT: 'rgb(var(--brand) / <alpha-value>)', fg: 'rgb(var(--brand-fg) / <alpha-value>)', subtle: 'rgb(var(--brand-subtle) / <alpha-value>)', 'subtle-fg': 'rgb(var(--brand-subtle-fg) / <alpha-value>)' },
+iris:    { 50:'#EEF0FF', /* …full ramp… */ 950:'#1C0F47' },
+primary: '/* alias → iris during migration */',
+ok: 'rgb(var(--ok) / <alpha-value>)', warn: 'rgb(var(--warn) / <alpha-value>)', bad: 'rgb(var(--bad) / <alpha-value>)',
+```
+
+Yields utilities like `bg-canvas`, `bg-surface`, `text-ink`, `text-ink-muted`, `border-border`, `bg-brand text-brand-fg`, `bg-ok/15 text-ok`.
+
+> **Naming decision (committed):** the text color key is **`ink`** (`text-ink`, `text-ink-muted`, `text-ink-subtle`), not `text` — `text-text` is too awkward. CSS vars stay named `--text*`; only the Tailwind key differs. The whole codebase uses `ink`.
+
+## 2. Typography & shape
+
+- **Standardize fonts.** Display = **Space Grotesk** (headings `h1–h4`, page titles, KPI numbers). Body/UI = **Inter**. Remove **DM Sans** entirely (currently declared as `sans` but the look is inconsistent and `app.html` separately loads Inter).
+- `app.css`: single Google Fonts import for Space Grotesk + Inter. Remove the DM Sans import.
+- `app.html`: remove the duplicate standalone Inter `<link>` (consolidate into `app.css`), keep the preconnects.
+- `tailwind.config.js`: `fontFamily.display = Space Grotesk`, `fontFamily.sans = Inter`.
+- **Type scale:** page titles `text-2xl`/`text-3xl` `font-bold tracking-tight` in Space Grotesk; section headings `text-sm`/`text-base font-semibold`; body `text-sm`; KPI values `text-2xl`/`text-3xl` Space Grotesk.
+- **Radius tokens:** `--r-sm: 8px`, `--r: 10px`, `--r-lg: 12px`, `--r-xl: 16px` (cards `--r-lg`, controls `--r-sm`/`--r`, modals `--r-xl`).
+- **Elevation:** light mode → subtle layered shadows; dark mode → rely on `border` + a `.glow-brand` utility (soft iris box-shadow) on primary buttons, the logo, and the active-nav / hero blocks.
+
+## 3. Component primitives
+
+Extract the repeated inline-utility patterns into `@layer components` classes in `app.css` (and/or a few thin Svelte wrappers where stateful). Target set:
+
+- `.btn`, `.btn-primary` (iris gradient + glow), `.btn-secondary` (surface + border), `.btn-ghost`, `.btn-danger`
+- `.card` (surface + border + radius)
+- `.kpi` (card + label/value/delta structure) and a `.kpi-feature` "confident color block" variant (iris gradient, used for the hero KPI)
+- `.badge` / `.chip` with `.badge-ok` / `.badge-warn` / `.badge-bad` / `.badge-brand`
+- `.input`, `.select`, `.textarea` (theme-aware, replacing reliance on `@tailwindcss/forms` defaults)
+- `.modal` shell (overlay + panel + header/body/footer)
+- `.nav-item` (sidebar link, with `.is-active` state)
+- `.glow-brand` utility
+
+These classes reference the semantic tokens, so they are dark-ready by construction. Keep them minimal — they encode the design language, not business logic.
+
+## 4. Reaching all ~50 pages (codemod)
+
+Semantic tokens only cascade where referenced, and much of the app hardcodes neutral utilities. The migration therefore includes a **scripted, reviewable find-and-replace** over `apps/web/src/**/*.svelte` for the highest-frequency patterns:
+
+| From | To |
+|---|---|
+| `bg-white` | `bg-surface` |
+| `bg-gray-50` | `bg-canvas` (page) / `bg-surface-2` (insets) — context-judged |
+| `bg-gray-100` | `bg-surface-2` |
+| `text-gray-900` / `text-gray-800` | `text-ink` |
+| `text-gray-500` / `text-gray-600` | `text-ink-muted` |
+| `text-gray-400` | `text-ink-subtle` |
+| `border-gray-200` / `border-gray-100` | `border-border` |
+| `bg-primary-600` / `hover:bg-primary-700` | `bg-brand` / `hover:bg-brand` (or `.btn-primary`) |
+| `text-primary-600/700` | `text-brand` |
+| `bg-primary-50` | `bg-brand-subtle/10` (dark) / `bg-brand-subtle` (light) |
+| `divide-gray-200` | `divide-border` |
+| `ring-primary-500` / `focus:ring-primary-500` | `ring-ring` |
+
+Process: run the replacement, then **manually review the diff** (the `bg-gray-50` → canvas/surface-2 split and any `dark:` collisions need eyes). Existing `dark:` variants that conflict with the new tokens are removed in the same pass. This is what makes dark mode genuinely complete rather than half-wired.
+
+Edge cases to leave alone / handle by hand: gradient avatars/logos (intentional brand color), status colors already using green/amber/red semantics (map to `ok/warn/bad`), and any third-party widget styling (Chart.js, MarkdownEditor).
+
+## 5. Navigation information architecture
+
+### 5.1 The model
+
+One sidebar, two mutually exclusive **contexts**, driven by whether a project is active (`currentProjectStore` + route):
+
+**Organization mode** (no project selected):
+- Context switcher at top shows **Organization** (amber accent) with the org name.
+- **Workspace:** Dashboard *(labelled "all projects")*, Projects, AI Chat, Templates.
+- **All projects · rollups:** Analytics, Finances (org-wide aggregates — kept).
+- **Settings:** Organization, Billing, Team, Integrations, Email accounts, Webhooks.
+
+**Project mode** (a project is open):
+- A persistent **"← All projects"** link returns to org mode.
+- Context switcher shows **Project** (iris accent) with the project name; clicking it switches between projects without leaving the current page type.
+- **This project:** Overview *(= this project's dashboard)*, Content, Checklists, Documents, Campaigns, Email, Analytics, AI Chat, Templates.
+- **Advanced** (collapsible, existing pattern): SEO, Competitors, Experiments, Sequences, Calendar.
+- **Settings:** Project settings.
+
+### 5.2 Behavior
+
+- The **header project picker** and the **sidebar context switcher** are the same control. Selecting a project → enter project mode and (by default) land on that project's Overview; choosing "All projects" → org mode.
+- Switching projects while on, e.g., a Content page keeps you on the Content page of the newly selected project (preserve the section, swap the project) — consistent with the existing project-switch refetch pattern.
+- **AI Chat & Templates in both scopes:** the links exist in both menus. In project mode they pre-scope to the current project (set `currentProjectStore` / pass the project context the existing pages already restore). Routes are unchanged (`/ai-chat`, `/templates`); no new routes required.
+- Org rollup pages (`/analytics`, `/finances`, `/content`, etc.) remain reachable **only** in org mode and are labelled as rollups, so they never visually collide with a project's own same-named pages.
+- Existing behaviors preserved: multi-org switcher, mobile drawer + backdrop, advanced-section auto-expand, theme toggle, help link, user/logout block.
+
+### 5.3 Dark-by-default
+
+`app.html` bootstrap currently defaults to system preference. Change so the **app interior defaults to dark** unless the user has explicitly chosen light (persisted in `localStorage.theme`). The light/dark toggle stays. (Auth/landing pages, out of scope here, keep their current behavior.)
+
+## 6. Phased delivery
+
+### Phase 1 — Foundation (tokens + primitives + codemod)
+- Add semantic tokens (light + dark) to `app.css`; pick `ink` vs `text` naming.
+- Rework `tailwind.config.js`: iris ramp, semantic color mappings, fonts, `primary` alias.
+- Fix fonts in `app.css` + `app.html` (Space Grotesk + Inter; drop DM Sans).
+- Add `@layer components` primitives + `.glow-brand`.
+- Run + hand-review the utility codemod across `apps/web/src`.
+- **Exit criteria:** app builds, both themes render coherently on a sampling of pages, no raw `bg-white`/`text-gray-900` left in shared surfaces.
+
+### Phase 2 — App shell + IA
+- Rebuild `Sidebar.svelte` with the two-mode contextual model + context switcher + "← All projects".
+- Update `Header.svelte` (picker as mode switch, theme toggle, language switcher restyle).
+- Update `(app)/+layout.svelte` canvas (`bg-canvas`), loading state, help button.
+- Make AI Chat + Templates appear and pre-scope in both modes.
+- Set dark-by-default bootstrap in `app.html`.
+- **Exit criteria:** org mode and project mode are visually distinct and unambiguous; both confusions from the brief are gone; shell fully themed in light + dark.
+
+### Phase 3 — Flagship pages
+- **Dashboard** (`(app)/dashboard`): new KPI cards, project cards, empty state, import modal restyle.
+- **Project Overview** (`projects/[id]/overview`): hero "confident color block" KPI, getting-started steps, recent activity, quick actions.
+- Restyle `DashboardKpiCards.svelte`, `ProjectCardStats.svelte` to the new `.kpi` primitives.
+- **Exit criteria:** dashboard + overview look like the approved mockups in both themes.
+
+## 7. Verification
+
+- `pnpm --filter web build` and `pnpm --filter web lint` pass.
+- Existing web Vitest suite passes (`cd apps/web && pnpm test`); update snapshots/selectors only where the redesign legitimately changes them.
+- Manual walkthrough in **both themes**: shell, dashboard, project overview, and a sampling of cascaded pages (Content, Settings, SEO) to confirm no unreadable/low-contrast or unthemed surfaces.
+- Accessibility checks: text contrast ≥ 4.5:1 on `text` and `text-muted` over `canvas`/`surface` in both themes; visible focus rings (`ring-ring`); icon-only buttons keep `aria-label`/`title`; `prefers-reduced-motion` block retained.
+- Responsive sanity at 375 / 768 / 1024 / 1440.
+
+## 8. Risks & mitigations
+
+- **Codemod over-reach** (a `bg-gray-50` that should stay an inset becomes a page canvas). → Manual diff review; the `bg-gray-50` split is judged per occurrence, not blind-replaced.
+- **`@tailwindcss/forms` default styling** fights theme tokens on inputs. → `.input`/`.select` primitives set explicit themed colors.
+- **Chart.js / MarkdownEditor** don't inherit tokens. → Pass theme-aware colors explicitly; out-of-scope deep polish noted.
+- **`primary-*` left in un-migrated pages.** → `primary` aliased to iris so nothing renders off-brand mid-migration.
+- **Dark-by-default surprises returning users.** → Respect an explicit stored `light` choice; only default to dark when unset.
+
+## 9. Visual reference
+
+Approved mockups live in `.superpowers/brainstorm/27906-1782575803/content/` (gitignored): `direction-v1.html` (token system + light/dark dashboard shell) and `nav-ia-v1.html` (two-mode sidebar). These are the visual source of truth for implementation.

--- a/packages/i18n/src/locales/en.json
+++ b/packages/i18n/src/locales/en.json
@@ -68,7 +68,14 @@
     "orgCalendar": "Calendar",
     "orgFinances": "Finances",
     "darkMode": "Dark Mode",
-    "lightMode": "Light Mode"
+    "lightMode": "Light Mode",
+    "allProjects": "All projects",
+    "organization": "Organization",
+    "project": "Project",
+    "workspace": "Workspace",
+    "rollups": "All projects · rollups",
+    "thisProject": "This project",
+    "switchProject": "Switch project"
   },
   "header": {
     "orgContext": "Organization",

--- a/packages/i18n/src/locales/pl.json
+++ b/packages/i18n/src/locales/pl.json
@@ -68,7 +68,14 @@
     "orgCalendar": "Kalendarz",
     "orgFinances": "Finanse",
     "darkMode": "Tryb ciemny",
-    "lightMode": "Tryb jasny"
+    "lightMode": "Tryb jasny",
+    "allProjects": "Wszystkie projekty",
+    "organization": "Organizacja",
+    "project": "Projekt",
+    "workspace": "Obszar roboczy",
+    "rollups": "Wszystkie projekty · zestawienia",
+    "thisProject": "Ten projekt",
+    "switchProject": "Zmień projekt"
   },
   "header": {
     "orgContext": "Organizacja",

--- a/packages/i18n/src/locales/ru.json
+++ b/packages/i18n/src/locales/ru.json
@@ -68,7 +68,14 @@
     "orgCalendar": "Календарь",
     "orgFinances": "Финансы",
     "darkMode": "Тёмная тема",
-    "lightMode": "Светлая тема"
+    "lightMode": "Светлая тема",
+    "allProjects": "Все проекты",
+    "organization": "Организация",
+    "project": "Проект",
+    "workspace": "Рабочее пространство",
+    "rollups": "Все проекты · сводка",
+    "thisProject": "Этот проект",
+    "switchProject": "Сменить проект"
   },
   "header": {
     "orgContext": "Организация",


### PR DESCRIPTION
Closes #106.

## What this does

Reskins `apps/web` to a bold, modern, dark-first enterprise identity ("Iris", refined violet-indigo) with a **complete dual light/dark theme** and an unambiguous **two-mode navigation** (Organization ↔ Project).

## Phases

**1 — Foundation**
- Semantic CSS-variable tokens (light + `.dark`) in `app.css` as RGB triplets (alpha-modifier friendly); `iris` ramp 50–950; `primary` aliased to iris during migration.
- Fonts standardized: Space Grotesk + Inter (DM Sans removed; stray Inter `<link>` in `app.html` removed).
- Dark-by-default interior (`theme !== 'light'`).
- `@layer components` primitives: `.btn* .card .kpi .kpi-feature .badge* .input .modal* .nav-item .glow-brand`.

**2 — Shell + IA**
- Sidebar rebuilt around explicit context: **Organization mode** (Workspace + rollups + Settings) vs **Project mode** ("← All projects", project chip with quick-switch, Overview = project dashboard, Advanced, Project settings).
- Header / ProjectPicker / layout on tokens; AI Chat + Templates surfaced in both scopes.
- Fixes the two reported ambiguities: no project menus without a project; project Overview replaces the all-projects dashboard in-context.

**3 — Flagship pages**
- Dashboard + KPI cards; Project Overview with a hero `.kpi-feature` color block.

## Migration mechanics

- `apps/web/scripts/iris-codemod.mjs` migrated ~3.3k hardcoded neutral/`primary` utilities across 76 files and stripped now-redundant `dark:` neutral overrides (tokens drive both themes).

## Verification

- `pnpm --filter web build` ✅ · `lint` ✅
- Dev server boots; `/`, `/login`, `/dashboard` → 200 with no compile/runtime errors.
- Production CSS contains the fonts + `--canvas/--brand/--surface` tokens; dark bootstrap present.
- ⚠️ Web unit test not run — `vitest` is not installed in the dev environment (tooling gap; the single test is unrelated to styling).

## Out of scope (follow-up)

- Bespoke polish of the ~50 non-flagship feature pages (they get the token cascade via codemod).
- Public landing/auth redesign; backend changes.

Spec: `docs/superpowers/specs/2026-06-27-ui-redesign-iris-design.md`
Plan: `docs/superpowers/plans/2026-06-27-ui-redesign-iris.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpoBDK6xYzub8iT51JJ7P2