### PR TITLE
fix(social): setting account language wipes OAuth token + scopes

### DIFF
--- a/apps/api/src/social/social.service.spec.ts
+++ b/apps/api/src/social/social.service.spec.ts
@@ -129,6 +129,54 @@ describe('SocialService.upsertOAuthAccount', () => {
   });
 });
 
+describe('SocialService.updateAccount', () => {
+  let service: SocialService;
+  const existing = {
+    id: 'acc1',
+    organizationId: 'org1',
+    platform: 'INSTAGRAM',
+    accountId: 'ig1',
+    encryptedTokens: 'opaque-existing-blob',
+    scopes: ['instagram_business_manage_insights'],
+  };
+  const prisma = {
+    socialAccount: {
+      findFirst: jest.fn().mockResolvedValue(existing),
+      update: jest.fn().mockResolvedValue(existing),
+    },
+  } as any;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const mod: TestingModule = await Test.createTestingModule({
+      providers: [
+        SocialService,
+        { provide: PrismaService, useValue: prisma },
+        { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue('a'.repeat(64)) } },
+        { provide: CronFailureNotifier, useValue: { report: jest.fn() } },
+      ],
+    }).compile();
+    service = mod.get(SocialService);
+  });
+
+  it('language-only update does not touch encryptedTokens or scopes (preserves OAuth connection)', async () => {
+    await service.updateAccount('acc1', 'org1', { language: 'ru' });
+    const arg = prisma.socialAccount.update.mock.calls[0][0];
+    expect(arg.data.language).toBe('ru');
+    // The bug: re-encrypting on a metadata-only update wiped the token; the
+    // upsert-via-POST path also reset scopes. Neither may be touched here.
+    expect(arg.data).not.toHaveProperty('encryptedTokens');
+    expect(arg.data).not.toHaveProperty('scopes');
+  });
+
+  it('still re-encrypts the token when an accessToken is supplied', async () => {
+    await service.updateAccount('acc1', 'org1', { accessToken: 'fresh-token' });
+    const arg = prisma.socialAccount.update.mock.calls[0][0];
+    expect(typeof arg.data.encryptedTokens).toBe('string');
+    expect(arg.data.encryptedTokens).not.toContain('fresh-token');
+  });
+});
+
 describe('SocialService.publishToInstagram', () => {
   let service: SocialService;
   const prisma = { socialAccount: { update: jest.fn().mockResolvedValue({}) } } as any;

--- a/apps/api/src/social/social.service.ts
+++ b/apps/api/src/social/social.service.ts
@@ -159,15 +159,23 @@ export class SocialService {
     })();
 
     const merged: Record<string, string | undefined> = { ...existingTokens };
+    let tokenChanged = false;
     for (const key of ['accessToken', 'refreshToken', 'accessSecret', 'appKey', 'appSecret', 'pageId', 'botToken', 'chatId'] as const) {
       const val = dto[key];
       if (typeof val === 'string' && val.length > 0) {
         merged[key] = val;
+        tokenChanged = true;
       }
     }
-    const encrypted = this.encryptTokens(merged);
 
-    const data: any = { encryptedTokens: encrypted };
+    const data: any = {};
+    // Only re-encrypt the token blob when the caller actually supplied a token
+    // field. A metadata-only update (e.g. changing the language) must NOT touch
+    // encryptedTokens — re-encrypting would wipe the token if the existing blob
+    // failed to decrypt, silently breaking OAuth connections.
+    if (tokenChanged) {
+      data.encryptedTokens = this.encryptTokens(merged);
+    }
     if (typeof dto.accountName === 'string' && dto.accountName.length > 0) data.accountName = dto.accountName;
     if (typeof dto.accountId === 'string' && dto.accountId.length > 0) data.accountId = dto.accountId;
     else if (typeof dto.chatId === 'string' && dto.chatId.length > 0 && account.platform === 'TELEGRAM') data.accountId = dto.chatId;

--- a/apps/web/src/routes/(app)/settings/integrations/+page.svelte
+++ b/apps/web/src/routes/(app)/settings/integrations/+page.svelte
@@ -264,10 +264,11 @@
 
   async function updateAccountLanguage(account: any) {
     try {
-      await api.post(`/social/accounts?organizationId=${$organizationIdStore}`, {
-        platform: account.platform,
-        accountName: account.accountName,
-        accountId: account.accountId,
+      // PUT (updateAccount), not POST (createAccount): POST upserts by
+      // (org, platform, accountId) and resets scopes=[] + an empty token,
+      // which destroys OAuth connections (Instagram/Threads/etc.). PUT only
+      // touches the language and preserves the token + granted scopes.
+      await api.put(`/social/accounts/${account.id}`, {
         language: account.language || null,
       });
     } catch (e: any) {


### PR DESCRIPTION
Closes #111.

## Root cause

The language dropdown in `/settings/integrations` called `POST /social/accounts` (`createAccount`), which upserts by `(org, platform, accountId)` and resets `scopes=[]` + an empty token on update. So **changing an account's language destroyed its OAuth connection** (token + granted scopes), causing the recurring "reconnect to enable analytics" banner on Instagram/Threads. Verified on prod: both accounts were wiped within 4s when the user set their languages.

## Fix

- **web:** `updateAccountLanguage` → `PUT /social/accounts/:id` (`updateAccount`), which only updates the language and preserves token + scopes.
- **api (defense-in-depth):** `updateAccount` only re-encrypts `encryptedTokens` when a token field is actually supplied — a metadata-only update never touches the token.
- **test:** language-only update leaves `encryptedTokens` + `scopes` untouched; still re-encrypts when an `accessToken` is provided.

## Verification

- `api` social tests 17/17 (incl. new `updateAccount` cases); `api` + `web` builds exit 0.

## After merge

Existing wiped accounts (Instagram/Threads) must be reconnected once via the OAuth "Connect …" button to restore the token + insights scope. After this fix, changing the language no longer wipes them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XpoBDK6xYzub8iT51JJ7P2